### PR TITLE
Update tr3_tony.cpp

### DIFF
--- a/TR5Main/Objects/TR3/Entity/tr3_tony.cpp
+++ b/TR5Main/Objects/TR3/Entity/tr3_tony.cpp
@@ -494,7 +494,7 @@ static void ExplodeTonyBoss(ITEM_INFO* item)
 		for (int i = 0; i < 2; i++)
 			TriggerExplosionSparks(x, y, z, 3, -1, 0, item->roomNumber);
 
-		SoundEffect(SFX_TR3_BLAST_CIRCLE, &item->pos, PITCH_SHIFT | 0x800000);
+		//SoundEffect(SFX_TR3_BLAST_CIRCLE, &item->pos, PITCH_SHIFT | 0x800000);
 	}
 
 	if (BossData.DrawExplode)


### PR DESCRIPTION
Currently , on frame 120 of Tony's dying animation there is a call for a hardcoded sound (warp.wav / 76: Blast Circle) to be played. I cannot fix this in wadtool and it is causing sound issues such as tony's dying sound to be played when lara fires her shotgun. SO I've commented out this line to see if that fixes it.