### PR TITLE
Fixed input handling

### DIFF
--- a/TombEngine/Game/gui.h
+++ b/TombEngine/Game/gui.h
@@ -457,8 +457,8 @@ private:
 	void DoStatisticsMode();
 	void DoExamineMode();
 	void DoDiary();
-	int DoLoad();
-	void DoSave();
+	bool DoLoad();
+	bool DoSave();
 	void DoInventory();
 	void ConstructCombineObjectList();
 	
@@ -468,8 +468,6 @@ private:
 	bool goUp, goDown, goRight, goLeft, goSelect, goDeselect;
 	bool dbUp, dbDown, dbRight, dbLeft, dbSelect, dbDeselect;
 	long rptRight, rptLeft;
-	bool stop_killing_me_you_dumb_input_system;
-	bool stop_killing_me_you_dumb_input_system2;
 
 	// Inventory
 	short combine_obj1;
@@ -500,7 +498,6 @@ private:
 	int inventoryItemChosen;
 	int enterInventory;
 	int lastInvItem;
-	bool ExitInvLoop;
 
 	// Ammo vars
 	unsigned short AmountShotGunAmmo1;


### PR DESCRIPTION
* Removes `stop_killing_me_you_dumb_input_system` globals which were apparently added by Del Gilchrist in delirium.
* Rearranges control handling for inventory and menus to avoid unnecessary temp variables and `ExitInvLoop` global.
* Fixes continuous "Lara no" sound in load game dialog.