### PR TITLE
Fix Monkey Crash when Monkey is triggered

### DIFF
--- a/TombEngine/Objects/TR3/Entity/tr3_monkey.cpp
+++ b/TombEngine/Objects/TR3/Entity/tr3_monkey.cpp
@@ -168,11 +168,11 @@ namespace TEN::Entities::Creatures::TR3
 			AI_INFO AI;
 			CreatureAIInfo(item, &AI);
 
-			if (!creature->HurtByLara && creature->Enemy->IsLara())
+			if (!creature->HurtByLara && creature->Enemy != nullptr && creature->Enemy->IsLara())
 				creature->Enemy = nullptr;
 
 			AI_INFO laraAI;
-			if (creature->Enemy->IsLara())
+			if (creature->Enemy != nullptr && creature->Enemy->IsLara())
 			{
 				laraAI.angle = AI.angle;
 				laraAI.distance = AI.distance;

--- a/TombEngine/Objects/TR3/Entity/tr3_monkey.cpp
+++ b/TombEngine/Objects/TR3/Entity/tr3_monkey.cpp
@@ -168,8 +168,11 @@ namespace TEN::Entities::Creatures::TR3
 			AI_INFO AI;
 			CreatureAIInfo(item, &AI);
 
-			if (!creature->HurtByLara && creature->Enemy != nullptr && creature->Enemy->IsLara())
-				creature->Enemy = nullptr;
+			if (creature->Enemy != nullptr)
+			{
+				if (!creature->HurtByLara && creature->Enemy->IsLara())
+					creature->Enemy = nullptr;
+			}
 
 			AI_INFO laraAI;
 			if (creature->Enemy != nullptr && creature->Enemy->IsLara())


### PR DESCRIPTION
If monkey is triggered, this is normally not Laras enemy.
So this condition creature->Enemy->IsLara() cant work, because creature->Enemy was previously set to nullptr which results to an uncatched exception