### PR TITLE
Use Location->RoomNumber for all GetCollisionInfo calculations for Lara

### DIFF
--- a/Documentation/Changes.txt
+++ b/Documentation/Changes.txt
@@ -12,6 +12,7 @@ Version 1.0.3
 * Fix rocket explosions near statics.
 * Fix TR3 monkey level crash.
 * Fix occasional ejection when landing on a slope.
+* Fix occasional ejections when climbing up on a ledge under a slope.
 * Fix slow centaur projectile velocity.
 * Fix search animations - allow chest and shelf animations to play properly.
 * Fix grabbing narrow ledges below ceilings.

--- a/TombEngine/Game/collision/collide_room.cpp
+++ b/TombEngine/Game/collision/collide_room.cpp
@@ -298,10 +298,12 @@ void GetCollisionInfo(CollisionInfo* coll, ItemInfo* item, const Vector3i& offse
 
 	// Parameter definition ends here, now process to actual collision tests...
 
-	// HACK: for certain ledge cases, Lara Location->roomNumber updates more properly than 
-	// item->RoomNumber, but since Location is ONLY updated for Lara, we can't use it for 
-	// all objects for now. In future, we should either update Location field for all
-	// objects or use this value as it is now.
+	// HACK: when using SetPosition animcommand, item->RoomNumber does not immediately
+	// update, but only at the end of control loop. This may cause bugs when Lara is
+	// climbing or vaulting ledges under slopes. Using Location->roomNumber solves
+	// these bugs, as it is updated immediately. But since Location->roomNumber is ONLY
+	// updated for Lara, we can't use it for all objects for now. In future, we should
+	// either update Location field for all objects or use this value as it is now.
 
 	int realRoomNumber = doPlayerCollision ? item->Location.roomNumber : item->RoomNumber;
 	

--- a/TombEngine/Game/collision/collide_room.cpp
+++ b/TombEngine/Game/collision/collide_room.cpp
@@ -297,10 +297,18 @@ void GetCollisionInfo(CollisionInfo* coll, ItemInfo* item, const Vector3i& offse
 	int height, ceiling;
 
 	// Parameter definition ends here, now process to actual collision tests...
+
+	// HACK: for certain ledge cases, Lara Location->roomNumber updates more properly than 
+	// item->RoomNumber, but since Location is ONLY updated for Lara, we can't use it for 
+	// all objects for now. In future, we should either update Location field for all
+	// objects or use this value as it is now.
+
+	int realRoomNumber = doPlayerCollision ? item->Location.roomNumber : item->RoomNumber;
 	
 	// TEST 1: TILT AND NEAREST LEDGE CALCULATION
 
-	auto collResult = GetCollision(probePos.x, item->Pose.Position.y, probePos.z, item->RoomNumber);
+	auto collResult = GetCollision(probePos.x, item->Pose.Position.y, probePos.z, realRoomNumber);
+
 	coll->FloorTilt = collResult.FloorTilt;
 	coll->CeilingTilt = collResult.CeilingTilt;
 	coll->NearestLedgeAngle = GetNearestLedgeAngle(item, coll, coll->NearestLedgeDistance);
@@ -311,7 +319,7 @@ void GetCollisionInfo(CollisionInfo* coll, ItemInfo* item, const Vector3i& offse
 	
 	// TEST 2: CENTERPOINT PROBE
 
-	collResult = GetCollision(probePos.x, probePos.y, probePos.z, item->RoomNumber);
+	collResult = GetCollision(probePos.x, probePos.y, probePos.z, realRoomNumber);
 	auto topRoomNumber = collResult.RoomNumber; // Keep top room number as we need it to re-probe from origin room.
 	
 	if (doPlayerCollision)
@@ -353,7 +361,7 @@ void GetCollisionInfo(CollisionInfo* coll, ItemInfo* item, const Vector3i& offse
 		{
 			tfLocation = item->Location;
 			tcLocation = item->Location;
-			topRoomNumber = item->RoomNumber;
+			topRoomNumber = realRoomNumber;
 		}
 
 		tfLocation = GetRoom(tfLocation, probePos.x, probePos.y, probePos.z);
@@ -414,10 +422,11 @@ void GetCollisionInfo(CollisionInfo* coll, ItemInfo* item, const Vector3i& offse
 	{
 		coll->Front.Floor = STOP_SIZE;
 	}
-	else if (coll->Setup.BlockMonkeySwingEdge &&
-		!GetCollision(probePos.x, probePos.y + coll->Setup.Height, probePos.z, item->RoomNumber).BottomBlock->Flags.Monkeyswing)
+	else if (coll->Setup.BlockMonkeySwingEdge)			
 	{
-		coll->Front.Floor = MAX_HEIGHT;
+		auto monkeyProbe = GetCollision(probePos.x, probePos.y + coll->Setup.Height, probePos.z, realRoomNumber);
+		if (monkeyProbe.BottomBlock->Flags.Monkeyswing)
+			coll->Front.Floor = MAX_HEIGHT;
 	}
 
 	// TEST 4: MIDDLE-LEFT PROBE


### PR DESCRIPTION
This PR fixes occasional wrong slope calculations when climbing up a ledge, and possibly some other collision issues, because newly introduced `Location` field is only immediately updated one when dealing with Lara in `GetCollisionInfo`. `item->RoomNumber` is not updated immediately and postponed until next control loop - therefore, when `SetPosition` animcommand is called, slopes for old room are passed by `GetCollisionInfo` function.

This is a very ancient issue which originates from the fact that original code used globals for getting slope values, which in turn were updated by `GetFloorHeight` function, which got completely refactored in TEN.

I need explicit approval from @asasas9500 on this change, because it involves systemic changes in `GetCollisionInfo` behaviour.