### PR TITLE
Filter out invisible flipped rooms in various parts of game code

### DIFF
--- a/Documentation/Changes.txt
+++ b/Documentation/Changes.txt
@@ -7,6 +7,7 @@ Version 1.0.4
 * Fix lasersight always displaying with revolver and crossbow.
 * Fix incorrect string IDs for item combine, HK and revolver with lasersight.
 * Fix puzzle holes not swapping to puzzle done objects.
+* Fix several collision and sound source issues in flipped rooms.
 
 Version 1.0.3
 =============

--- a/TombEngine/Game/camera.cpp
+++ b/TombEngine/Game/camera.cpp
@@ -1774,9 +1774,12 @@ std::vector<short> FillCollideableItemList()
 
 	for (short i = 0; i < g_Level.NumItems; i++)
 	{
-		auto item = &g_Level.Items[i];
+		auto* item = &g_Level.Items[i];
 
 		if (std::find(roomList.begin(), roomList.end(), item->RoomNumber) == roomList.end())
+			continue;
+
+		if (!g_Level.Rooms[item->RoomNumber].Active())
 			continue;
 
 		if (!CheckItemCollideCamera(&g_Level.Items[i]))
@@ -1827,7 +1830,11 @@ std::vector<MESH_INFO*> FillCollideableStaticsList()
 
 	for (auto i : roomList)
 	{
-		auto room = &g_Level.Rooms[i];
+		auto* room = &g_Level.Rooms[i];
+
+		if (!room->Active())
+			continue;
+
 		for (short j = 0; j < room->mesh.size(); j++)
 		{
 			if (!CheckStaticCollideCamera(&room->mesh[j]))

--- a/TombEngine/Game/collision/collide_item.cpp
+++ b/TombEngine/Game/collision/collide_item.cpp
@@ -318,6 +318,9 @@ void TestForObjectOnLedge(ItemInfo* item, CollisionInfo* coll)
 
 		for (auto i : g_Level.Rooms[item->RoomNumber].neighbors)
 		{
+			if (!g_Level.Rooms[i].Active())
+				continue;
+
 			short itemNumber = g_Level.Rooms[i].itemNumber;
 			while (itemNumber != NO_ITEM)
 			{
@@ -826,6 +829,9 @@ void CollideSolidStatics(ItemInfo* item, CollisionInfo* coll)
 
 	for (auto i : g_Level.Rooms[item->RoomNumber].neighbors)
 	{
+		if (!g_Level.Rooms[i].Active())
+			continue;
+
 		for (auto& mesh : g_Level.Rooms[i].mesh)
 		{
 			// Only process meshes which are visible and solid.
@@ -1688,6 +1694,9 @@ void DoObjectCollision(ItemInfo* laraItem, CollisionInfo* coll)
 
 	for (auto i : g_Level.Rooms[laraItem->RoomNumber].neighbors)
 	{
+		if (!g_Level.Rooms[i].Active())
+			continue;
+
 		int nextItem = g_Level.Rooms[i].itemNumber;
 		while (nextItem != NO_ITEM)
 		{

--- a/TombEngine/Game/room.cpp
+++ b/TombEngine/Game/room.cpp
@@ -17,6 +17,14 @@ int FlipMap[MAX_FLIPMAP];
 
 std::vector<short> OutsideRoomTable[OUTSIDE_SIZE][OUTSIDE_SIZE];
 
+bool ROOM_INFO::Active()
+{
+	if (flipNumber == -1)
+		return true;
+
+	return !(FlipStats[flipNumber] && flippedRoom == -1);
+}
+
 void DoFlipMap(short group)
 {
 	ROOM_INFO temp;

--- a/TombEngine/Game/room.cpp
+++ b/TombEngine/Game/room.cpp
@@ -19,10 +19,10 @@ std::vector<short> OutsideRoomTable[OUTSIDE_SIZE][OUTSIDE_SIZE];
 
 bool ROOM_INFO::Active()
 {
-	if (flipNumber == -1)
+	if (flipNumber == NO_ROOM)
 		return true;
 
-	return !(FlipStats[flipNumber] && flippedRoom == -1);
+	return !(FlipStats[flipNumber] && flippedRoom == NO_ROOM);
 }
 
 void DoFlipMap(short group)

--- a/TombEngine/Game/room.h
+++ b/TombEngine/Game/room.h
@@ -127,6 +127,8 @@ struct ROOM_INFO
 	std::vector<ROOM_DOOR> doors;
 
 	std::vector<int> neighbors; // TODO: Move to level struct
+
+	bool Active();
 };
 
 constexpr auto NUM_ROOMS = 1024;

--- a/TombEngine/Game/room.h
+++ b/TombEngine/Game/room.h
@@ -6,8 +6,6 @@
 
 struct TriggerVolume;
 
-constexpr auto MAX_FLIPMAP = 256;
-
 struct ROOM_VERTEX
 {
 	Vector3 position;
@@ -131,6 +129,7 @@ struct ROOM_INFO
 	bool Active();
 };
 
+constexpr auto MAX_FLIPMAP = 256;
 constexpr auto NUM_ROOMS = 1024;
 constexpr auto NO_ROOM = -1;
 constexpr auto OUTSIDE_Z = 64;

--- a/TombEngine/Objects/TR3/Vehicles/kayak.cpp
+++ b/TombEngine/Objects/TR3/Vehicles/kayak.cpp
@@ -1125,6 +1125,9 @@ namespace TEN::Entities::Vehicles
 	{
 		for (auto i : g_Level.Rooms[kayakItem->RoomNumber].neighbors)
 		{
+			if (!g_Level.Rooms[i].Active())
+				continue;
+
 			short itemNum = g_Level.Rooms[i].itemNumber;
 
 			while (itemNum != NO_ITEM)

--- a/TombEngine/Objects/TR3/Vehicles/minecart.cpp
+++ b/TombEngine/Objects/TR3/Vehicles/minecart.cpp
@@ -286,6 +286,9 @@ namespace TEN::Entities::Vehicles
 	{
 		for (auto i : g_Level.Rooms[minecartItem->RoomNumber].neighbors)
 		{
+			if (!g_Level.Rooms[i].Active())
+				continue;
+
 			short itemNumber = g_Level.Rooms[i].itemNumber;
 
 			while (itemNumber != NO_ITEM)

--- a/TombEngine/Renderer/Renderer11Compatibility.cpp
+++ b/TombEngine/Renderer/Renderer11Compatibility.cpp
@@ -167,7 +167,11 @@ namespace TEN::Renderer
 			r->ItemsToDraw.reserve(MAX_ITEMS_DRAW);
 			r->EffectsToDraw.reserve(MAX_ITEMS_DRAW);
 			r->TransparentFacesToDraw.reserve(MAX_TRANSPARENT_FACES_PER_ROOM);
-			r->Neighbors = room.neighbors;
+			
+			r->Neighbors.clear();
+			for (int j : room.neighbors)
+				if (g_Level.Rooms[j].Active())
+					r->Neighbors.push_back(j);
 
 			if (room.mesh.size() > 0)
 				r->StaticsToDraw.reserve(room.mesh.size());

--- a/TombEngine/Sound/sound.cpp
+++ b/TombEngine/Sound/sound.cpp
@@ -911,20 +911,19 @@ int GetShatterSound(int shatterID)
 
 void PlaySoundSources()
 {
+	static constexpr int PLAY_ALWAYS    = 0x8000;
+	static constexpr int PLAY_BASE_ROOM = 0x4000;
+	static constexpr int PLAY_FLIP_ROOM = 0x2000;
+
 	for (size_t i = 0; i < g_Level.SoundSources.size(); i++)
 	{
 		const auto& sound = g_Level.SoundSources[i];
 
-		short t = sound.Flags & 31;
-		short group = t & 1;
-		group += t & 2;
-		group += ((t >> 2) & 1) * 3;
-		group += ((t >> 3) & 1) * 4;
-		group += ((t >> 4) & 1) * 5;
+		int group = sound.Flags & 0x1FFF;
 
-		if (!FlipStats[group] && (sound.Flags & 128) == 0)
+		if (!FlipStats[group] && (sound.Flags & PLAY_FLIP_ROOM))
 			continue;
-		else if (FlipStats[group] && (sound.Flags & 128) == 0)
+		else if (FlipStats[group] && (sound.Flags & PLAY_BASE_ROOM))
 			continue;
 
 		SoundEffect(sound.SoundID, (Pose*)&sound.Position);


### PR DESCRIPTION
This pull request fixes several problems with flipmaps, namely "ghost" static mesh collision, light spilling from flipped to unflipped room, and several issues with object collision handling.

Complementary [changes to TE](https://github.com/MontyTRC89/Tomb-Editor/tree/filtered_flipped_rooms) are needed, otherwise correct behaviour is not guaranteed.