### PR TITLE
Unify DoTitle and DoLevel

### DIFF
--- a/TombEngine/Game/Lara/lara.cpp
+++ b/TombEngine/Game/Lara/lara.cpp
@@ -1021,13 +1021,13 @@ void UpdateLara(ItemInfo* item, bool isTitle)
 	// is implemented -- Lwmte, 07.12.22
 
 	auto actionMap = ActionMap;
-	auto trInput = TrInput;
 	auto dbInput = DbInput;
+	auto trInput = TrInput;
 
 	if (isTitle)
 		ClearAllActions();
 
-	// Control Lara
+	// Control Lara.
 	InItemControlLoop = true;
 	LaraControl(item, &LaraCollision);
 	LaraCheatyBits(item);
@@ -1036,9 +1036,9 @@ void UpdateLara(ItemInfo* item, bool isTitle)
 
 	if (isTitle)
 	{
-		TrInput = trInput;
-		DbInput = dbInput;
 		ActionMap = actionMap;
+		DbInput = dbInput;
+		TrInput = trInput;
 	}
 
 	if (g_Gui.GetInventoryItemChosen() != NO_ITEM)
@@ -1047,10 +1047,10 @@ void UpdateLara(ItemInfo* item, bool isTitle)
 		SayNo();
 	}
 
-	// Update Lara's animations
+	// Update Lara's animations.
 	g_Renderer.UpdateLaraAnimations(true);
 
-	// Update Lara's effects
+	// Update Lara's effects.
 	TriggerLaraDrips(item);
 	HairControl(item, g_GameFlow->GetLevel(CurrentLevel)->GetLaraType() == LaraType::Young);
 	ProcessEffects(item);

--- a/TombEngine/Game/Lara/lara.cpp
+++ b/TombEngine/Game/Lara/lara.cpp
@@ -1017,32 +1017,38 @@ void UpdateLara(ItemInfo* item, bool title)
 	if (title && !g_GameFlow->IsLaraInTitleEnabled())
 		return;
 
-	// TODO: Disable this condition when proper control lock 
+	// HACK: backup controls until proper control lock 
 	// is implemented -- Lwmte, 07.12.22
 
-	if (!title)
+	auto actionMap = ActionMap;
+	auto trInput = TrInput;
+	auto dbInput = DbInput;
+
+	if (title)
+		ClearAllActions();
+
+	// Control Lara
+	InItemControlLoop = true;
+	LaraControl(item, &LaraCollision);
+	LaraCheatyBits(item);
+	InItemControlLoop = false;
+	KillMoveItems();
+
+	if (title)
 	{
-		// Control Lara
-		InItemControlLoop = true;
-		LaraControl(item, &LaraCollision);
-		InItemControlLoop = false;
-		KillMoveItems();
-
-		LaraCheatyBits(item);
-
-		if (g_Gui.GetInventoryItemChosen() != NO_ITEM)
-		{
-			g_Gui.SetInventoryItemChosen(NO_ITEM);
-			SayNo();
-		}
-
-		// Update Lara's animations
-		g_Renderer.UpdateLaraAnimations(true);
+		TrInput = trInput;
+		DbInput = dbInput;
+		ActionMap = actionMap;
 	}
-	else
+
+	if (g_Gui.GetInventoryItemChosen() != NO_ITEM)
 	{
-		AnimateLara(item);
+		g_Gui.SetInventoryItemChosen(NO_ITEM);
+		SayNo();
 	}
+
+	// Update Lara's animations
+	g_Renderer.UpdateLaraAnimations(true);
 
 	// Update Lara's effects
 	TriggerLaraDrips(item);

--- a/TombEngine/Game/Lara/lara.cpp
+++ b/TombEngine/Game/Lara/lara.cpp
@@ -1014,7 +1014,11 @@ void LaraCheat(ItemInfo* item, CollisionInfo* coll)
 
 void UpdateLara(ItemInfo* item, bool title)
 {
-	auto* level = g_GameFlow->GetLevel(CurrentLevel);
+	if (title && !g_GameFlow->IsLaraInTitleEnabled())
+		return;
+
+	// TODO: Disable this condition when proper control lock 
+	// is implemented -- Lwmte, 07.12.22
 
 	if (!title)
 	{
@@ -1024,26 +1028,26 @@ void UpdateLara(ItemInfo* item, bool title)
 		InItemControlLoop = false;
 		KillMoveItems();
 
-		g_Renderer.UpdateLaraAnimations(true);
+		LaraCheatyBits(item);
 
 		if (g_Gui.GetInventoryItemChosen() != NO_ITEM)
 		{
-			SayNo();
 			g_Gui.SetInventoryItemChosen(NO_ITEM);
+			SayNo();
 		}
 
-		LaraCheatyBits(item);
-		TriggerLaraDrips(item);
-
-		// Update Lara's ponytails
-		HairControl(item, level->GetLaraType() == LaraType::Young);
-		ProcessEffects(item);
+		// Update Lara's animations
+		g_Renderer.UpdateLaraAnimations(true);
 	}
-	else if (g_GameFlow->IsLaraInTitleEnabled())
+	else
 	{
 		AnimateLara(item);
-		HairControl(item, level->GetLaraType() == LaraType::Young);
 	}
+
+	// Update Lara's effects
+	TriggerLaraDrips(item);
+	HairControl(item, g_GameFlow->GetLevel(CurrentLevel)->GetLaraType() == LaraType::Young);
+	ProcessEffects(item);
 }
 
 // Offset values may be used to account for the quirk of room traversal only being able to occur at portals.

--- a/TombEngine/Game/Lara/lara.cpp
+++ b/TombEngine/Game/Lara/lara.cpp
@@ -27,6 +27,7 @@
 #include "Game/collision/floordata.h"
 #include "Game/control/flipeffect.h"
 #include "Game/control/volume.h"
+#include "Game/effects/hair.h"
 #include "Game/effects/item_fx.h"
 #include "Game/effects/tomb4fx.h"
 #include "Game/Gui.h"
@@ -1008,6 +1009,40 @@ void LaraCheat(ItemInfo* item, CollisionInfo* coll)
 		InitialiseLaraMeshes(item);
 		item->HitPoints = LARA_HEALTH_MAX;
 		lara->Control.HandStatus = HandStatus::Free;
+	}
+}
+
+void UpdateLara(ItemInfo* item, bool title)
+{
+	auto* level = g_GameFlow->GetLevel(CurrentLevel);
+
+	if (!title)
+	{
+		// Control Lara
+		InItemControlLoop = true;
+		LaraControl(item, &LaraCollision);
+		InItemControlLoop = false;
+		KillMoveItems();
+
+		g_Renderer.UpdateLaraAnimations(true);
+
+		if (g_Gui.GetInventoryItemChosen() != NO_ITEM)
+		{
+			SayNo();
+			g_Gui.SetInventoryItemChosen(NO_ITEM);
+		}
+
+		LaraCheatyBits(item);
+		TriggerLaraDrips(item);
+
+		// Update Lara's ponytails
+		HairControl(item, level->GetLaraType() == LaraType::Young);
+		ProcessEffects(item);
+	}
+	else if (g_GameFlow->IsLaraInTitleEnabled())
+	{
+		AnimateLara(item);
+		HairControl(item, level->GetLaraType() == LaraType::Young);
 	}
 }
 

--- a/TombEngine/Game/Lara/lara.cpp
+++ b/TombEngine/Game/Lara/lara.cpp
@@ -1012,9 +1012,9 @@ void LaraCheat(ItemInfo* item, CollisionInfo* coll)
 	}
 }
 
-void UpdateLara(ItemInfo* item, bool title)
+void UpdateLara(ItemInfo* item, bool isTitle)
 {
-	if (title && !g_GameFlow->IsLaraInTitleEnabled())
+	if (isTitle && !g_GameFlow->IsLaraInTitleEnabled())
 		return;
 
 	// HACK: backup controls until proper control lock 
@@ -1024,7 +1024,7 @@ void UpdateLara(ItemInfo* item, bool title)
 	auto trInput = TrInput;
 	auto dbInput = DbInput;
 
-	if (title)
+	if (isTitle)
 		ClearAllActions();
 
 	// Control Lara
@@ -1034,7 +1034,7 @@ void UpdateLara(ItemInfo* item, bool title)
 	InItemControlLoop = false;
 	KillMoveItems();
 
-	if (title)
+	if (isTitle)
 	{
 		TrInput = trInput;
 		DbInput = dbInput;

--- a/TombEngine/Game/Lara/lara.h
+++ b/TombEngine/Game/Lara/lara.h
@@ -102,4 +102,5 @@ void LaraWaterSurface(ItemInfo* item, CollisionInfo* coll);
 void LaraUnderwater(ItemInfo* item, CollisionInfo* coll);
 void LaraCheat(ItemInfo* item, CollisionInfo* coll);
 void AnimateLara(ItemInfo* item);
+void UpdateLara(ItemInfo* item, bool title);
 bool UpdateLaraRoom(ItemInfo* item, int height, int xOffset = 0, int zOffset = 0);

--- a/TombEngine/Game/Lara/lara.h
+++ b/TombEngine/Game/Lara/lara.h
@@ -102,5 +102,5 @@ void LaraWaterSurface(ItemInfo* item, CollisionInfo* coll);
 void LaraUnderwater(ItemInfo* item, CollisionInfo* coll);
 void LaraCheat(ItemInfo* item, CollisionInfo* coll);
 void AnimateLara(ItemInfo* item);
-void UpdateLara(ItemInfo* item, bool title);
+void UpdateLara(ItemInfo* item, bool isTitle);
 bool UpdateLaraRoom(ItemInfo* item, int height, int xOffset = 0, int zOffset = 0);

--- a/TombEngine/Game/Lara/lara_struct.h
+++ b/TombEngine/Game/Lara/lara_struct.h
@@ -976,7 +976,7 @@ public:
 
 	Ammo& operator --()
 	{
-		assert(this->Count > 0);
+		assertion(this->Count > 0, "Ammo count is already 0!");
 		--this->Count;
 		return *this;
 	}

--- a/TombEngine/Game/camera.cpp
+++ b/TombEngine/Game/camera.cpp
@@ -152,6 +152,9 @@ void InitialiseCamera()
 
 	UseForcedFixedCamera = 0;
 	CalculateCamera();
+
+	// Fade in screen.
+	SetScreenFadeIn(FADE_SCREEN_SPEED);
 }
 
 void MoveCamera(GameVector* ideal, int speed)

--- a/TombEngine/Game/camera.cpp
+++ b/TombEngine/Game/camera.cpp
@@ -2052,8 +2052,8 @@ void HandleOptics(ItemInfo* item)
 	{
 		if (Lara.Control.HandStatus == HandStatus::WeaponReady &&
 			((Lara.Control.Weapon.GunType == LaraWeaponType::HK && Lara.Weapons[(int)LaraWeaponType::HK].HasLasersight) ||
-				(Lara.Control.Weapon.GunType == LaraWeaponType::Revolver && Lara.Weapons[(int)LaraWeaponType::Revolver].HasLasersight) ||
-				(Lara.Control.Weapon.GunType == LaraWeaponType::Crossbow && Lara.Weapons[(int)LaraWeaponType::Crossbow].HasLasersight)))
+			 (Lara.Control.Weapon.GunType == LaraWeaponType::Revolver && Lara.Weapons[(int)LaraWeaponType::Revolver].HasLasersight) ||
+			 (Lara.Control.Weapon.GunType == LaraWeaponType::Crossbow && Lara.Weapons[(int)LaraWeaponType::Crossbow].HasLasersight)))
 		{
 			BinocularRange = 128;
 			BinocularOldCamera = Camera.oldType;

--- a/TombEngine/Game/control/control.cpp
+++ b/TombEngine/Game/control/control.cpp
@@ -273,12 +273,12 @@ GameStatus DoLevel(int levelIndex, bool loadGame)
 	InitialiseHair();
 	InitialiseItemBoxData();
 
-	// Initialize game variables and optionally load game.
-	InitialiseOrLoadGame(loadGame);
-
 	// Initialize scripting.
 	InitialiseScripting(levelIndex, loadGame);
 	InitialiseNodeScripts();
+
+	// Initialize game variables and optionally load game.
+	InitialiseOrLoadGame(loadGame);
 
 	// Prepare title menu, if necessary.
 	if (isTitle)
@@ -420,11 +420,6 @@ void InitialiseScripting(int levelIndex, bool loadGame)
 		});
 	}
 
-	if (loadGame)
-		g_GameScript->OnLoad();
-	else
-		g_GameScript->OnStart();
-
 	// Play default background music.
 	PlaySoundTrack(level->GetAmbientTrack(), SoundTrackType::BGM);
 }
@@ -460,7 +455,9 @@ void InitialiseOrLoadGame(bool loadGame)
 		Camera.target.z = LaraItem->Pose.Position.z;
 
 		InitialiseGame = false;
+
 		g_GameFlow->SelectedSaveGame = 0;
+		g_GameScript->OnLoad();
 	}
 	else
 	{
@@ -474,6 +471,8 @@ void InitialiseOrLoadGame(bool loadGame)
 			GameTimer = 0;
 			InitialiseGame = false;
 		}
+
+		g_GameScript->OnStart();
 	}
 }
 

--- a/TombEngine/Game/control/control.cpp
+++ b/TombEngine/Game/control/control.cpp
@@ -141,18 +141,15 @@ GameStatus ControlPhase(int numFrames)
 		// which assumes 30 iterations per second.
 		g_GameScript->OnControlPhase(DELTA_TIME);
 
+		// Handle inventory / pause / load / save screens.
 		auto result = HandleMenuCalls(title);
 		if (result != GameStatus::None)
 			return result;
 
-		if (!title)
-		{
-			HandleOptics(LaraItem);
-
-			result = HandleLevelEnd();
-			if (result != GameStatus::None)
-				return result;
-		}
+		// Handle global input events.
+		result = HandleGlobalInputEvents(title);
+		if (result != GameStatus::None)
+			return result;
 
 		UpdateLara(LaraItem, title);
 		UpdateAllItems();
@@ -620,8 +617,13 @@ GameStatus HandleMenuCalls(bool title)
 	return result;
 }
 
-GameStatus HandleLevelEnd()
+GameStatus HandleGlobalInputEvents(bool title)
 {
+	if (title)
+		return GameStatus::None;
+
+	HandleOptics(LaraItem);
+
 	// Is Lara dead?
 	static constexpr int DEATH_NO_INPUT_TIMEOUT = 5 * FPS;
 	static constexpr int DEATH_INPUT_TIMEOUT = 10 * FPS;

--- a/TombEngine/Game/control/control.cpp
+++ b/TombEngine/Game/control/control.cpp
@@ -487,10 +487,6 @@ GameStatus DoLevel(int index, bool loadFromSavegame)
 
 			if (invStatus != InventoryResult::None)
 				break;
-
-			g_Renderer.RenderTitle();
-			Camera.numberFrames = g_Renderer.Synchronize();
-			numFrames = Camera.numberFrames;
 		}
 		else
 		{

--- a/TombEngine/Game/control/control.cpp
+++ b/TombEngine/Game/control/control.cpp
@@ -46,8 +46,8 @@
 #include "Scripting/Include/ScriptInterfaceGame.h"
 #include "Scripting/Include/Strings/ScriptInterfaceStringsHandler.h"
 #include "Sound/sound.h"
-#include "Specific/Input/Input.h"
 #include "Specific/clock.h"
+#include "Specific/Input/Input.h"
 #include "Specific/level.h"
 #include "Specific/setup.h"
 #include "Specific/winmain.h"
@@ -57,20 +57,16 @@ using namespace TEN::Effects::Drip;
 using namespace TEN::Effects::Environment;
 using namespace TEN::Effects::Explosion;
 using namespace TEN::Effects::Footprints;
-using namespace TEN::Entities::Generic;
 using namespace TEN::Effects::Lightning;
 using namespace TEN::Effects::Smoke;
 using namespace TEN::Effects::Spark;
+using namespace TEN::Entities::Generic;
 using namespace TEN::Entities::Switches;
 using namespace TEN::Entities::TR4;
 using namespace TEN::Floordata;
 using namespace TEN::Input;
 using namespace TEN::Math::Random;
 using namespace TEN::Renderer;
-
-using std::string;
-using std::unordered_map;
-using std::vector;
 
 int GameTimer       = 0;
 int GlobalCounter   = 0;
@@ -112,7 +108,7 @@ int DrawPhase(bool isTitle)
 
 GameStatus ControlPhase(int numFrames)
 {
-	bool isTitle = CurrentLevel == 0;
+	bool isTitle = (CurrentLevel == 0);
 
 	RegeneratePickups();
 
@@ -131,7 +127,7 @@ GameStatus ControlPhase(int numFrames)
 
 	for (framesCount += numFrames; framesCount > 0; framesCount -= 2)
 	{
-		// Controls should be polled before OnControlPhase, so input data could be
+		// TODO: Controls should be polled before OnControlPhase, so input data could be
 		// overwritten by script API methods.
 		HandleControls(isTitle);
 
@@ -158,26 +154,26 @@ GameStatus ControlPhase(int numFrames)
 
 		if (UseSpotCam)
 		{
-			// Draw flyby cameras
+			// Draw flyby cameras.
 			CalculateSpotCameras();
 		}
 		else
 		{
-			// Do the standard camera
+			// Do the standard camera.
 			TrackCameraInit = false;
 			CalculateCamera();
 		}
 
-		// Update oscillator seed
+		// Update oscillator seed.
 		Wibble = (Wibble + WIBBLE_SPEED) & WIBBLE_MAX;
 
-		// Smash shatters and clear stopper flags under them
+		// Smash shatters and clear stopper flags under them.
 		UpdateShatters();
 
-		// Update weather
+		// Update weather.
 		Weather.Update();
 
-		// Update special FX
+		// Update special FX.
 		UpdateSparks();
 		UpdateFireSparks();
 		UpdateSmoke();
@@ -201,21 +197,21 @@ GameStatus ControlPhase(int numFrames)
 		UpdateBeetleSwarm();
 		UpdateLocusts();
 
-		// Update screen UI and overlays
+		// Update screen UI and overlays.
 		UpdateBars(LaraItem);
 		UpdateFadeScreenAndCinematicBars();
 
-		// Rumble screen (like in submarine level of TRC)
+		// Rumble screen (like in submarine level of TRC).
 		if (g_GameFlow->GetLevel(CurrentLevel)->Rumble)
 			RumbleScreen();
 
 		PlaySoundSources();
 		DoFlipEffect(FlipEffect, LaraItem);
 
-		// Clear savegame loaded flag
+		// Clear savegame loaded flag.
 		JustLoaded = false;
 
-		// Update timers
+		// Update timers.
 		GameTimer++;
 		GlobalCounter++;
 
@@ -236,19 +232,19 @@ unsigned CALLBACK GameMain(void *)
 
 	TimeInit();
 
-	// Do a fixed time title image
+	// Do a fixed time title image.
 	if (g_GameFlow->IntroImagePath.empty())
 		TENLog("Intro image path is not set.", LogLevel::Warning);
 	else
 		g_Renderer.RenderTitleImage();
 
 
-	// Execute the LUA gameflow and play the game
+	// Execute the Lua gameflow and play the game.
 	g_GameFlow->DoFlow();
 
 	DoTheGame = false;
 
-	// Finish the thread
+	// Finish the thread.
 	PostMessage(WindowsHandle, WM_CLOSE, NULL, NULL);
 	EndThread();
 
@@ -265,7 +261,7 @@ GameStatus DoLevel(int levelIndex, bool loadGame)
 	if (!LoadLevelFile(levelIndex))
 		return isTitle ? GameStatus::ExitGame : GameStatus::ExitToTitle;
 
-	// Initialize items, effects, lots and cameras.
+	// Initialize items, effects, lots, and cameras.
 	InitialiseFXArray(true);
 	InitialisePickupDisplay();
 	InitialiseCamera();
@@ -287,7 +283,7 @@ GameStatus DoLevel(int levelIndex, bool loadGame)
 		g_Gui.SetSelectedOption(0);
 	}
 
-	// DoGameLoop returns only when level has ended.
+	// DoGameLoop() returns only when level has ended.
 	return DoGameLoop(levelIndex);
 }
 
@@ -300,7 +296,7 @@ void UpdateShatters()
 	{
 		SmashedMeshCount--;
 
-		FloorInfo* floor = GetFloor(
+		auto* floor = GetFloor(
 			SmashedMesh[SmashedMeshCount]->pos.Position.x,
 			SmashedMesh[SmashedMeshCount]->pos.Position.y,
 			SmashedMesh[SmashedMeshCount]->pos.Position.z,
@@ -407,7 +403,7 @@ void InitialiseScripting(int levelIndex, bool loadGame)
 
 	auto* level = g_GameFlow->GetLevel(levelIndex);
 
-	// Run level script, if exists.
+	// Run level script if it exists.
 	if (!level->ScriptFileName.empty())
 	{
 		g_GameScript->ExecuteScriptFile(level->ScriptFileName);
@@ -466,7 +462,7 @@ void InitialiseOrLoadGame(bool loadGame)
 
 		if (InitialiseGame)
 		{
-			// Clear all game infos as well
+			// Clear all game info as well.
 			Statistics.Game = {};
 			GameTimer = 0;
 			InitialiseGame = false;
@@ -552,7 +548,9 @@ void HandleControls(bool isTitle)
 			UpdateInputActions(LaraItem);
 	}
 	else
+	{
 		ClearAction(In::Look);
+	}
 }
 
 GameStatus HandleMenuCalls(bool isTitle)

--- a/TombEngine/Game/control/control.cpp
+++ b/TombEngine/Game/control/control.cpp
@@ -369,7 +369,7 @@ GameStatus DoLevel(int index, bool loadGame)
 
 	// Load the level. Fall back to title if unsuccessful.
 	if (!LoadLevelFile(index))
-		return GameStatus::ExitToTitle;
+		return title ? GameStatus::ExitGame : GameStatus::ExitToTitle;
 
 	// Initialize items, effects, lots and cameras.
 	InitialiseFXArray(true);

--- a/TombEngine/Game/control/control.cpp
+++ b/TombEngine/Game/control/control.cpp
@@ -209,8 +209,8 @@ GameStatus ControlPhase(int numFrames)
 			}
 
 			// Is Lara dead?
-			static constexpr int DEATH_NO_INPUT_TIMEOUT = 10 * FPS;
-			static constexpr int DEATH_INPUT_TIMEOUT = 5 * FPS;
+			static constexpr int DEATH_NO_INPUT_TIMEOUT = 5 * FPS;
+			static constexpr int DEATH_INPUT_TIMEOUT = 10 * FPS;
 
 			if (Lara.Control.Count.Death > DEATH_NO_INPUT_TIMEOUT || 
 				Lara.Control.Count.Death > DEATH_INPUT_TIMEOUT && !NoAction())

--- a/TombEngine/Game/control/control.cpp
+++ b/TombEngine/Game/control/control.cpp
@@ -95,9 +95,9 @@ short NextItemFree;
 short NextFxActive;
 short NextFxFree;
 
-int DrawPhase(bool title)
+int DrawPhase(bool isTitle)
 {
-	if (title)
+	if (isTitle)
 	{
 		g_Renderer.RenderTitle();
 	}
@@ -112,7 +112,7 @@ int DrawPhase(bool title)
 
 GameStatus ControlPhase(int numFrames)
 {
-	bool title = CurrentLevel == 0;
+	bool isTitle = CurrentLevel == 0;
 
 	RegeneratePickups();
 
@@ -134,7 +134,7 @@ GameStatus ControlPhase(int numFrames)
 	{
 		// Controls should be polled before OnControlPhase, so input data could be
 		// overwritten by script API methods.
-		HandleControls(title);
+		HandleControls(isTitle);
 
 		// This might not be the exact amount of time that has passed, but giving it a
 		// value of 1/30 keeps it in lock-step with the rest of the game logic,
@@ -142,16 +142,16 @@ GameStatus ControlPhase(int numFrames)
 		g_GameScript->OnControlPhase(DELTA_TIME);
 
 		// Handle inventory / pause / load / save screens.
-		auto result = HandleMenuCalls(title);
+		auto result = HandleMenuCalls(isTitle);
 		if (result != GameStatus::None)
 			return result;
 
 		// Handle global input events.
-		result = HandleGlobalInputEvents(title);
+		result = HandleGlobalInputEvents(isTitle);
 		if (result != GameStatus::None)
 			return result;
 
-		UpdateLara(LaraItem, title);
+		UpdateLara(LaraItem, isTitle);
 		UpdateAllItems();
 		UpdateAllEffects();
 
@@ -258,19 +258,19 @@ unsigned CALLBACK GameMain(void *)
 
 GameStatus DoLevel(int levelIndex, bool loadGame)
 {
-	bool title = !levelIndex;
+	bool isTitle = !levelIndex;
 
-	TENLog(title ? "DoTitle" : "DoLevel", LogLevel::Info);
+	TENLog(isTitle ? "DoTitle" : "DoLevel", LogLevel::Info);
 
 	// Load the level. Fall back to title if unsuccessful.
 	if (!LoadLevelFile(levelIndex))
-		return title ? GameStatus::ExitGame : GameStatus::ExitToTitle;
+		return isTitle ? GameStatus::ExitGame : GameStatus::ExitToTitle;
 
 	// Initialize items, effects, lots and cameras.
 	InitialiseFXArray(true);
 	InitialisePickupDisplay();
 	InitialiseCamera();
-	InitialiseSpotCamSequences(title);
+	InitialiseSpotCamSequences(isTitle);
 	InitialiseHair();
 	InitialiseNodeScripts();
 	InitialiseItemBoxData();
@@ -282,7 +282,7 @@ GameStatus DoLevel(int levelIndex, bool loadGame)
 	InitialiseScripting(levelIndex, loadGame);
 
 	// Prepare title menu, if necessary.
-	if (title)
+	if (isTitle)
 	{
 		g_Gui.SetMenuToDisplay(Menu::Title);
 		g_Gui.SetSelectedOption(0);
@@ -542,10 +542,10 @@ void EndGameLoop(int levelIndex)
 	StopRumble();
 }
 
-void HandleControls(bool title)
+void HandleControls(bool isTitle)
 {
 	// Poll keyboard and update input variables.
-	if (!title)
+	if (!isTitle)
 	{
 		if (Lara.Control.Locked)
 			ClearAllActions();
@@ -557,11 +557,11 @@ void HandleControls(bool title)
 		ClearAction(In::Look);
 }
 
-GameStatus HandleMenuCalls(bool title)
+GameStatus HandleMenuCalls(bool isTitle)
 {
 	auto result = GameStatus::None;
 
-	if (title || ScreenFading)
+	if (isTitle || ScreenFading)
 		return result;
 
 	// Does the player want to enter inventory?
@@ -617,9 +617,9 @@ GameStatus HandleMenuCalls(bool title)
 	return result;
 }
 
-GameStatus HandleGlobalInputEvents(bool title)
+GameStatus HandleGlobalInputEvents(bool isTitle)
 {
-	if (title)
+	if (isTitle)
 		return GameStatus::None;
 
 	HandleOptics(LaraItem);

--- a/TombEngine/Game/control/control.cpp
+++ b/TombEngine/Game/control/control.cpp
@@ -149,7 +149,8 @@ GameStatus ControlPhase(int numFrames)
 		// Queued input actions are read again and cleared after UI 
 		// interrupts are processed, so first frame after exiting UI
 		// will still register it.
-		UnqueueInputActions(true);
+		ApplyActionQueue();
+		ClearActionQueue();
 
 		UpdateAllItems();
 		UpdateAllEffects();

--- a/TombEngine/Game/control/control.cpp
+++ b/TombEngine/Game/control/control.cpp
@@ -116,8 +116,7 @@ GameStatus ControlPhase(int numFrames)
 
 	RegeneratePickups();
 
-	if (numFrames > 10)
-		numFrames = 10;
+	numFrames = std::clamp(numFrames, 0, 10);
 
 	if (TrackCameraInit)
 	{
@@ -202,7 +201,8 @@ GameStatus ControlPhase(int numFrames)
 		UpdateBeetleSwarm();
 		UpdateLocusts();
 
-		// Update screen overlays
+		// Update screen UI and overlays
+		UpdateBars(LaraItem);
 		UpdateFadeScreenAndCinematicBars();
 
 		// Rumble screen (like in submarine level of TRC)
@@ -218,7 +218,6 @@ GameStatus ControlPhase(int numFrames)
 		// Update timers
 		GameTimer++;
 		GlobalCounter++;
-		HealthBarTimer--;
 
 		// Add renderer objects on the first processed frame.
 		if (isFirstTime)

--- a/TombEngine/Game/control/control.cpp
+++ b/TombEngine/Game/control/control.cpp
@@ -146,6 +146,11 @@ GameStatus ControlPhase(int numFrames)
 		if (result != GameStatus::None)
 			return result;
 
+		// Queued input actions are read again and cleared after UI 
+		// interrupts are processed, so first frame after exiting UI
+		// will still register it.
+		UnqueueInputActions(true);
+
 		UpdateAllItems();
 		UpdateAllEffects();
 		UpdateLara(LaraItem, isTitle);
@@ -545,7 +550,7 @@ void HandleControls(bool isTitle)
 			ClearAllActions();
 		else
 			// TODO: To allow cutscene skipping later, don't clear Deselect action.
-			UpdateInputActions(LaraItem);
+			UpdateInputActions(LaraItem, true);
 	}
 	else
 	{

--- a/TombEngine/Game/control/control.cpp
+++ b/TombEngine/Game/control/control.cpp
@@ -151,9 +151,9 @@ GameStatus ControlPhase(int numFrames)
 		if (result != GameStatus::None)
 			return result;
 
-		UpdateLara(LaraItem, isTitle);
 		UpdateAllItems();
 		UpdateAllEffects();
+		UpdateLara(LaraItem, isTitle);
 
 		g_GameScriptEntities->TestCollidingObjects();
 
@@ -272,7 +272,6 @@ GameStatus DoLevel(int levelIndex, bool loadGame)
 	InitialiseCamera();
 	InitialiseSpotCamSequences(isTitle);
 	InitialiseHair();
-	InitialiseNodeScripts();
 	InitialiseItemBoxData();
 
 	// Initialize game variables and optionally load game.
@@ -280,6 +279,7 @@ GameStatus DoLevel(int levelIndex, bool loadGame)
 
 	// Initialize scripting.
 	InitialiseScripting(levelIndex, loadGame);
+	InitialiseNodeScripts();
 
 	// Prepare title menu, if necessary.
 	if (isTitle)

--- a/TombEngine/Game/control/control.cpp
+++ b/TombEngine/Game/control/control.cpp
@@ -127,7 +127,7 @@ GameStatus ControlPhase(int numFrames)
 
 	for (framesCount += numFrames; framesCount > 0; framesCount -= 2)
 	{
-		// TODO: Controls should be polled before OnControlPhase, so input data could be
+		// Controls are polled before OnControlPhase, so input data could be
 		// overwritten by script API methods.
 		HandleControls(isTitle);
 

--- a/TombEngine/Game/control/control.cpp
+++ b/TombEngine/Game/control/control.cpp
@@ -375,7 +375,7 @@ GameStatus DoLevel(int levelIndex, bool loadGame)
 	InitialiseFXArray(true);
 	InitialisePickupDisplay();
 	InitialiseCamera();
-	InitSpotCamSequences(title);
+	InitialiseSpotCamSequences(title);
 	InitialiseHair();
 	InitialiseNodeScripts();
 	InitialiseItemBoxData();

--- a/TombEngine/Game/control/control.h
+++ b/TombEngine/Game/control/control.h
@@ -70,11 +70,10 @@ extern short NextFxFree;
 
 extern std::vector<short> OutsideRoomTable[OUTSIDE_SIZE][OUTSIDE_SIZE];
 
-int DrawPhase();
+GameStatus DoLevel(int index, bool loadFromSavegame = false);
+GameStatus ControlPhase(int numFrames);
 
-GameStatus DoTitle(int index);
-GameStatus DoLevel(int index, bool loadFromSavegame);
-GameStatus ControlPhase(int numFrames, bool demoMode);
+int DrawPhase(bool title);
 
 int GetRandomControl();
 int GetRandomDraw();

--- a/TombEngine/Game/control/control.h
+++ b/TombEngine/Game/control/control.h
@@ -70,7 +70,8 @@ extern short NextFxFree;
 
 extern std::vector<short> OutsideRoomTable[OUTSIDE_SIZE][OUTSIDE_SIZE];
 
-GameStatus DoLevel(int index, bool loadFromSavegame = false);
+GameStatus DoLevel(int index, bool loadGame = false);
+GameStatus DoGameLoop(int index);
 GameStatus ControlPhase(int numFrames);
 
 int DrawPhase(bool title);
@@ -83,5 +84,9 @@ void KillMoveEffects();
 void UpdateShatters();
 
 void CleanUp();
+
+void InitialiseOrLoadGame(bool loadGame);
+void InitialiseScripting(int index, bool loadGame);
+void DeInitialiseScripting(int index);
 
 unsigned CALLBACK GameMain(void*);

--- a/TombEngine/Game/control/control.h
+++ b/TombEngine/Game/control/control.h
@@ -77,6 +77,10 @@ GameStatus DoLevel(int levelIndex, bool loadGame = false);
 GameStatus DoGameLoop(int levelIndex);
 void EndGameLoop(int levelIndex);
 
+GameStatus HandleMenuCalls(bool title);
+GameStatus HandleLevelEnd();
+void HandleControls(bool title);
+
 int GetRandomControl();
 int GetRandomDraw();
 

--- a/TombEngine/Game/control/control.h
+++ b/TombEngine/Game/control/control.h
@@ -70,11 +70,12 @@ extern short NextFxFree;
 
 extern std::vector<short> OutsideRoomTable[OUTSIDE_SIZE][OUTSIDE_SIZE];
 
-GameStatus DoLevel(int index, bool loadGame = false);
-GameStatus DoGameLoop(int index);
-GameStatus ControlPhase(int numFrames);
-
 int DrawPhase(bool title);
+
+GameStatus ControlPhase(int numFrames);
+GameStatus DoLevel(int levelIndex, bool loadGame = false);
+GameStatus DoGameLoop(int levelIndex);
+void EndGameLoop(int levelIndex);
 
 int GetRandomControl();
 int GetRandomDraw();
@@ -86,7 +87,7 @@ void UpdateShatters();
 void CleanUp();
 
 void InitialiseOrLoadGame(bool loadGame);
-void InitialiseScripting(int index, bool loadGame);
-void DeInitialiseScripting(int index);
+void InitialiseScripting(int levelIndex, bool loadGame);
+void DeInitialiseScripting(int levelIndex);
 
 unsigned CALLBACK GameMain(void*);

--- a/TombEngine/Game/control/control.h
+++ b/TombEngine/Game/control/control.h
@@ -70,16 +70,16 @@ extern short NextFxFree;
 
 extern std::vector<short> OutsideRoomTable[OUTSIDE_SIZE][OUTSIDE_SIZE];
 
-int DrawPhase(bool title);
+int DrawPhase(bool isTitle);
 
 GameStatus ControlPhase(int numFrames);
 GameStatus DoLevel(int levelIndex, bool loadGame = false);
 GameStatus DoGameLoop(int levelIndex);
 void EndGameLoop(int levelIndex);
 
-GameStatus HandleMenuCalls(bool title);
-GameStatus HandleGlobalInputEvents(bool title);
-void HandleControls(bool title);
+GameStatus HandleMenuCalls(bool isTitle);
+GameStatus HandleGlobalInputEvents(bool isTitle);
+void HandleControls(bool isTitle);
 
 int GetRandomControl();
 int GetRandomDraw();

--- a/TombEngine/Game/control/control.h
+++ b/TombEngine/Game/control/control.h
@@ -78,7 +78,7 @@ GameStatus DoGameLoop(int levelIndex);
 void EndGameLoop(int levelIndex);
 
 GameStatus HandleMenuCalls(bool title);
-GameStatus HandleLevelEnd();
+GameStatus HandleGlobalInputEvents(bool title);
 void HandleControls(bool title);
 
 int GetRandomControl();

--- a/TombEngine/Game/effects/simple_particle.cpp
+++ b/TombEngine/Game/effects/simple_particle.cpp
@@ -11,7 +11,7 @@ namespace TEN::Effects
 {
 	std::array<SimpleParticle, 15> simpleParticles;
 
-	SimpleParticle& getFreeSimpleParticle()
+	SimpleParticle& GetFreeSimpleParticle()
 	{
 		for (auto& p : simpleParticles)
 			if (!p.active)
@@ -28,7 +28,7 @@ namespace TEN::Effects
 		float z = std::cos(angle + angleVariation);
 		x = x* -500 + snowMobile->Pose.Position.x;
 		z = z* -500 + snowMobile->Pose.Position.z;
-		SimpleParticle& p = getFreeSimpleParticle();
+		SimpleParticle& p = GetFreeSimpleParticle();
 		p = {};
 		p.active = true;
 		p.life = Random::GenerateFloat(8, 14);
@@ -52,7 +52,7 @@ namespace TEN::Effects
 			float z = std::cos(angle + angleVariation);
 			x = x * offset.z + z * offset.x + boat->Pose.Position.x;
 			z = z * offset.z + x * offset.x + boat->Pose.Position.z;
-			SimpleParticle& p = getFreeSimpleParticle();
+			SimpleParticle& p = GetFreeSimpleParticle();
 			p = {};
 			p.active = true;
 			p.life = Random::GenerateFloat(5, 9);
@@ -64,7 +64,7 @@ namespace TEN::Effects
 		}
 	}
 
-	void updateSimpleParticles()
+	void UpdateSimpleParticles()
 	{
 		for (auto& p : simpleParticles)
 		{

--- a/TombEngine/Game/effects/simple_particle.h
+++ b/TombEngine/Game/effects/simple_particle.h
@@ -23,8 +23,8 @@ namespace TEN::Effects
 	};
 	extern std::array<SimpleParticle, 15> simpleParticles;
 
-	SimpleParticle& getFreeSimpleParticle();
+	SimpleParticle& GetFreeSimpleParticle();
 	void TriggerSnowmobileSnow(ItemInfo* snowMobile);
 	void TriggerSpeedboatFoam(ItemInfo* boat, Vector3 offset);
-	void updateSimpleParticles();
+	void UpdateSimpleParticles();
 }

--- a/TombEngine/Game/gui.cpp
+++ b/TombEngine/Game/gui.cpp
@@ -607,7 +607,7 @@ namespace TEN::Gui
 					g_Renderer.RenderTitle();
 					Camera.numberFrames = g_Renderer.Synchronize();
 					int numFrames = Camera.numberFrames;
-					ControlPhase(numFrames, false);
+					ControlPhase(numFrames);
 				}
 			}
 		}

--- a/TombEngine/Game/gui.cpp
+++ b/TombEngine/Game/gui.cpp
@@ -2906,7 +2906,7 @@ namespace TEN::Gui
 	{
 		auto* lara = GetLaraInfo(item);
 
-		bool returnValue = false;
+		bool doLoad = false;
 
 		lara->Inventory.OldBusy = lara->Inventory.IsBusy;
 
@@ -2965,7 +2965,7 @@ namespace TEN::Gui
 				switch (DoLoad())
 				{
 				case LoadResult::Load:
-					returnValue = true;
+					doLoad = true;
 					exitLoop = true;
 					break;
 
@@ -3013,7 +3013,7 @@ namespace TEN::Gui
 		lara->Inventory.IsBusy = lara->Inventory.OldBusy;
 		InvMode = InventoryMode::None;
 
-		return returnValue;
+		return doLoad;
 	}
 
 	void GuiController::DoStatisticsMode()

--- a/TombEngine/Game/health.cpp
+++ b/TombEngine/Game/health.cpp
@@ -32,67 +32,60 @@ extern RendererHUDBar* g_AirBar;
 
 void DrawHUD(ItemInfo* item)
 {
-	static bool flash = false;
+	static bool doFlash = false;
 	if ((GameTimer & 0x07) == 0x07)
-		flash = !flash;
+		doFlash = !doFlash;
 
 	if (CurrentLevel == 0 || CinematicBarsHeight > 0)
 		return;
 
 	DrawSprintBar(LaraItem);
-	DrawHealthBar(LaraItem, flash);
-	DrawAirBar(LaraItem, flash);
+	DrawHealthBar(LaraItem, doFlash);
+	DrawAirBar(LaraItem, doFlash);
 	DrawAllPickups();
 }
 
 void DrawHealthBarOverlay(ItemInfo* item, int value)
 {
-	auto* lara = GetLaraInfo(item);
+	const auto& lara = *GetLaraInfo(item);
 
 	if (CurrentLevel)
-	{
-		int color2 = 0;
-		if (lara->PoisonPotency)
-			color2 = 0xA0A000;
-		else
-			color2 = 0xA00000;
-
 		g_Renderer.DrawBar(value, g_HealthBar, ID_HEALTH_BAR_TEXTURE, GlobalCounter, Lara.PoisonPotency);
-	}
 }
 
 void DrawHealthBar(ItemInfo* item, float value)
 {
-	auto* lara = GetLaraInfo(item);
-	g_Renderer.DrawBar(value, g_HealthBar, ID_HEALTH_BAR_TEXTURE, GlobalCounter, lara->PoisonPotency);
+	const auto& lara = *GetLaraInfo(item);
+
+	g_Renderer.DrawBar(value, g_HealthBar, ID_HEALTH_BAR_TEXTURE, GlobalCounter, lara.PoisonPotency);
 }
 
-void DrawHealthBar(ItemInfo* item, bool flash)
+void DrawHealthBar(ItemInfo* item, bool doFlash)
 {
-	auto* lara = GetLaraInfo(item);
+	const auto& lara = *GetLaraInfo(item);
 
 	// Flash when at critical capacity and bar is not transitioning.
 	if (HealthBarValue <= LARA_HEALTH_CRITICAL)
 	{
 		if (!BinocularRange)
 		{
-			if (flash || HealthBarMutateAmount)
+			if (doFlash || HealthBarMutateAmount)
 				DrawHealthBar(item, HealthBarValue / LARA_HEALTH_MAX);
 			else
 				DrawHealthBar(item, 0.0f);
 		}
 		else
 		{
-			if (flash || HealthBarMutateAmount)
+			if (doFlash || HealthBarMutateAmount)
 				DrawHealthBarOverlay(item, HealthBarValue / LARA_HEALTH_MAX);
 			else
 				DrawHealthBarOverlay(item, 0);
 		}
 	}
 	else if (HealthBarTimer > 0 || HealthBarValue <= 0 ||
-			 lara->Control.HandStatus == HandStatus::WeaponReady &&
-			 lara->Control.Weapon.GunType != LaraWeaponType::Torch ||
-			 lara->PoisonPotency)
+			 lara.Control.HandStatus == HandStatus::WeaponReady &&
+			 lara.Control.Weapon.GunType != LaraWeaponType::Torch ||
+			 lara.PoisonPotency)
 	{
 		if (!BinocularRange)
 			DrawHealthBar(item, HealthBarValue / LARA_HEALTH_MAX);
@@ -106,37 +99,43 @@ void DrawAirBar(float value)
 	g_Renderer.DrawBar(value, g_AirBar,ID_AIR_BAR_TEXTURE, 0, 0);
 }
 
-void DrawAirBar(ItemInfo* item, bool flash)
+void DrawAirBar(ItemInfo* item, bool doFlash)
 {
-	auto* lara = GetLaraInfo(item);
+	const auto& lara = *GetLaraInfo(item);
 
-	if (lara->Air == LARA_AIR_MAX || item->HitPoints <= 0)
+	if (lara.Air == LARA_AIR_MAX || item->HitPoints <= 0)
 		return;
 
-	if (lara->Vehicle == NO_ITEM ||
-		g_Level.Items[lara->Vehicle].ObjectNumber != ID_UPV)
+	if (lara.Vehicle == NO_ITEM ||
+		g_Level.Items[lara.Vehicle].ObjectNumber != ID_UPV)
 	{
-		if (lara->Control.WaterStatus != WaterStatus::Underwater &&
-			lara->Control.WaterStatus != WaterStatus::TreadWater &&
-			!(TestEnvironment(ENV_FLAG_SWAMP, item) && lara->WaterSurfaceDist < -(CLICK(3) - 1)))
+		if (lara.Control.WaterStatus != WaterStatus::Underwater &&
+			lara.Control.WaterStatus != WaterStatus::TreadWater &&
+			!(TestEnvironment(ENV_FLAG_SWAMP, item) && lara.WaterSurfaceDist < -(CLICK(3) - 1)))
 			return;
 	}
 
-	int air = lara->Air;
-	if (air < 0)
-		air = 0;
+	float air = lara.Air;
+	if (air < 0.0f)
+	{
+		air = 0.0f;
+	}
 	else if (air > LARA_AIR_MAX)
+	{
 		air = LARA_AIR_MAX;
+	}
 
 	if (air <= LARA_AIR_CRITICAL)
 	{
-		if (flash)
+		if (doFlash)
 			DrawAirBar(air / LARA_AIR_MAX);
 		else
 			DrawAirBar(0.0f);
 	}
 	else
+	{
 		DrawAirBar(air / LARA_AIR_MAX);
+	}
 }
 
 void DrawSprintBar(float value)
@@ -146,24 +145,24 @@ void DrawSprintBar(float value)
 
 void DrawSprintBar(ItemInfo* item)
 {
-	auto* lara = GetLaraInfo(item);
+	const auto& lara = *GetLaraInfo(item);
 
-	if (lara->SprintEnergy < LARA_SPRINT_ENERGY_MAX)
-		DrawSprintBar(lara->SprintEnergy / LARA_SPRINT_ENERGY_MAX);
+	if (lara.SprintEnergy < LARA_SPRINT_ENERGY_MAX)
+		DrawSprintBar(lara.SprintEnergy / LARA_SPRINT_ENERGY_MAX);
 }
 
 void DrawAllPickups()
 {
-	auto* pickup = &Pickups[CurrentPickup];
+	auto& pickup = Pickups[CurrentPickup];
 
-	if (pickup->Life > 0)
+	if (pickup.Life > 0)
 	{
 		if (PickupX > 0)
 			PickupX += -PickupX >> 3;
 		else
-			pickup->Life--;
+			pickup.Life--;
 	}
-	else if (pickup->Life == 0)
+	else if (pickup.Life == 0)
 	{
 		if (PickupX < 128)
 		{
@@ -174,7 +173,7 @@ void DrawAllPickups()
 		}
 		else
 		{
-			pickup->Life = -1;
+			pickup.Life = -1;
 			PickupVel = 0;
 		}
 	}
@@ -200,21 +199,16 @@ void DrawAllPickups()
 	g_Renderer.DrawPickup(Pickups[CurrentPickup].ObjectNumber);
 }
 
-
 void AddDisplayPickup(GAME_OBJECT_ID objectNumber)
 {
-	auto* pickup = Pickups;
-
-	for (int i = 0; i < MAX_COLLECTED_PICKUPS; i++)
+	for (auto& pickup : Pickups)
 	{
-		if (pickup->Life < 0)
+		if (pickup.Life < 0)
 		{
-			pickup->Life = 45;
-			pickup->ObjectNumber = objectNumber;
+			pickup.Life = 45;
+			pickup.ObjectNumber = objectNumber;
 			break;
 		}
-
-		pickup++;
 	}
 
 	// No free slot found; pickup the object without displaying it.
@@ -223,8 +217,8 @@ void AddDisplayPickup(GAME_OBJECT_ID objectNumber)
 
 void InitialisePickupDisplay()
 {
-	for (int i = 0; i < MAX_COLLECTED_PICKUPS; i++)
-		Pickups[i].Life = -1;
+	for (auto& pickup : Pickups)
+		pickup.Life = -1;
 
 	PickupX = 128;
 	PickupY = 128;
@@ -237,14 +231,18 @@ void UpdateBars(ItemInfo* item)
 	if (HealthBarTimer)
 		HealthBarTimer--;
 
-	auto* lara = GetLaraInfo(item);
+	const auto& lara = *GetLaraInfo(item);
 
-	auto hitPoints = (float)item->HitPoints;
+	float hitPoints = item->HitPoints;
 
 	if (hitPoints < 0)
+	{
 		hitPoints = 0;
+	}
 	else if (hitPoints > LARA_HEALTH_MAX)
+	{
 		hitPoints = LARA_HEALTH_MAX;
+	}
 
 	// Smoothly transition health bar display.
 	if (EnableSmoothHealthBar)
@@ -257,9 +255,13 @@ void UpdateBars(ItemInfo* item)
 		}
 
 		if (HealthBarValue - HealthBarMutateAmount < 0)
+		{
 			HealthBarMutateAmount = HealthBarValue;
+		}
 		else if (HealthBarValue - HealthBarMutateAmount > LARA_HEALTH_MAX)
+		{
 			HealthBarMutateAmount = HealthBarValue - LARA_HEALTH_MAX;
+		}
 
 		HealthBarValue -= HealthBarMutateAmount / 3;
 		HealthBarMutateAmount -= HealthBarMutateAmount / 3;

--- a/TombEngine/Game/health.cpp
+++ b/TombEngine/Game/health.cpp
@@ -32,12 +32,12 @@ extern RendererHUDBar* g_AirBar;
 
 void DrawHUD(ItemInfo* item)
 {
-	if (CurrentLevel == 0 || CinematicBarsHeight > 0)
-		return;
-
 	static bool flash = false;
 	if ((GameTimer & 0x07) == 0x07)
 		flash = !flash;
+
+	if (CurrentLevel == 0 || CinematicBarsHeight > 0)
+		return;
 
 	DrawSprintBar(LaraItem);
 	DrawHealthBar(LaraItem, flash);

--- a/TombEngine/Game/health.h
+++ b/TombEngine/Game/health.h
@@ -14,25 +14,18 @@ struct DisplayPickup
 void DrawHUD(ItemInfo* item);
 void DrawHealthBarOverlay(ItemInfo* item, int value);
 void DrawHealthBar(ItemInfo* item, float value);
-void UpdateHealthBar(ItemInfo* item, int flash);
+void DrawHealthBar(ItemInfo* item, bool flash);
 void DrawAirBar(float value);
-void UpdateAirBar(ItemInfo* item, int flash);
+void DrawAirBar(ItemInfo* item, bool flash);
 void DrawSprintBar(float value);
-void UpdateSprintBar(ItemInfo* item);
+void DrawSprintBar(ItemInfo* item);
+void UpdateBars(ItemInfo* item);
 void AddDisplayPickup(GAME_OBJECT_ID objectNumber);
 void DrawAllPickups();
 void InitialisePickupDisplay();
-int FlashIt();
 
 extern short PickupX;
 extern short PickupY;
-extern short CurrentPickup;
 extern DisplayPickup Pickups[MAX_COLLECTED_PICKUPS];
-extern short PickupVel;
-extern int OldHitPoints;
-extern int HealthBarTimer;
-extern float HealthBar;
-extern float MutateAmount;
-extern int FlashState;
 
 extern bool EnableSmoothHealthBar;

--- a/TombEngine/Game/health.h
+++ b/TombEngine/Game/health.h
@@ -14,9 +14,9 @@ struct DisplayPickup
 void DrawHUD(ItemInfo* item);
 void DrawHealthBarOverlay(ItemInfo* item, int value);
 void DrawHealthBar(ItemInfo* item, float value);
-void DrawHealthBar(ItemInfo* item, bool flash);
+void DrawHealthBar(ItemInfo* item, bool doFlash);
 void DrawAirBar(float value);
-void DrawAirBar(ItemInfo* item, bool flash);
+void DrawAirBar(ItemInfo* item, bool doFlash);
 void DrawSprintBar(float value);
 void DrawSprintBar(ItemInfo* item);
 void UpdateBars(ItemInfo* item);

--- a/TombEngine/Game/savegame.cpp
+++ b/TombEngine/Game/savegame.cpp
@@ -759,6 +759,12 @@ bool SaveGame::Save(int slot)
 	}
 	auto soundtrackMapOffset = fbb.CreateVector(soundTrackMap);
 
+	// Action queue
+	std::vector<int> actionQueue;
+	for (int i = 0; i < ActionQueue.size(); i++)
+		actionQueue.push_back((int)ActionQueue[i]);
+	auto actionQueueOffset = fbb.CreateVector(actionQueue);
+
 	// Flipmaps
 	std::vector<int> flipMaps;
 	for (int i = 0; i < MAX_FLIPMAP; i++)
@@ -1137,6 +1143,7 @@ bool SaveGame::Save(int slot)
 	sgb.add_oneshot_track(oneshotTrackOffset);
 	sgb.add_oneshot_position(oneshotTrackData.second);
 	sgb.add_cd_flags(soundtrackMapOffset);
+	sgb.add_action_queue(actionQueueOffset);
 	sgb.add_flip_maps(flipMapsOffset);
 	sgb.add_flip_stats(flipStatsOffset);
 	sgb.add_room_items(roomItemsOffset);
@@ -1233,6 +1240,13 @@ bool SaveGame::Load(int slot)
 
 	// Restore camera FOV
 	AlterFOV(s->current_fov());
+
+	// Restore action queue
+	for (int i = 0; i < s->action_queue()->size(); i++)
+	{
+		assertion(i < ActionQueue.size(), "Action queue size was changed");
+		ActionQueue[i] = (QueueState)s->action_queue()->Get(i);
+	}
 
 	// Restore soundtracks
 	PlaySoundTrack(s->ambient_track()->str(), SoundTrackType::BGM, s->ambient_position());

--- a/TombEngine/Game/spotcam.cpp
+++ b/TombEngine/Game/spotcam.cpp
@@ -65,7 +65,7 @@ void ClearSpotCamSequences()
 		SpotCam[i] = {};
 }
 
-void InitSpotCamSequences(bool title)
+void InitialiseSpotCamSequences(bool title)
 {
 	TrackCameraInit = 0;
 

--- a/TombEngine/Game/spotcam.cpp
+++ b/TombEngine/Game/spotcam.cpp
@@ -65,7 +65,7 @@ void ClearSpotCamSequences()
 		SpotCam[i] = {};
 }
 
-void InitialiseSpotCamSequences(bool isTitle)
+void InitialiseSpotCamSequences(bool startFirstSequence)
 {
 	TrackCameraInit = 0;
 
@@ -100,7 +100,7 @@ void InitialiseSpotCamSequences(bool isTitle)
 		SpotCamRemap[s] = ce;
 	}
 
-	if (isTitle)
+	if (startFirstSequence)
 	{
 		InitialiseSpotCam(0);
 		UseSpotCam = true;

--- a/TombEngine/Game/spotcam.cpp
+++ b/TombEngine/Game/spotcam.cpp
@@ -65,7 +65,7 @@ void ClearSpotCamSequences()
 		SpotCam[i] = {};
 }
 
-void InitialiseSpotCamSequences(bool title)
+void InitialiseSpotCamSequences(bool isTitle)
 {
 	TrackCameraInit = 0;
 
@@ -100,7 +100,7 @@ void InitialiseSpotCamSequences(bool title)
 		SpotCamRemap[s] = ce;
 	}
 
-	if (title)
+	if (isTitle)
 	{
 		InitialiseSpotCam(0);
 		UseSpotCam = true;

--- a/TombEngine/Game/spotcam.cpp
+++ b/TombEngine/Game/spotcam.cpp
@@ -65,10 +65,11 @@ void ClearSpotCamSequences()
 		SpotCam[i] = {};
 }
 
-void InitSpotCamSequences() 
+void InitSpotCamSequences(bool title)
 {
-	int n = NumberSpotcams;
 	TrackCameraInit = 0;
+
+	int n = NumberSpotcams;
 	int cc = 1;
 
 	if (n != 0)
@@ -99,7 +100,11 @@ void InitSpotCamSequences()
 		SpotCamRemap[s] = ce;
 	}
 
-	return;
+	if (title)
+	{
+		InitialiseSpotCam(0);
+		UseSpotCam = true;
+	}
 }
 
 void InitialiseSpotCam(short Sequence)

--- a/TombEngine/Game/spotcam.h
+++ b/TombEngine/Game/spotcam.h
@@ -56,7 +56,7 @@ extern bool SpotcamOverlay;
 extern bool TrackCameraInit;
 
 void ClearSpotCamSequences();
-void InitialiseSpotCamSequences(bool title);
+void InitialiseSpotCamSequences(bool isTitle);
 void InitialiseSpotCam(short sequence);
 void CalculateSpotCameras();
 int Spline(int x, int* knots, int nk);

--- a/TombEngine/Game/spotcam.h
+++ b/TombEngine/Game/spotcam.h
@@ -56,7 +56,7 @@ extern bool SpotcamOverlay;
 extern bool TrackCameraInit;
 
 void ClearSpotCamSequences();
-void InitialiseSpotCamSequences(bool isTitle);
+void InitialiseSpotCamSequences(bool startFirstSequence);
 void InitialiseSpotCam(short sequence);
 void CalculateSpotCameras();
 int Spline(int x, int* knots, int nk);

--- a/TombEngine/Game/spotcam.h
+++ b/TombEngine/Game/spotcam.h
@@ -56,7 +56,7 @@ extern bool SpotcamOverlay;
 extern bool TrackCameraInit;
 
 void ClearSpotCamSequences();
-void InitSpotCamSequences();
+void InitSpotCamSequences(bool title);
 void InitialiseSpotCam(short sequence);
 void CalculateSpotCameras();
 int Spline(int x, int* knots, int nk);

--- a/TombEngine/Game/spotcam.h
+++ b/TombEngine/Game/spotcam.h
@@ -56,7 +56,7 @@ extern bool SpotcamOverlay;
 extern bool TrackCameraInit;
 
 void ClearSpotCamSequences();
-void InitSpotCamSequences(bool title);
+void InitialiseSpotCamSequences(bool title);
 void InitialiseSpotCam(short sequence);
 void CalculateSpotCameras();
 int Spline(int x, int* knots, int nk);

--- a/TombEngine/Renderer/Renderer11.h
+++ b/TombEngine/Renderer/Renderer11.h
@@ -624,14 +624,14 @@ namespace TEN::Renderer
 		void DrawBar(float percent, const RendererHUDBar* bar, GAME_OBJECT_ID textureSlot, int frame, bool poison);
 		void Create();
 		void Initialise(int w, int h, bool windowed, HWND handle);
-		void Draw();
+		void Render();
+		void RenderTitle();
 		void Lock();
 		bool PrepareDataForTheRenderer();
 		void UpdateCameraMatrices(CAMERA_INFO* cam, float roll, float fov, float farView);
 		void RenderSimpleScene(ID3D11RenderTargetView* target, ID3D11DepthStencilView* depthTarget, RenderView& view);
 		void DumpGameScene();
 		void RenderInventory();
-		void RenderTitle();
 		void RenderScene(ID3D11RenderTargetView* target, ID3D11DepthStencilView* depthTarget, RenderView& view);
 		void PrintDebugMessage(LPCSTR message, ...);
 		void DrawDebugInfo(RenderView& view);

--- a/TombEngine/Renderer/Renderer11.h
+++ b/TombEngine/Renderer/Renderer11.h
@@ -478,7 +478,6 @@ namespace TEN::Renderer
 		void CollectLightsForCamera();
 		void CalculateLightFades(RendererItem* item);
 		void CollectEffects(short roomNumber);
-		void ClearScene();
 		void ClearSceneItems();
 		void ClearDynamicLights();
 		void ClearShadowMap();
@@ -564,6 +563,7 @@ namespace TEN::Renderer
 		void SetCullMode(CULL_MODES cullMode, bool force = false);
 		void SetAlphaTest(ALPHA_TEST_MODES mode, float threshold, bool force = false);
 		void SetScissor(RendererRectangle rectangle);
+		void ResetAnimations();
 		void ResetScissor();
 		void ResetDebugVariables();
 		float CalculateFrameRate();
@@ -633,6 +633,7 @@ namespace TEN::Renderer
 		void DumpGameScene();
 		void RenderInventory();
 		void RenderScene(ID3D11RenderTargetView* target, ID3D11DepthStencilView* depthTarget, RenderView& view);
+		void ClearScene();
 		void PrintDebugMessage(LPCSTR message, ...);
 		void DrawDebugInfo(RenderView& view);
 		void SwitchDebugPage(bool back);
@@ -658,7 +659,6 @@ namespace TEN::Renderer
 		void AddDebugSphere(Vector3 center, float radius, Vector4 color, RENDERER_DEBUG_PAGE page);
 		void ChangeScreenResolution(int width, int height, bool windowed);
 		void FlipRooms(short roomNumber1, short roomNumber2);
-		void ResetAnimations();
 		void UpdateLaraAnimations(bool force);
 		void UpdateItemAnimations(int itemNumber, bool force);
 		void GetItemAbsBonePosition(int itemNumber, Vector3& pos, int jointIndex);

--- a/TombEngine/Renderer/Renderer11Draw.cpp
+++ b/TombEngine/Renderer/Renderer11Draw.cpp
@@ -2282,7 +2282,7 @@ namespace TEN::Renderer
 		m_context->ClearDepthStencilView(depthTarget, D3D11_CLEAR_DEPTH | D3D11_CLEAR_STENCIL, 1.0f, 0);
 	}
 
-	void Renderer11::Draw()
+	void Renderer11::Render()
 	{
 		//RenderToCubemap(m_reflectionCubemap, Vector3(LaraItem->pos.xPos, LaraItem->pos.yPos - 1024, LaraItem->pos.zPos), LaraItem->roomNumber);
 		RenderScene(m_backBufferRTV, m_depthStencilView, gameCamera);

--- a/TombEngine/Scripting/Internal/TEN/Flow/FlowHandler.cpp
+++ b/TombEngine/Scripting/Internal/TEN/Flow/FlowHandler.cpp
@@ -377,7 +377,7 @@ bool FlowHandler::DoFlow()
 	SelectedSaveGame = 0;
 	SaveGameHeader header;
 
-	// We loop indefinitely, looking for return values of DoTitle or DoLevel
+	// We loop indefinitely, looking for return values of DoLevel
 	bool loadFromSavegame = false;
 
 	while (DoTheGame)
@@ -391,7 +391,7 @@ bool FlowHandler::DoFlow()
 		{
 			try
 			{
-				status = DoTitle(0);
+				status = DoLevel(CurrentLevel);
 			}
 			catch (TENScriptException const& e)
 			{

--- a/TombEngine/Specific/Input/Input.cpp
+++ b/TombEngine/Specific/Input/Input.cpp
@@ -212,6 +212,29 @@ namespace TEN::Input
 		TrInput = 0;
 	}
 
+	void UnqueueInputActions(bool clearQueue)
+	{
+		for (int i = 0; i < KEY_COUNT; i++)
+		{
+			if (ActionQueue[i] != QueueState::None)
+			{
+				if (ActionQueue[i] == QueueState::Push)
+				{
+					ActionMap[i].Update(true);
+				}
+				else
+				{
+					ActionMap[i].Clear();
+				}
+
+				if (clearQueue)
+				{
+					ActionQueue[i] = QueueState::None;
+				}
+			}
+		}
+	}
+
 	bool LayoutContainsIndex(unsigned int index)
 	{
 		for (int l = 0; l < 2; l++)
@@ -633,7 +656,7 @@ namespace TEN::Input
 		RumbleInfo.LastPower = RumbleInfo.Power;
 	}
 
-	void UpdateInputActions(ItemInfo* item)
+	void UpdateInputActions(ItemInfo* item, bool queue)
 	{
 		ClearInputData();
 		UpdateRumble();
@@ -644,17 +667,12 @@ namespace TEN::Input
 		for (int i = 0; i < KEY_COUNT; i++)
 		{
 			// TODO: Poll analog value of key. Potentially, any can be a trigger.
-			ActionMap[i].Update(Key(i) ? true : false); 
+			ActionMap[i].Update(Key(i) ? true : false);
 		}
 
-		// Also update action map from queue.
-		for (int i = 0; i < ActionQueue.size(); i++)
+		if (queue)
 		{
-			if (ActionQueue[i] != QueueState::None)
-			{
-				ActionMap[i].Update(ActionQueue[i] == QueueState::Push);
-				ActionQueue[i] = QueueState::None;
-			}
+			UnqueueInputActions(false);
 		}
 
 		// Additional handling.
@@ -675,6 +693,9 @@ namespace TEN::Input
 	{
 		for (auto& action : ActionMap)
 			action.Clear();
+
+		for (auto& queue : ActionQueue)
+			queue = QueueState::None;
 
 		DbInput = 0;
 		TrInput = 0;

--- a/TombEngine/Specific/Input/Input.cpp
+++ b/TombEngine/Specific/Input/Input.cpp
@@ -212,7 +212,7 @@ namespace TEN::Input
 		TrInput = 0;
 	}
 
-	void UnqueueInputActions(bool clearQueue)
+	void ApplyActionQueue()
 	{
 		for (int i = 0; i < KEY_COUNT; i++)
 		{
@@ -226,13 +226,14 @@ namespace TEN::Input
 				{
 					ActionMap[i].Clear();
 				}
-
-				if (clearQueue)
-				{
-					ActionQueue[i] = QueueState::None;
-				}
 			}
 		}
+	}
+
+	void ClearActionQueue()
+	{
+		for (auto& queue : ActionQueue)
+			queue = QueueState::None;
 	}
 
 	bool LayoutContainsIndex(unsigned int index)
@@ -656,7 +657,7 @@ namespace TEN::Input
 		RumbleInfo.LastPower = RumbleInfo.Power;
 	}
 
-	void UpdateInputActions(ItemInfo* item, bool queue)
+	void UpdateInputActions(ItemInfo* item, bool applyQueue)
 	{
 		ClearInputData();
 		UpdateRumble();
@@ -670,9 +671,9 @@ namespace TEN::Input
 			ActionMap[i].Update(Key(i) ? true : false);
 		}
 
-		if (queue)
+		if (applyQueue)
 		{
-			UnqueueInputActions(false);
+			ApplyActionQueue();
 		}
 
 		// Additional handling.

--- a/TombEngine/Specific/Input/Input.h
+++ b/TombEngine/Specific/Input/Input.h
@@ -143,8 +143,9 @@ namespace TEN::Input
 	void InitialiseInput(HWND handle);
 	void DeinitialiseInput();
 	void DefaultConflict();
-	void UpdateInputActions(ItemInfo* item, bool queue = false);
-	void UnqueueInputActions(bool clearQueue);
+	void UpdateInputActions(ItemInfo* item, bool applyQueue = false);
+	void ApplyActionQueue();
+	void ClearActionQueue();
 	void ClearAllActions();
 	void Rumble(float power, float delayInSec = 0.3f, RumbleMode mode = RumbleMode::Both);
 	void StopRumble();

--- a/TombEngine/Specific/Input/Input.h
+++ b/TombEngine/Specific/Input/Input.h
@@ -143,7 +143,8 @@ namespace TEN::Input
 	void InitialiseInput(HWND handle);
 	void DeinitialiseInput();
 	void DefaultConflict();
-	void UpdateInputActions(ItemInfo* item);
+	void UpdateInputActions(ItemInfo* item, bool queue = false);
+	void UnqueueInputActions(bool clearQueue);
 	void ClearAllActions();
 	void Rumble(float power, float delayInSec = 0.3f, RumbleMode mode = RumbleMode::Both);
 	void StopRumble();

--- a/TombEngine/Specific/level.cpp
+++ b/TombEngine/Specific/level.cpp
@@ -1142,7 +1142,7 @@ unsigned int _stdcall LoadLevel(void* data)
 
 		// Initialise the game
 		InitialiseGameFlags();
-		InitialiseLara(!(InitialiseGame || CurrentLevel == 1));
+		InitialiseLara(!(InitialiseGame || CurrentLevel <= 1));
 		InitializeNeighborRoomList();
 		GetCarriedItems();
 		GetAIPickups();

--- a/TombEngine/Specific/savegame/schema/ten_savegame.fbs
+++ b/TombEngine/Specific/savegame/schema/ten_savegame.fbs
@@ -471,6 +471,7 @@ table SaveGame {
 	flip_timer: int32;
 	flip_status: int32;
 	current_fov: int16;
+	action_queue: [int32];
 	ambient_track: string;
 	ambient_position: uint64;
 	oneshot_track: string;


### PR DESCRIPTION
Decopypastes `DoTitle` and `DoLevel` control routines and merges them into single `DoLevel` routine. Also refactors inconsistent underlying methods as well.

Additionally, allows to spawn "real" Lara in title flyby, which means she can be killed and can interact with room geometry and objects.

**Things to test**

1) Do new game / new game with level select / load game from title menu.
2) Do load game from in-game.
3) Exit game from title and from in-game.
4) Enter / exit inventory and try to use various items from it.
5) Check if any weird things are happening in any of these cases during gameplay (object activation, Lara controls, triggers).
6) Test how Lara works in title level (`Flow.EnableLaraInTitle(true)` command in Gameflow.lua)