### PR TITLE
Fix offset for pushing and pulling a block

### DIFF
--- a/TombEngine/Game/Lara/lara.h
+++ b/TombEngine/Game/Lara/lara.h
@@ -84,6 +84,9 @@ constexpr auto WADE_DEPTH		   = STEPUP_HEIGHT;
 constexpr auto SWIM_DEPTH		   = CLICK(3) - 38;
 constexpr auto SLOPE_DIFFERENCE	   = 60;
 
+constexpr auto LARA_PUSHABLE_PUSH_BBOX_Z2 = 1108 - BLOCK(1);
+constexpr auto LARA_PUSHABLE_PULL_BBOX_Z2 = BLOCK(1) - 944;
+
 extern LaraInfo Lara;
 extern ItemInfo* LaraItem;
 extern CollisionInfo LaraCollision;

--- a/TombEngine/Game/Lara/lara.h
+++ b/TombEngine/Game/Lara/lara.h
@@ -84,9 +84,6 @@ constexpr auto WADE_DEPTH		   = STEPUP_HEIGHT;
 constexpr auto SWIM_DEPTH		   = CLICK(3) - 38;
 constexpr auto SLOPE_DIFFERENCE	   = 60;
 
-constexpr auto LARA_PUSHABLE_PUSH_BBOX_Z2 = 1108 - BLOCK(1);
-constexpr auto LARA_PUSHABLE_PULL_BBOX_Z2 = BLOCK(1) - 944;
-
 extern LaraInfo Lara;
 extern ItemInfo* LaraItem;
 extern CollisionInfo LaraCollision;

--- a/TombEngine/Game/animation.cpp
+++ b/TombEngine/Game/animation.cpp
@@ -398,44 +398,6 @@ bool GetStateDispatch(ItemInfo* item, const AnimData& anim)
 	return false;
 }
 
-AnimFrame* GetBestFrame(ItemInfo* item)
-{
-	int rate = 0;
-	AnimFrame* framePtr[2];
-	int frac = GetFrame(item, framePtr, rate);
-
-	if (frac <= (rate >> 1))
-		return framePtr[0];
-	else
-		return framePtr[1];
-}
-
-AnimFrame* GetFirstFrame(GAME_OBJECT_ID slot, int animNumber)
-{
-	return GetFrame(slot, animNumber, 0);
-}
-
-AnimFrame* GetLastFrame(GAME_OBJECT_ID slot, int animNumber)
-{
-	return GetFrame(slot, animNumber, INT_MAX);
-}
-
-AnimFrame* GetFrame(GAME_OBJECT_ID slot, int animNumber, int frameNumber)
-{
-	int animIndex = Objects[slot].animIndex + animNumber;
-	assertion(animIndex < g_Level.Anims.size(), "GetFrame: Attempt to access nonexistent animation.");
-
-	const auto& anim = g_Level.Anims[animIndex];
-
-	int frameCount = anim.frameEnd - anim.frameBase;
-	if (frameNumber > frameCount)
-		frameNumber = frameCount;
-
-	AnimFrame* result = &g_Level.Frames[anim.FramePtr];
-	result += (frameNumber / anim.Interpolation);
-	return result;
-}
-
 int GetFrame(ItemInfo* item, AnimFrame* outFramePtr[], int& outRate)
 {
 	int frame = item->Animation.FrameNumber;
@@ -443,7 +405,7 @@ int GetFrame(ItemInfo* item, AnimFrame* outFramePtr[], int& outRate)
 
 	outFramePtr[0] = outFramePtr[1] = &g_Level.Frames[anim.FramePtr];
 	int rate = outRate = anim.Interpolation & 0x00FF;
-	frame -= anim.frameBase; 
+	frame -= anim.frameBase;
 
 	int first = frame / rate;
 	int interpolation = frame % rate;
@@ -459,6 +421,44 @@ int GetFrame(ItemInfo* item, AnimFrame* outFramePtr[], int& outRate)
 		outRate = anim.frameEnd - (second - rate);
 
 	return interpolation;
+}
+
+AnimFrame* GetFrame(GAME_OBJECT_ID slot, int animNumber, int frameNumber)
+{
+	int animIndex = Objects[slot].animIndex + animNumber;
+	assertion(animIndex < g_Level.Anims.size(), "GetFrame() attempted to access nonexistent animation.");
+
+	const auto& anim = g_Level.Anims[animIndex];
+
+	int frameCount = anim.frameEnd - anim.frameBase;
+	if (frameNumber > frameCount)
+		frameNumber = frameCount;
+
+	auto* result = &g_Level.Frames[anim.FramePtr];
+	result += frameNumber / anim.Interpolation;
+	return result;
+}
+
+AnimFrame* GetFirstFrame(GAME_OBJECT_ID slot, int animNumber)
+{
+	return GetFrame(slot, animNumber, 0);
+}
+
+AnimFrame* GetLastFrame(GAME_OBJECT_ID slot, int animNumber)
+{
+	return GetFrame(slot, animNumber, INT_MAX);
+}
+
+AnimFrame* GetBestFrame(ItemInfo* item)
+{
+	int rate = 0;
+	AnimFrame* framePtr[2];
+	int frac = GetFrame(item, framePtr, rate);
+
+	if (frac <= (rate >> 1))
+		return framePtr[0];
+	else
+		return framePtr[1];
 }
 
 int GetCurrentRelativeFrameNumber(ItemInfo* item)

--- a/TombEngine/Game/animation.h
+++ b/TombEngine/Game/animation.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "Math/Math.h"
+#include "Objects/game_object_ids.h"
 
 using namespace TEN::Math;
 
@@ -95,6 +96,9 @@ int GetNextAnimState(ItemInfo* item);
 int GetNextAnimState(int objectID, int animNumber);
 bool GetStateDispatch(ItemInfo* item, const AnimData& anim);
 int GetFrame(ItemInfo* item, AnimFrame* outFramePtr[], int& outRate);
+AnimFrame* GetFrame(GAME_OBJECT_ID slot, int animNumber, int frameNumber);
+AnimFrame* GetFirstFrame(GAME_OBJECT_ID slot, int animNumber);
+AnimFrame* GetLastFrame(GAME_OBJECT_ID slot, int animNumber);
 AnimFrame* GetBestFrame(ItemInfo* item);
 
 void ClampRotation(Pose& outPose, short angle, short rotation); 

--- a/TombEngine/Game/animation.h
+++ b/TombEngine/Game/animation.h
@@ -95,6 +95,7 @@ int GetFrameCount(int animNumber);
 int GetNextAnimState(ItemInfo* item);
 int GetNextAnimState(int objectID, int animNumber);
 bool GetStateDispatch(ItemInfo* item, const AnimData& anim);
+
 int GetFrame(ItemInfo* item, AnimFrame* outFramePtr[], int& outRate);
 AnimFrame* GetFrame(GAME_OBJECT_ID slot, int animNumber, int frameNumber);
 AnimFrame* GetFirstFrame(GAME_OBJECT_ID slot, int animNumber);

--- a/TombEngine/Game/collision/collide_room.h
+++ b/TombEngine/Game/collision/collide_room.h
@@ -130,7 +130,7 @@ CollisionResult GetCollision(FloorInfo* floor, int x, int y, int z);
 
 void  GetCollisionInfo(CollisionInfo* coll, ItemInfo* item, const Vector3i& offset, bool resetRoom = false);
 void  GetCollisionInfo(CollisionInfo* coll, ItemInfo* item, bool resetRoom = false);
-int   GetQuadrant(short angle);
+int	  GetQuadrant(short angle);
 short GetNearestLedgeAngle(ItemInfo* item, CollisionInfo* coll, float& distance);
 
 FloorInfo* GetFloor(int x, int y, int z, short* roomNumber);

--- a/TombEngine/Game/control/box.cpp
+++ b/TombEngine/Game/control/box.cpp
@@ -2065,7 +2065,7 @@ void InitialiseItemBoxData()
 		auto* currentItem = &g_Level.Items[i];
 
 		if (currentItem->Active && currentItem->Data.is<PushableInfo>())
-			ClearMovableBlockSplitters(currentItem->Pose.Position.x, currentItem->Pose.Position.y, currentItem->Pose.Position.z, currentItem->RoomNumber);
+			ClearMovableBlockSplitters(currentItem->Pose.Position, currentItem->RoomNumber);
 	}
 
 	for (auto& room : g_Level.Rooms)

--- a/TombEngine/Game/control/control.h
+++ b/TombEngine/Game/control/control.h
@@ -25,7 +25,7 @@ enum class GameStatus
 	LevelComplete
 };
 
-enum HEADINGS
+enum CardinalDirection
 {
 	NORTH,
 	EAST,
@@ -33,7 +33,7 @@ enum HEADINGS
 	WEST
 };
 
-enum FADE_STATUS
+enum FadeStatus
 {
 	FADE_STATUS_NONE,
 	FADE_STATUS_FADEIN,

--- a/TombEngine/Game/itemdata/itemdata.h
+++ b/TombEngine/Game/itemdata/itemdata.h
@@ -27,13 +27,15 @@ template<class... Ts> visitor(Ts...)->visitor<Ts...>; // line not needed in C++2
 
 using namespace TEN::Entities::TR4;
 using namespace TEN::Entities::Creatures::TR5;
+using namespace TEN::Entities::Generic;
 using namespace TEN::Entities::Vehicles;
 
 struct ItemInfo;
 
 class ITEM_DATA
 {
-	std::variant<std::nullptr_t,
+	std::variant<
+		std::nullptr_t,
 		char,
 		short,
 		int,

--- a/TombEngine/Game/itemdata/itemdata.h
+++ b/TombEngine/Game/itemdata/itemdata.h
@@ -27,7 +27,6 @@ template<class... Ts> visitor(Ts...)->visitor<Ts...>; // line not needed in C++2
 
 using namespace TEN::Entities::TR4;
 using namespace TEN::Entities::Creatures::TR5;
-using namespace TEN::Entities::Generic;
 using namespace TEN::Entities::Vehicles;
 
 struct ItemInfo;

--- a/TombEngine/Game/itemdata/itemdata.h
+++ b/TombEngine/Game/itemdata/itemdata.h
@@ -7,6 +7,7 @@
 #include "Game/itemdata/creature_info.h"
 #include "Game/itemdata/door_data.h"
 #include "Game/Lara/lara_struct.h"
+#include "Math/Math.h"
 #include "Objects/TR2/Vehicles/skidoo_info.h"
 #include "Objects/TR2/Vehicles/speedboat_info.h"
 #include "Objects/TR3/Vehicles/big_gun_info.h"
@@ -20,13 +21,13 @@
 #include "Objects/TR4/Vehicles/motorbike_info.h"
 #include "Objects/TR5/Entity/tr5_laserhead_info.h"
 #include "Objects/TR5/Object/tr5_pushableblock_info.h"
-#include "Math/Math.h"
 
 template<class... Ts> struct visitor : Ts... { using Ts::operator()...; };
 template<class... Ts> visitor(Ts...)->visitor<Ts...>; // line not needed in C++20...
 
 using namespace TEN::Entities::TR4;
 using namespace TEN::Entities::Creatures::TR5;
+using namespace TEN::Entities::Generic;
 using namespace TEN::Entities::Vehicles;
 
 struct ItemInfo;

--- a/TombEngine/Objects/TR5/Object/tr5_pushableblock.cpp
+++ b/TombEngine/Objects/TR5/Object/tr5_pushableblock.cpp
@@ -1,20 +1,20 @@
 #include "framework.h"
 #include "Objects/TR5/Object/tr5_pushableblock.h"
 
-#include "Game/Lara/lara.h"
-#include "Game/Lara/lara_helpers.h"
 #include "Game/animation.h"
 #include "Game/items.h"
-#include "Game/collision/collide_room.h"
 #include "Game/collision/collide_item.h"
+#include "Game/collision/collide_room.h"
 #include "Game/collision/floordata.h"
-#include "Game/control/flipeffect.h"
+#include "Game/Lara/lara.h"
+#include "Game/Lara/lara_helpers.h"
 #include "Game/control/box.h"
-#include "Specific/level.h"
-#include "Specific/Input/Input.h"
-#include "Sound/sound.h"
-#include "Specific/setup.h"
+#include "Game/control/flipeffect.h"
 #include "Objects/TR5/Object/tr5_pushableblock_info.h"
+#include "Sound/sound.h"
+#include "Specific/Input/Input.h"
+#include "Specific/level.h"
+#include "Specific/setup.h"
 
 using namespace TEN::Floordata;
 using namespace TEN::Input;
@@ -44,7 +44,7 @@ void ClearMovableBlockSplitters(int x, int y, int z, short roomNumber)
 	if (floor->Box == NO_BOX)
 		return;
 
-	g_Level.Boxes[floor->Box].flags &= (~BLOCKED);
+	g_Level.Boxes[floor->Box].flags &= ~BLOCKED;
 	short height = g_Level.Boxes[floor->Box].height;
 	short baseRoomNumber = roomNumber;
 	
@@ -121,7 +121,9 @@ void InitialisePushableBlock(short itemNumber)
 		height = (OCB & 0x1F) * CLICK(1);
 	}
 	else
+	{
 		height = -GameBoundingBox(item).Y1;
+	}
 
 	pushable->height = height;
 

--- a/TombEngine/Objects/TR5/Object/tr5_pushableblock.cpp
+++ b/TombEngine/Objects/TR5/Object/tr5_pushableblock.cpp
@@ -20,6 +20,10 @@ using namespace TEN::Input;
 
 namespace TEN::Entities::Generic
 {
+	// TODO: Derive from anim data.
+	constexpr auto PUSHABLE_BOX_OFFSET_PUSH = 1108 - BLOCK(1);
+	constexpr auto PUSHABLE_BOX_OFFSET_PULL = BLOCK(1) - 944;
+
 	static auto PushableBlockPos = Vector3i::Zero;
 	ObjectCollisionBounds PushableBlockBounds = 
 	{
@@ -28,8 +32,8 @@ namespace TEN::Entities::Generic
 			-CLICK(0.25f), 0,
 			0, 0),
 		std::pair(
-			EulerAngles(ANGLE(-10.0f), ANGLE(-30.0f), ANGLE(-10.0f)),
-			EulerAngles(ANGLE(10.0f), ANGLE(30.0f), ANGLE(10.0f)))
+			EulerAngles(ANGLE(-10.0f), -LARA_GRAB_THRESHOLD, ANGLE(-10.0f)),
+			EulerAngles(ANGLE(10.0f), LARA_GRAB_THRESHOLD, ANGLE(10.0f)))
 	};
 
 	PushableInfo& GetPushableInfo(ItemInfo& item)
@@ -201,7 +205,7 @@ namespace TEN::Entities::Generic
 		switch (LaraItem->Animation.AnimNumber)
 		{
 		case LA_PUSHABLE_PUSH:
-			displaceBox -= LARA_PUSHABLE_PUSH_BBOX_Z2;
+			displaceBox -= PUSHABLE_BOX_OFFSET_PUSH;
 
 			if (LaraItem->Animation.FrameNumber == g_Level.Anims[LaraItem->Animation.AnimNumber].frameBase)
 			{
@@ -290,7 +294,7 @@ namespace TEN::Entities::Generic
 			break;
 
 		case LA_PUSHABLE_PULL:
-			displaceBox -= LARA_PUSHABLE_PULL_BBOX_Z2;
+			displaceBox -= PUSHABLE_BOX_OFFSET_PULL;
 
 			if (LaraItem->Animation.FrameNumber == g_Level.Anims[LaraItem->Animation.AnimNumber].frameBase)
 			{

--- a/TombEngine/Objects/TR5/Object/tr5_pushableblock.cpp
+++ b/TombEngine/Objects/TR5/Object/tr5_pushableblock.cpp
@@ -81,7 +81,7 @@ namespace TEN::Entities::Generic
 		*/
 		pushable.hasFloorCeiling = false;
 
-		int height;
+		int height = 0;
 		if (ocb & 0x40 && (ocb & 0x1F) >= 2)
 		{
 			pushable.hasFloorCeiling = true;
@@ -99,9 +99,9 @@ namespace TEN::Entities::Generic
 		FindStack(itemNumber);
 	}
 
-	void ClearMovableBlockSplitters(int x, int y, int z, short roomNumber)
+	void ClearMovableBlockSplitters(const Vector3i& pos, short roomNumber)
 	{
-		FloorInfo* floor = GetFloor(x, y, z, &roomNumber);
+		FloorInfo* floor = GetFloor(pos.x, pos.y, pos.z, &roomNumber);
 		if (floor->Box == NO_BOX)
 			return;
 
@@ -109,35 +109,35 @@ namespace TEN::Entities::Generic
 		int height = g_Level.Boxes[floor->Box].height;
 		int baseRoomNumber = roomNumber;
 	
-		floor = GetFloor(x + BLOCK(1), y, z, &roomNumber);
+		floor = GetFloor(pos.x + BLOCK(1), pos.y, pos.z, &roomNumber);
 		if (floor->Box != NO_BOX)
 		{
 			if (g_Level.Boxes[floor->Box].height == height && (g_Level.Boxes[floor->Box].flags & BLOCKABLE) && (g_Level.Boxes[floor->Box].flags & BLOCKED))
-				ClearMovableBlockSplitters(x + BLOCK(1), y, z, roomNumber);
+				ClearMovableBlockSplitters(Vector3i(pos.x + BLOCK(1), pos.y, pos.z), roomNumber);
 		}
 
 		roomNumber = baseRoomNumber;
-		floor = GetFloor(x - BLOCK(1), y, z, &roomNumber);
+		floor = GetFloor(pos.x - BLOCK(1), pos.y, pos.z, &roomNumber);
 		if (floor->Box != NO_BOX)
 		{
 			if (g_Level.Boxes[floor->Box].height == height && (g_Level.Boxes[floor->Box].flags & BLOCKABLE) && (g_Level.Boxes[floor->Box].flags & BLOCKED))
-				ClearMovableBlockSplitters(x - BLOCK(1), y, z, roomNumber);
+				ClearMovableBlockSplitters(Vector3i(pos.x - BLOCK(1), pos.y, pos.z), roomNumber);
 		}
 
 		roomNumber = baseRoomNumber;
-		floor = GetFloor(x, y, z + BLOCK(1), &roomNumber);
+		floor = GetFloor(pos.x, pos.y, pos.z + BLOCK(1), &roomNumber);
 		if (floor->Box != NO_BOX)
 		{
 			if (g_Level.Boxes[floor->Box].height == height && (g_Level.Boxes[floor->Box].flags & BLOCKABLE) && (g_Level.Boxes[floor->Box].flags & BLOCKED))
-				ClearMovableBlockSplitters(x, y, z + BLOCK(1), roomNumber);
+				ClearMovableBlockSplitters(Vector3i(pos.x, pos.y, pos.z + BLOCK(1)), roomNumber);
 		}
 
 		roomNumber = baseRoomNumber;
-		floor = GetFloor(x, y, z - BLOCK(1), &roomNumber);
+		floor = GetFloor(pos.x, pos.y, pos.z - BLOCK(1), &roomNumber);
 		if (floor->Box != NO_BOX)
 		{
 			if (g_Level.Boxes[floor->Box].height == height && (g_Level.Boxes[floor->Box].flags & BLOCKABLE) && (g_Level.Boxes[floor->Box].flags & BLOCKED))
-				ClearMovableBlockSplitters(x, y, z - BLOCK(1), roomNumber);
+				ClearMovableBlockSplitters(Vector3i(pos.x, pos.y, pos.z - BLOCK(1)), roomNumber);
 		}
 	}
 
@@ -1022,6 +1022,7 @@ namespace TEN::Entities::Generic
 			const auto height = item.Pose.Position.y - (item.TriggerFlags & 0x1F) * CLICK(1);
 			return std::optional{height};
 		}
+
 		return std::nullopt;
 	}
 
@@ -1030,9 +1031,9 @@ namespace TEN::Entities::Generic
 		auto& item = g_Level.Items[itemNumber];
 		const auto& pushable = GetPushableInfo(item);
 
-		auto bboxHeight = GetBridgeItemIntersect(itemNumber, x, y, z, true);
+		auto boxHeight = GetBridgeItemIntersect(itemNumber, x, y, z, true);
 
-		if (item.Status != ITEM_INVISIBLE && pushable.hasFloorCeiling && bboxHeight.has_value())
+		if (item.Status != ITEM_INVISIBLE && pushable.hasFloorCeiling && boxHeight.has_value())
 			return std::optional{item.Pose.Position.y};
 
 		return std::nullopt;

--- a/TombEngine/Objects/TR5/Object/tr5_pushableblock.cpp
+++ b/TombEngine/Objects/TR5/Object/tr5_pushableblock.cpp
@@ -21,10 +21,6 @@ using namespace TEN::Input;
 constexpr auto PUSHABLE_FALL_VELOCITY_MAX	 = BLOCK(1 / 8.0f);
 constexpr auto PUSHABLE_FALL_RUMBLE_VELOCITY = 96.0f;
 
-// TODO: Derive from anim data.
-constexpr auto PUSHABLE_BOX_OFFSET_PUSH = 1108 - BLOCK(1);
-constexpr auto PUSHABLE_BOX_OFFSET_PULL = BLOCK(1) - 944;
-
 static auto PushableBlockPos = Vector3i::Zero;
 ObjectCollisionBounds PushableBlockBounds = 
 {
@@ -202,13 +198,15 @@ void PushableBlockControl(short itemNumber)
 	}
 
 	// Move pushable based on player bounds.Z2.
+	int displaceDepth = 0;
 	int displaceBox = GameBoundingBox(LaraItem).Z2;
 	auto prevPos = item->Pose.Position;
 
 	switch (LaraItem->Animation.AnimNumber)
 	{
 	case LA_PUSHABLE_PUSH:
-		displaceBox -= PUSHABLE_BOX_OFFSET_PUSH;
+		displaceDepth = GetLastFrame(GAME_OBJECT_ID::ID_LARA, LaraItem->Animation.AnimNumber)->boundingBox.Z2;
+		displaceBox -= displaceDepth - BLOCK(1);
 
 		if (LaraItem->Animation.FrameNumber == g_Level.Anims[LaraItem->Animation.AnimNumber].frameBase)
 		{
@@ -298,7 +296,8 @@ void PushableBlockControl(short itemNumber)
 		break;
 
 	case LA_PUSHABLE_PULL:
-		displaceBox -= PUSHABLE_BOX_OFFSET_PULL;
+		displaceDepth = GetLastFrame(GAME_OBJECT_ID::ID_LARA, LaraItem->Animation.AnimNumber)->boundingBox.Z2;
+		displaceBox -= BLOCK(1) + displaceDepth;
 
 		if (LaraItem->Animation.FrameNumber == g_Level.Anims[LaraItem->Animation.AnimNumber].frameBase)
 		{

--- a/TombEngine/Objects/TR5/Object/tr5_pushableblock.cpp
+++ b/TombEngine/Objects/TR5/Object/tr5_pushableblock.cpp
@@ -991,8 +991,8 @@ bool CheckStackLimit(ItemInfo* item)
 {
 	auto* pushable = GetPushableInfo(item);
 
-	unsigned int limit = pushable->stackLimit;
-	unsigned int count = 1;
+	int limit = pushable->stackLimit;
+	int count = 1;
 
 	auto* stackItem = item;
 	while (stackItem->ItemFlags[1] != NO_ITEM)

--- a/TombEngine/Objects/TR5/Object/tr5_pushableblock.cpp
+++ b/TombEngine/Objects/TR5/Object/tr5_pushableblock.cpp
@@ -18,534 +18,526 @@
 using namespace TEN::Floordata;
 using namespace TEN::Input;
 
-constexpr auto PUSHABLE_FALL_VELOCITY_MAX	 = BLOCK(1 / 8.0f);
-constexpr auto PUSHABLE_FALL_RUMBLE_VELOCITY = 96.0f;
-
-static auto PushableBlockPos = Vector3i::Zero;
-ObjectCollisionBounds PushableBlockBounds = 
+namespace TEN::Entities::Generic
 {
-	GameBoundingBox(
-		0, 0,
-		-CLICK(0.25f), 0,
-		0, 0),
-	std::pair(
-		EulerAngles(ANGLE(-10.0f), -LARA_GRAB_THRESHOLD, ANGLE(-10.0f)),
-		EulerAngles(ANGLE(10.0f), LARA_GRAB_THRESHOLD, ANGLE(10.0f)))
-};
+	constexpr auto PUSHABLE_FALL_VELOCITY_MAX	 = BLOCK(1 / 8.0f);
+	constexpr auto PUSHABLE_FALL_RUMBLE_VELOCITY = 96.0f;
 
-PushableInfo* GetPushableInfo(ItemInfo* item)
-{
-	return (PushableInfo*)item->Data;
-}
-
-void InitialisePushableBlock(short itemNumber)
-{
-	auto* item = &g_Level.Items[itemNumber];
-	item->Data = PushableInfo();
-	auto* pushable = GetPushableInfo(item);
-
-	item->ItemFlags[1] = NO_ITEM; // NOTE: ItemFlags[1] stores linked index.
-
-	pushable->moveX = item->Pose.Position.x;
-	pushable->moveZ = item->Pose.Position.z;
-
-	// TODO: Attributes.
-	pushable->stackLimit = 3;
-	pushable->gravity = 8;
-	pushable->weight = 100;
-	pushable->loopSound = SFX_TR4_PUSHABLE_SOUND;
-	pushable->stopSound = SFX_TR4_PUSH_BLOCK_END;
-	pushable->fallSound = SFX_TR4_BOULDER_FALL;
-
-	// Read OCB flags.
-	int ocb = item->TriggerFlags;
-
-	pushable->canFall = ocb & 0x20;
-	pushable->disablePull = ocb & 0x80;
-	pushable->disablePush = ocb & 0x100;
-	pushable->disableW = pushable->disableE = ocb & 0x200;
-	pushable->disableN = pushable->disableS = ocb & 0x400;
-
-	// TODO: Must be a better way.
-	pushable->climb = 0;
-	/*
-	pushable->climb |= (OCB & 0x800) ? CLIMB_WEST : 0;
-	pushable->climb |= (OCB & 0x1000) ? CLIMB_NORTH : 0;
-	pushable->climb |= (OCB & 0x2000) ? CLIMB_EAST : 0;
-	pushable->climb |= (OCB & 0x4000) ? CLIMB_SOUTH : 0;
-	*/
-	pushable->hasFloorCeiling = false;
-
-	int height = 0;
-	if (ocb & 0x40 && (ocb & 0x1F) >= 2)
+	static auto PushableBlockPos = Vector3i::Zero;
+	ObjectCollisionBounds PushableBlockBounds = 
 	{
-		pushable->hasFloorCeiling = true;
-		TEN::Floordata::AddBridge(itemNumber);
-		height = (ocb & 0x1F) * CLICK(1);
-	}
-	else
+		GameBoundingBox(
+			0, 0,
+			-CLICK(0.25f), 0,
+			0, 0),
+		std::pair(
+			EulerAngles(ANGLE(-10.0f), -LARA_GRAB_THRESHOLD, ANGLE(-10.0f)),
+			EulerAngles(ANGLE(10.0f), LARA_GRAB_THRESHOLD, ANGLE(10.0f)))
+	};
+
+	PushableInfo* GetPushableInfo(ItemInfo* item)
 	{
-		height = -GameBoundingBox(item).Y1;
+		return (PushableInfo*)item->Data;
 	}
 
-	pushable->height = height;
-
-	// Check for stack formation.
-	FindStack(itemNumber);
-}
-
-void ClearMovableBlockSplitters(const Vector3i& pos, short roomNumber)
-{
-	FloorInfo* floor = GetFloor(pos.x, pos.y, pos.z, &roomNumber);
-	if (floor->Box == NO_BOX)
-		return;
-
-	g_Level.Boxes[floor->Box].flags &= ~BLOCKED;
-	int height = g_Level.Boxes[floor->Box].height;
-	int baseRoomNumber = roomNumber;
-	
-	floor = GetFloor(pos.x + BLOCK(1), pos.y, pos.z, &roomNumber);
-	if (floor->Box != NO_BOX)
+	void InitialisePushableBlock(short itemNumber)
 	{
-		if (g_Level.Boxes[floor->Box].height == height && (g_Level.Boxes[floor->Box].flags & BLOCKABLE) && (g_Level.Boxes[floor->Box].flags & BLOCKED))
-			ClearMovableBlockSplitters(Vector3i(pos.x + BLOCK(1), pos.y, pos.z), roomNumber);
-	}
+		auto* item = &g_Level.Items[itemNumber];
+		item->Data = PushableInfo();
+		auto* pushable = GetPushableInfo(item);
 
-	roomNumber = baseRoomNumber;
-	floor = GetFloor(pos.x - BLOCK(1), pos.y, pos.z, &roomNumber);
-	if (floor->Box != NO_BOX)
-	{
-		if (g_Level.Boxes[floor->Box].height == height && (g_Level.Boxes[floor->Box].flags & BLOCKABLE) && (g_Level.Boxes[floor->Box].flags & BLOCKED))
-			ClearMovableBlockSplitters(Vector3i(pos.x - BLOCK(1), pos.y, pos.z), roomNumber);
-	}
+		item->ItemFlags[1] = NO_ITEM; // NOTE: ItemFlags[1] stores linked index.
 
-	roomNumber = baseRoomNumber;
-	floor = GetFloor(pos.x, pos.y, pos.z + BLOCK(1), &roomNumber);
-	if (floor->Box != NO_BOX)
-	{
-		if (g_Level.Boxes[floor->Box].height == height && (g_Level.Boxes[floor->Box].flags & BLOCKABLE) && (g_Level.Boxes[floor->Box].flags & BLOCKED))
-			ClearMovableBlockSplitters(Vector3i(pos.x, pos.y, pos.z + BLOCK(1)), roomNumber);
-	}
+		pushable->moveX = item->Pose.Position.x;
+		pushable->moveZ = item->Pose.Position.z;
 
-	roomNumber = baseRoomNumber;
-	floor = GetFloor(pos.x, pos.y, pos.z - BLOCK(1), &roomNumber);
-	if (floor->Box != NO_BOX)
-	{
-		if (g_Level.Boxes[floor->Box].height == height && (g_Level.Boxes[floor->Box].flags & BLOCKABLE) && (g_Level.Boxes[floor->Box].flags & BLOCKED))
-			ClearMovableBlockSplitters(Vector3i(pos.x, pos.y, pos.z - BLOCK(1)), roomNumber);
-	}
-}
+		// TODO: Attributes.
+		pushable->stackLimit = 3;
+		pushable->gravity = 8;
+		pushable->weight = 100;
+		pushable->loopSound = SFX_TR4_PUSHABLE_SOUND;
+		pushable->stopSound = SFX_TR4_PUSH_BLOCK_END;
+		pushable->fallSound = SFX_TR4_BOULDER_FALL;
 
-void PushableBlockControl(short itemNumber)
-{
-	auto* item = &g_Level.Items[itemNumber];
-	auto* pushable = GetPushableInfo(item);
+		// Read OCB flags.
+		int ocb = item->TriggerFlags;
 
-	Lara.InteractedItem = itemNumber;
+		pushable->canFall = ocb & 0x20;
+		pushable->disablePull = ocb & 0x80;
+		pushable->disablePush = ocb & 0x100;
+		pushable->disableW = pushable->disableE = ocb & 0x200;
+		pushable->disableN = pushable->disableS = ocb & 0x400;
 
-	auto pos = Vector3i::Zero;
+		// TODO: Must be a better way.
+		pushable->climb = 0;
+		/*
+		pushable->climb |= (OCB & 0x800) ? CLIMB_WEST : 0;
+		pushable->climb |= (OCB & 0x1000) ? CLIMB_NORTH : 0;
+		pushable->climb |= (OCB & 0x2000) ? CLIMB_EAST : 0;
+		pushable->climb |= (OCB & 0x4000) ? CLIMB_SOUTH : 0;
+		*/
+		pushable->hasFloorCeiling = false;
 
-	int quadrant = GetQuadrant(LaraItem->Pose.Orientation.y);
-
-	int x, z;
-	int blockHeight = GetStackHeight(item);
-
-	// Control block falling.
-	if (item->Animation.IsAirborne)
-	{
-		int floorHeight = GetCollision(item->Pose.Position.x, item->Pose.Position.y + 10, item->Pose.Position.z, item->RoomNumber).Position.Floor;
-
-		if (item->Pose.Position.y < (floorHeight - item->Animation.Velocity.y))
+		int height = 0;
+		if (ocb & 0x40 && (ocb & 0x1F) >= 2)
 		{
-			if ((item->Animation.Velocity.y + pushable->gravity) < PUSHABLE_FALL_VELOCITY_MAX)
-				item->Animation.Velocity.y += pushable->gravity;
-			else
-				item->Animation.Velocity.y++;
-			item->Pose.Position.y += item->Animation.Velocity.y;
-
-			MoveStackY(itemNumber, item->Animation.Velocity.y);
+			pushable->hasFloorCeiling = true;
+			TEN::Floordata::AddBridge(itemNumber);
+			height = (ocb & 0x1F) * CLICK(1);
 		}
 		else
 		{
-			item->Animation.IsAirborne = false;
-			int relY = floorHeight - item->Pose.Position.y;
-			item->Pose.Position.y = floorHeight;
-
-			if (item->Animation.Velocity.y >= PUSHABLE_FALL_RUMBLE_VELOCITY)
-				FloorShake(item);
-
-			item->Animation.Velocity.y = 0.0f;
-			SoundEffect(pushable->fallSound, &item->Pose, SoundEnvironment::Always);
-
-			MoveStackY(itemNumber, relY);
-			AddBridgeStack(itemNumber);
-
-			// If fallen on top of existing pushable, don't test triggers.
-			if (FindStack(itemNumber) == NO_ITEM)
-				TestTriggers(item, true, item->Flags & IFLAG_ACTIVATION_MASK);
-			
-			RemoveActiveItem(itemNumber);
-			item->Status = ITEM_NOT_ACTIVE;
-
-			if (pushable->hasFloorCeiling)
-			{
-				//AlterFloorHeight(item, -((item->triggerFlags - 64) * 256));
-				AdjustStopperFlag(item, item->ItemFlags[0] + 0x8000, false);
-			}
+			height = -GameBoundingBox(item).Y1;
 		}
 
-		return;
+		pushable->height = height;
+
+		// Check for stack formation.
+		FindStack(itemNumber);
 	}
 
-	// Move pushable based on player bounds.Z2.
-	int displaceDepth = 0;
-	int displaceBox = GameBoundingBox(LaraItem).Z2;
-	auto prevPos = item->Pose.Position;
-
-	switch (LaraItem->Animation.AnimNumber)
+	void ClearMovableBlockSplitters(const Vector3i& pos, short roomNumber)
 	{
-	case LA_PUSHABLE_PUSH:
-		displaceDepth = GetLastFrame(GAME_OBJECT_ID::ID_LARA, LaraItem->Animation.AnimNumber)->boundingBox.Z2;
-		displaceBox -= displaceDepth - BLOCK(1);
-
-		if (LaraItem->Animation.FrameNumber == g_Level.Anims[LaraItem->Animation.AnimNumber].frameBase)
-		{
-			RemoveFromStack(itemNumber);
-			RemoveBridgeStack(itemNumber);
-		}
-
-		switch (quadrant) 
-		{
-		case NORTH:
-			z = pushable->moveZ + displaceBox;
-
-			if (abs(item->Pose.Position.z - z) < BLOCK(0.5f) && item->Pose.Position.z < z)
-				item->Pose.Position.z = z;
-				
-			break;
-
-		case EAST:
-			x = pushable->moveX + displaceBox;
-
-			if (abs(item->Pose.Position.x - x) < BLOCK(0.5f) && item->Pose.Position.x < x)
-				item->Pose.Position.x = x;
-
-			break;
-
-		case SOUTH:
-			z = pushable->moveZ - displaceBox;
-
-			if (abs(item->Pose.Position.z - z) < BLOCK(0.5f) && item->Pose.Position.z > z)
-				item->Pose.Position.z = z;
-				
-			break;
-
-		case WEST:
-			x = pushable->moveX - displaceBox;
-
-			if (abs(item->Pose.Position.x - x) < BLOCK(0.5f) && item->Pose.Position.x > x)
-				item->Pose.Position.x = x;
-				
-			break;
-
-		default:
-			break;
-		}
-
-		MoveStackXZ(itemNumber);
-
-		if (LaraItem->Animation.FrameNumber == g_Level.Anims[LaraItem->Animation.AnimNumber].frameEnd - 1)
-		{
-			// Check if pushable is about to fall.
-			if (pushable->canFall)
-			{
-				int floorHeight = GetCollision(item->Pose.Position.x, item->Pose.Position.y + 10, item->Pose.Position.z, item->RoomNumber).Position.Floor;
-				if (floorHeight > item->Pose.Position.y)
-				{
-					item->Pose.Position.x = item->Pose.Position.x & 0xFFFFFE00 | 0x200;
-					item->Pose.Position.z = item->Pose.Position.z & 0xFFFFFE00 | 0x200;
-					MoveStackXZ(itemNumber);
-					LaraItem->Animation.TargetState = LS_IDLE;
-
-					pushable->MovementState = PushableMovementState::None;
-
-					item->Animation.IsAirborne = true;
-					return;
-				}
-			}
-
-			if (IsHeld(In::Action))
-			{
-				if (!TestBlockPush(item, blockHeight, quadrant))
-				{
-					LaraItem->Animation.TargetState = LS_IDLE;
-				}
-				else
-				{
-					item->Pose.Position.x = pushable->moveX = item->Pose.Position.x & 0xFFFFFE00 | 0x200;
-					item->Pose.Position.z = pushable->moveZ = item->Pose.Position.z & 0xFFFFFE00 | 0x200;
-					TestTriggers(item, true, item->Flags & IFLAG_ACTIVATION_MASK);
-				}
-			}
-			else
-			{
-				LaraItem->Animation.TargetState = LS_IDLE;
-			}
-		}
-
-		break;
-
-	case LA_PUSHABLE_PULL:
-		displaceDepth = GetLastFrame(GAME_OBJECT_ID::ID_LARA, LaraItem->Animation.AnimNumber)->boundingBox.Z2;
-		displaceBox -= BLOCK(1) + displaceDepth;
-
-		if (LaraItem->Animation.FrameNumber == g_Level.Anims[LaraItem->Animation.AnimNumber].frameBase)
-		{
-			RemoveFromStack(itemNumber);
-			RemoveBridgeStack(itemNumber);
-		}
-
-		switch (quadrant)
-		{
-		case NORTH:
-			z = pushable->moveZ + displaceBox;
-			if (abs(item->Pose.Position.z - z) < BLOCK(0.5f) && item->Pose.Position.z > z)
-				item->Pose.Position.z = z;
-
-			break;
-
-		case EAST:
-			x = pushable->moveX + displaceBox;
-			if (abs(item->Pose.Position.x - x) < BLOCK(0.5f) && item->Pose.Position.x > x)
-				item->Pose.Position.x = x;
-
-			break;
-
-		case SOUTH:
-			z = pushable->moveZ - displaceBox;
-			if (abs(item->Pose.Position.z - z) < BLOCK(0.5f) && item->Pose.Position.z < z)
-				item->Pose.Position.z = z;
-
-			break;
-
-		case WEST:
-			x = pushable->moveX - displaceBox;
-			if (abs(item->Pose.Position.x - x) < BLOCK(0.5f) && item->Pose.Position.x < x)
-				item->Pose.Position.x = x;
-
-			break;
-
-		default:
-			break;
-		}
-
-		MoveStackXZ(itemNumber);
-
-		if (LaraItem->Animation.FrameNumber == g_Level.Anims[LaraItem->Animation.AnimNumber].frameEnd - 1)
-		{
-			if (IsHeld(In::Action))
-			{
-				if (!TestBlockPull(item, blockHeight, quadrant))
-				{
-					LaraItem->Animation.TargetState = LS_IDLE;
-				}
-				else
-				{
-					item->Pose.Position.x = pushable->moveX = item->Pose.Position.x & 0xFFFFFE00 | 0x200;
-					item->Pose.Position.z = pushable->moveZ = item->Pose.Position.z & 0xFFFFFE00 | 0x200;
-					TestTriggers(item, true, item->Flags & IFLAG_ACTIVATION_MASK);
-				}
-			}
-			else
-			{
-				LaraItem->Animation.TargetState = LS_IDLE;
-			}
-		}
-
-		break;
-
-	case LA_PUSHABLE_GRAB:
-	case LA_PUSHABLE_RELEASE:
-	case LA_PUSHABLE_PUSH_TO_STAND:
-	case LA_PUSHABLE_PULL_TO_STAND:
-		break;
-
-	default:
-		if (item->Status == ITEM_ACTIVE)
-		{
-			item->Pose.Position.x = item->Pose.Position.x & 0xFFFFFE00 | 0x200;
-			item->Pose.Position.z = item->Pose.Position.z & 0xFFFFFE00 | 0x200;
-
-			MoveStackXZ(itemNumber);
-			FindStack(itemNumber);
-			AddBridgeStack(itemNumber);
-
-			TestTriggers(item, true, item->Flags & IFLAG_ACTIVATION_MASK);
-
-			RemoveActiveItem(itemNumber);
-			item->Status = ITEM_NOT_ACTIVE;
-
-			if (pushable->hasFloorCeiling)
-			{
-				//AlterFloorHeight(item, -((item->triggerFlags - 64) * 256));
-				AdjustStopperFlag(item, item->ItemFlags[0] + 0x8000, false);
-			}
-		}
-
-		break;
-	}
-
-	// Set pushable movement state.
-	float distance = Vector3i::Distance(item->Pose.Position, prevPos);
-	if (distance > 0.0f)
-		PushLoop(item);
-	else
-		PushEnd(item);
-
-	// Do sound effects.
-	if (pushable->MovementState == PushableMovementState::Moving)
-	{
-		SoundEffect(pushable->loopSound, &item->Pose, SoundEnvironment::Always);
-	}
-	else if (pushable->MovementState == PushableMovementState::Stopping)
-	{
-		pushable->MovementState = PushableMovementState::None;
-		SoundEffect(pushable->stopSound, &item->Pose, SoundEnvironment::Always);
-	}
-}
-
-void PushableBlockCollision(short itemNumber, ItemInfo* laraItem, CollisionInfo* coll)
-{
-	auto* pushableItem = &g_Level.Items[itemNumber];
-	auto* pushable = GetPushableInfo(pushableItem);
-	auto* lara = GetLaraInfo(laraItem);
-
-	int blockHeight = GetStackHeight(pushableItem);
-	
-	if ((!IsHeld(In::Action) ||
-		laraItem->Animation.ActiveState != LS_IDLE ||
-		laraItem->Animation.AnimNumber != LA_STAND_IDLE ||
-		laraItem->Animation.IsAirborne ||
-		lara->Control.HandStatus != HandStatus::Free ||
-		pushableItem->Status == ITEM_INVISIBLE ||
-		pushableItem->TriggerFlags < 0) &&
-		(!lara->Control.IsMoving || lara->InteractedItem != itemNumber))
-	{
-		if (laraItem->Animation.ActiveState != LS_PUSHABLE_GRAB ||
-			!TestLastFrame(laraItem, LA_PUSHABLE_GRAB) ||
-			lara->NextCornerPos.Position.x != itemNumber)
-		{
-			if (!pushable->hasFloorCeiling)
-				ObjectCollision(itemNumber, laraItem, coll);
-
+		FloorInfo* floor = GetFloor(pos.x, pos.y, pos.z, &roomNumber);
+		if (floor->Box == NO_BOX)
 			return;
+
+		g_Level.Boxes[floor->Box].flags &= ~BLOCKED;
+		int height = g_Level.Boxes[floor->Box].height;
+		int baseRoomNumber = roomNumber;
+	
+		floor = GetFloor(pos.x + BLOCK(1), pos.y, pos.z, &roomNumber);
+		if (floor->Box != NO_BOX)
+		{
+			if (g_Level.Boxes[floor->Box].height == height && (g_Level.Boxes[floor->Box].flags & BLOCKABLE) && (g_Level.Boxes[floor->Box].flags & BLOCKED))
+				ClearMovableBlockSplitters(Vector3i(pos.x + BLOCK(1), pos.y, pos.z), roomNumber);
 		}
+
+		roomNumber = baseRoomNumber;
+		floor = GetFloor(pos.x - BLOCK(1), pos.y, pos.z, &roomNumber);
+		if (floor->Box != NO_BOX)
+		{
+			if (g_Level.Boxes[floor->Box].height == height && (g_Level.Boxes[floor->Box].flags & BLOCKABLE) && (g_Level.Boxes[floor->Box].flags & BLOCKED))
+				ClearMovableBlockSplitters(Vector3i(pos.x - BLOCK(1), pos.y, pos.z), roomNumber);
+		}
+
+		roomNumber = baseRoomNumber;
+		floor = GetFloor(pos.x, pos.y, pos.z + BLOCK(1), &roomNumber);
+		if (floor->Box != NO_BOX)
+		{
+			if (g_Level.Boxes[floor->Box].height == height && (g_Level.Boxes[floor->Box].flags & BLOCKABLE) && (g_Level.Boxes[floor->Box].flags & BLOCKED))
+				ClearMovableBlockSplitters(Vector3i(pos.x, pos.y, pos.z + BLOCK(1)), roomNumber);
+		}
+
+		roomNumber = baseRoomNumber;
+		floor = GetFloor(pos.x, pos.y, pos.z - BLOCK(1), &roomNumber);
+		if (floor->Box != NO_BOX)
+		{
+			if (g_Level.Boxes[floor->Box].height == height && (g_Level.Boxes[floor->Box].flags & BLOCKABLE) && (g_Level.Boxes[floor->Box].flags & BLOCKED))
+				ClearMovableBlockSplitters(Vector3i(pos.x, pos.y, pos.z - BLOCK(1)), roomNumber);
+		}
+	}
+
+	void PushableBlockControl(short itemNumber)
+	{
+		auto* item = &g_Level.Items[itemNumber];
+		auto* pushable = GetPushableInfo(item);
+
+		Lara.InteractedItem = itemNumber;
+
+		auto pos = Vector3i::Zero;
 
 		int quadrant = GetQuadrant(LaraItem->Pose.Orientation.y);
-		bool isQuadrantDisabled = false;
-		switch (quadrant)
+
+		int x, z;
+		int blockHeight = GetStackHeight(item);
+
+		// Control block falling.
+		if (item->Animation.IsAirborne)
 		{
-		case NORTH:
-			isQuadrantDisabled = pushable->disableN;
-			break;
+			int floorHeight = GetCollision(item->Pose.Position.x, item->Pose.Position.y + 10, item->Pose.Position.z, item->RoomNumber).Position.Floor;
 
-		case EAST:
-			isQuadrantDisabled = pushable->disableE;
-			break;
+			if (item->Pose.Position.y < (floorHeight - item->Animation.Velocity.y))
+			{
+				if ((item->Animation.Velocity.y + pushable->gravity) < PUSHABLE_FALL_VELOCITY_MAX)
+					item->Animation.Velocity.y += pushable->gravity;
+				else
+					item->Animation.Velocity.y++;
+				item->Pose.Position.y += item->Animation.Velocity.y;
 
-		case SOUTH:
-			isQuadrantDisabled = pushable->disableS;
-			break;
+				MoveStackY(itemNumber, item->Animation.Velocity.y);
+			}
+			else
+			{
+				item->Animation.IsAirborne = false;
+				int relY = floorHeight - item->Pose.Position.y;
+				item->Pose.Position.y = floorHeight;
 
-		case WEST:
-			isQuadrantDisabled = pushable->disableW;
-			break;
-		}
+				if (item->Animation.Velocity.y >= PUSHABLE_FALL_RUMBLE_VELOCITY)
+					FloorShake(item);
 
-		if (isQuadrantDisabled)
+				item->Animation.Velocity.y = 0.0f;
+				SoundEffect(pushable->fallSound, &item->Pose, SoundEnvironment::Always);
+
+				MoveStackY(itemNumber, relY);
+				AddBridgeStack(itemNumber);
+
+				// If fallen on top of existing pushable, don't test triggers.
+				if (FindStack(itemNumber) == NO_ITEM)
+					TestTriggers(item, true, item->Flags & IFLAG_ACTIVATION_MASK);
+			
+				RemoveActiveItem(itemNumber);
+				item->Status = ITEM_NOT_ACTIVE;
+
+				if (pushable->hasFloorCeiling)
+				{
+					//AlterFloorHeight(item, -((item->triggerFlags - 64) * 256));
+					AdjustStopperFlag(item, item->ItemFlags[0] + 0x8000, false);
+				}
+			}
+
 			return;
-
-		if (!CheckStackLimit(pushableItem))
-			return;
-
-		if (IsHeld(In::Forward))
-		{
-			if (!TestBlockPush(pushableItem, blockHeight, quadrant) || pushable->disablePush)
-				return;
-
-			laraItem->Animation.TargetState = LS_PUSHABLE_PUSH;
-		}
-		else if (IsHeld(In::Back))
-		{
-			if (!TestBlockPull(pushableItem, blockHeight, quadrant) || pushable->disablePull)
-				return;
-
-			laraItem->Animation.TargetState = LS_PUSHABLE_PULL;
-		}
-		else
-		{
-			return;
 		}
 
-		pushableItem->Status = ITEM_ACTIVE;
-		AddActiveItem(itemNumber);
-		ResetLaraFlex(laraItem);
-		
-		pushable->moveX = pushableItem->Pose.Position.x;
-		pushable->moveZ = pushableItem->Pose.Position.z;
+		// Move pushable based on player bounds.Z2.
+		int displaceDepth = 0;
+		int displaceBox = GameBoundingBox(LaraItem).Z2;
+		auto prevPos = item->Pose.Position;
 
-		if (pushable->hasFloorCeiling)
+		switch (LaraItem->Animation.AnimNumber)
 		{
-			//AlterFloorHeight(item, ((item->triggerFlags - 64) * 256));
-			AdjustStopperFlag(pushableItem, pushableItem->ItemFlags[0], false);
-		}
-	}
-	else
-	{
-		auto bounds = GameBoundingBox(pushableItem);
-		PushableBlockBounds.BoundingBox.X1 = (bounds.X1 / 2) - 100;
-		PushableBlockBounds.BoundingBox.X2 = (bounds.X2 / 2) + 100;
-		PushableBlockBounds.BoundingBox.Z1 = bounds.Z1 - 200;
-		PushableBlockBounds.BoundingBox.Z2 = 0;
+		case LA_PUSHABLE_PUSH:
+			displaceDepth = GetLastFrame(GAME_OBJECT_ID::ID_LARA, LaraItem->Animation.AnimNumber)->boundingBox.Z2;
+			displaceBox -= displaceDepth - BLOCK(1);
 
-		short yOrient = pushableItem->Pose.Orientation.y;
-		pushableItem->Pose.Orientation.y = GetQuadrant(laraItem->Pose.Orientation.y) * ANGLE(90.0f);
+			if (LaraItem->Animation.FrameNumber == g_Level.Anims[LaraItem->Animation.AnimNumber].frameBase)
+			{
+				RemoveFromStack(itemNumber);
+				RemoveBridgeStack(itemNumber);
+			}
 
-		if (TestLaraPosition(PushableBlockBounds, pushableItem, laraItem))
-		{
-			int quadrant = GetQuadrant(pushableItem->Pose.Orientation.y);
-			switch (quadrant)
+			switch (quadrant) 
 			{
 			case NORTH:
-			case SOUTH:
-				PushableBlockPos.z = bounds.Z1 - CLICK(0.4f);
+				z = pushable->moveZ + displaceBox;
+
+				if (abs(item->Pose.Position.z - z) < BLOCK(0.5f) && item->Pose.Position.z < z)
+					item->Pose.Position.z = z;
+				
 				break;
 
 			case EAST:
+				x = pushable->moveX + displaceBox;
+
+				if (abs(item->Pose.Position.x - x) < BLOCK(0.5f) && item->Pose.Position.x < x)
+					item->Pose.Position.x = x;
+
+				break;
+
+			case SOUTH:
+				z = pushable->moveZ - displaceBox;
+
+				if (abs(item->Pose.Position.z - z) < BLOCK(0.5f) && item->Pose.Position.z > z)
+					item->Pose.Position.z = z;
+				
+				break;
+
 			case WEST:
-				PushableBlockPos.z = bounds.X1 - CLICK(0.4f);
+				x = pushable->moveX - displaceBox;
+
+				if (abs(item->Pose.Position.x - x) < BLOCK(0.5f) && item->Pose.Position.x > x)
+					item->Pose.Position.x = x;
+				
 				break;
 
 			default:
 				break;
 			}
 
-			if (pushable->hasFloorCeiling)
-			{					
-				// NOTE: Not using auto align function because it interferes with vaulting.
+			MoveStackXZ(itemNumber);
 
-				SetAnimation(laraItem, LA_PUSHABLE_GRAB);
-				laraItem->Pose.Orientation = pushableItem->Pose.Orientation;
-				lara->Control.IsMoving = false;
-				lara->Control.HandStatus = HandStatus::Busy;
-				lara->NextCornerPos.Position.x = itemNumber;
-				pushableItem->Pose.Orientation.y = yOrient;
+			if (LaraItem->Animation.FrameNumber == g_Level.Anims[LaraItem->Animation.AnimNumber].frameEnd - 1)
+			{
+				// Check if pushable is about to fall.
+				if (pushable->canFall)
+				{
+					int floorHeight = GetCollision(item->Pose.Position.x, item->Pose.Position.y + 10, item->Pose.Position.z, item->RoomNumber).Position.Floor;
+					if (floorHeight > item->Pose.Position.y)
+					{
+						item->Pose.Position.x = item->Pose.Position.x & 0xFFFFFE00 | 0x200;
+						item->Pose.Position.z = item->Pose.Position.z & 0xFFFFFE00 | 0x200;
+						MoveStackXZ(itemNumber);
+						LaraItem->Animation.TargetState = LS_IDLE;
+
+						pushable->MovementState = PushableMovementState::None;
+
+						item->Animation.IsAirborne = true;
+						return;
+					}
+				}
+
+				if (IsHeld(In::Action))
+				{
+					if (!TestBlockPush(item, blockHeight, quadrant))
+					{
+						LaraItem->Animation.TargetState = LS_IDLE;
+					}
+					else
+					{
+						item->Pose.Position.x = pushable->moveX = item->Pose.Position.x & 0xFFFFFE00 | 0x200;
+						item->Pose.Position.z = pushable->moveZ = item->Pose.Position.z & 0xFFFFFE00 | 0x200;
+						TestTriggers(item, true, item->Flags & IFLAG_ACTIVATION_MASK);
+					}
+				}
+				else
+				{
+					LaraItem->Animation.TargetState = LS_IDLE;
+				}
+			}
+
+			break;
+
+		case LA_PUSHABLE_PULL:
+			displaceDepth = GetLastFrame(GAME_OBJECT_ID::ID_LARA, LaraItem->Animation.AnimNumber)->boundingBox.Z2;
+			displaceBox -= BLOCK(1) + displaceDepth;
+
+			if (LaraItem->Animation.FrameNumber == g_Level.Anims[LaraItem->Animation.AnimNumber].frameBase)
+			{
+				RemoveFromStack(itemNumber);
+				RemoveBridgeStack(itemNumber);
+			}
+
+			switch (quadrant)
+			{
+			case NORTH:
+				z = pushable->moveZ + displaceBox;
+				if (abs(item->Pose.Position.z - z) < BLOCK(0.5f) && item->Pose.Position.z > z)
+					item->Pose.Position.z = z;
+
+				break;
+
+			case EAST:
+				x = pushable->moveX + displaceBox;
+				if (abs(item->Pose.Position.x - x) < BLOCK(0.5f) && item->Pose.Position.x > x)
+					item->Pose.Position.x = x;
+
+				break;
+
+			case SOUTH:
+				z = pushable->moveZ - displaceBox;
+				if (abs(item->Pose.Position.z - z) < BLOCK(0.5f) && item->Pose.Position.z < z)
+					item->Pose.Position.z = z;
+
+				break;
+
+			case WEST:
+				x = pushable->moveX - displaceBox;
+				if (abs(item->Pose.Position.x - x) < BLOCK(0.5f) && item->Pose.Position.x < x)
+					item->Pose.Position.x = x;
+
+				break;
+
+			default:
+				break;
+			}
+
+			MoveStackXZ(itemNumber);
+
+			if (LaraItem->Animation.FrameNumber == g_Level.Anims[LaraItem->Animation.AnimNumber].frameEnd - 1)
+			{
+				if (IsHeld(In::Action))
+				{
+					if (!TestBlockPull(item, blockHeight, quadrant))
+					{
+						LaraItem->Animation.TargetState = LS_IDLE;
+					}
+					else
+					{
+						item->Pose.Position.x = pushable->moveX = item->Pose.Position.x & 0xFFFFFE00 | 0x200;
+						item->Pose.Position.z = pushable->moveZ = item->Pose.Position.z & 0xFFFFFE00 | 0x200;
+						TestTriggers(item, true, item->Flags & IFLAG_ACTIVATION_MASK);
+					}
+				}
+				else
+				{
+					LaraItem->Animation.TargetState = LS_IDLE;
+				}
+			}
+
+			break;
+
+		case LA_PUSHABLE_GRAB:
+		case LA_PUSHABLE_RELEASE:
+		case LA_PUSHABLE_PUSH_TO_STAND:
+		case LA_PUSHABLE_PULL_TO_STAND:
+			break;
+
+		default:
+			if (item->Status == ITEM_ACTIVE)
+			{
+				item->Pose.Position.x = item->Pose.Position.x & 0xFFFFFE00 | 0x200;
+				item->Pose.Position.z = item->Pose.Position.z & 0xFFFFFE00 | 0x200;
+
+				MoveStackXZ(itemNumber);
+				FindStack(itemNumber);
+				AddBridgeStack(itemNumber);
+
+				TestTriggers(item, true, item->Flags & IFLAG_ACTIVATION_MASK);
+
+				RemoveActiveItem(itemNumber);
+				item->Status = ITEM_NOT_ACTIVE;
+
+				if (pushable->hasFloorCeiling)
+				{
+					//AlterFloorHeight(item, -((item->triggerFlags - 64) * 256));
+					AdjustStopperFlag(item, item->ItemFlags[0] + 0x8000, false);
+				}
+			}
+
+			break;
+		}
+
+		// Set pushable movement state.
+		float distance = Vector3i::Distance(item->Pose.Position, prevPos);
+		if (distance > 0.0f)
+			PushLoop(item);
+		else
+			PushEnd(item);
+
+		// Do sound effects.
+		if (pushable->MovementState == PushableMovementState::Moving)
+		{
+			SoundEffect(pushable->loopSound, &item->Pose, SoundEnvironment::Always);
+		}
+		else if (pushable->MovementState == PushableMovementState::Stopping)
+		{
+			pushable->MovementState = PushableMovementState::None;
+			SoundEffect(pushable->stopSound, &item->Pose, SoundEnvironment::Always);
+		}
+	}
+
+	void PushableBlockCollision(short itemNumber, ItemInfo* laraItem, CollisionInfo* coll)
+	{
+		auto* pushableItem = &g_Level.Items[itemNumber];
+		auto* pushable = GetPushableInfo(pushableItem);
+		auto* lara = GetLaraInfo(laraItem);
+
+		int blockHeight = GetStackHeight(pushableItem);
+	
+		if ((!IsHeld(In::Action) ||
+			laraItem->Animation.ActiveState != LS_IDLE ||
+			laraItem->Animation.AnimNumber != LA_STAND_IDLE ||
+			laraItem->Animation.IsAirborne ||
+			lara->Control.HandStatus != HandStatus::Free ||
+			pushableItem->Status == ITEM_INVISIBLE ||
+			pushableItem->TriggerFlags < 0) &&
+			(!lara->Control.IsMoving || lara->InteractedItem != itemNumber))
+		{
+			if (laraItem->Animation.ActiveState != LS_PUSHABLE_GRAB ||
+				!TestLastFrame(laraItem, LA_PUSHABLE_GRAB) ||
+				lara->NextCornerPos.Position.x != itemNumber)
+			{
+				if (!pushable->hasFloorCeiling)
+					ObjectCollision(itemNumber, laraItem, coll);
+
+				return;
+			}
+
+			int quadrant = GetQuadrant(LaraItem->Pose.Orientation.y);
+			bool isQuadrantDisabled = false;
+			switch (quadrant)
+			{
+			case NORTH:
+				isQuadrantDisabled = pushable->disableN;
+				break;
+
+			case EAST:
+				isQuadrantDisabled = pushable->disableE;
+				break;
+
+			case SOUTH:
+				isQuadrantDisabled = pushable->disableS;
+				break;
+
+			case WEST:
+				isQuadrantDisabled = pushable->disableW;
+				break;
+			}
+
+			if (isQuadrantDisabled)
+				return;
+
+			if (!CheckStackLimit(pushableItem))
+				return;
+
+			if (IsHeld(In::Forward))
+			{
+				if (!TestBlockPush(pushableItem, blockHeight, quadrant) || pushable->disablePush)
+					return;
+
+				laraItem->Animation.TargetState = LS_PUSHABLE_PUSH;
+			}
+			else if (IsHeld(In::Back))
+			{
+				if (!TestBlockPull(pushableItem, blockHeight, quadrant) || pushable->disablePull)
+					return;
+
+				laraItem->Animation.TargetState = LS_PUSHABLE_PULL;
 			}
 			else
 			{
-				if (MoveLaraPosition(PushableBlockPos, pushableItem, laraItem))
+				return;
+			}
+
+			pushableItem->Status = ITEM_ACTIVE;
+			AddActiveItem(itemNumber);
+			ResetLaraFlex(laraItem);
+		
+			pushable->moveX = pushableItem->Pose.Position.x;
+			pushable->moveZ = pushableItem->Pose.Position.z;
+
+			if (pushable->hasFloorCeiling)
+			{
+				//AlterFloorHeight(item, ((item->triggerFlags - 64) * 256));
+				AdjustStopperFlag(pushableItem, pushableItem->ItemFlags[0], false);
+			}
+		}
+		else
+		{
+			auto bounds = GameBoundingBox(pushableItem);
+			PushableBlockBounds.BoundingBox.X1 = (bounds.X1 / 2) - 100;
+			PushableBlockBounds.BoundingBox.X2 = (bounds.X2 / 2) + 100;
+			PushableBlockBounds.BoundingBox.Z1 = bounds.Z1 - 200;
+			PushableBlockBounds.BoundingBox.Z2 = 0;
+
+			short yOrient = pushableItem->Pose.Orientation.y;
+			pushableItem->Pose.Orientation.y = GetQuadrant(laraItem->Pose.Orientation.y) * ANGLE(90.0f);
+
+			if (TestLaraPosition(PushableBlockBounds, pushableItem, laraItem))
+			{
+				int quadrant = GetQuadrant(pushableItem->Pose.Orientation.y);
+				switch (quadrant)
 				{
+				case NORTH:
+				case SOUTH:
+					PushableBlockPos.z = bounds.Z1 - CLICK(0.4f);
+					break;
+
+				case EAST:
+				case WEST:
+					PushableBlockPos.z = bounds.X1 - CLICK(0.4f);
+					break;
+
+				default:
+					break;
+				}
+
+				if (pushable->hasFloorCeiling)
+				{					
+					// NOTE: Not using auto align function because it interferes with vaulting.
+
 					SetAnimation(laraItem, LA_PUSHABLE_GRAB);
+					laraItem->Pose.Orientation = pushableItem->Pose.Orientation;
 					lara->Control.IsMoving = false;
 					lara->Control.HandStatus = HandStatus::Busy;
 					lara->NextCornerPos.Position.x = itemNumber;
@@ -553,511 +545,522 @@ void PushableBlockCollision(short itemNumber, ItemInfo* laraItem, CollisionInfo*
 				}
 				else
 				{
-					lara->InteractedItem = itemNumber;
-					pushableItem->Pose.Orientation.y = yOrient;
+					if (MoveLaraPosition(PushableBlockPos, pushableItem, laraItem))
+					{
+						SetAnimation(laraItem, LA_PUSHABLE_GRAB);
+						lara->Control.IsMoving = false;
+						lara->Control.HandStatus = HandStatus::Busy;
+						lara->NextCornerPos.Position.x = itemNumber;
+						pushableItem->Pose.Orientation.y = yOrient;
+					}
+					else
+					{
+						lara->InteractedItem = itemNumber;
+						pushableItem->Pose.Orientation.y = yOrient;
+					}
 				}
 			}
-		}
-		else
-		{
-			if (lara->Control.IsMoving && lara->InteractedItem == itemNumber)
+			else
 			{
-				lara->Control.IsMoving = false;
-				lara->Control.HandStatus = HandStatus::Free;
-			}
-
-			pushableItem->Pose.Orientation.y = yOrient;
-		}
-	}
-}
-
-void PushLoop(ItemInfo* item)
-{
-	auto* pushable = GetPushableInfo(item);
-
-	pushable->MovementState = PushableMovementState::Moving;
-}
-
-void PushEnd(ItemInfo* item)
-{
-	auto* pushable = GetPushableInfo(item);
-
-	if (pushable->MovementState == PushableMovementState::Moving)
-		pushable->MovementState = PushableMovementState::Stopping;
-}
-
-bool TestBlockMovable(ItemInfo* item, int blockHeight)
-{
-	RemoveBridge(item->Index);
-	auto pointColl = GetCollision(item);
-	AddBridge(item->Index);
-
-	if (pointColl.Block->IsWall(pointColl.Block->SectorPlane(item->Pose.Position.x, item->Pose.Position.z)))
-		return false;
-
-	if (pointColl.Position.Floor != item->Pose.Position.y)
-		return false;
-
-	return true;
-}
-
-bool TestBlockPush(ItemInfo* item, int blockHeight, int quadrant)
-{
-	if (!TestBlockMovable(item, blockHeight))
-		return false;
-
-	const auto& pushable = GetPushableInfo(item);
-
-	auto pos = item->Pose.Position;
-	switch (quadrant)
-	{
-	case NORTH:
-		pos.z += BLOCK(1);
-		break;
-
-	case EAST:
-		pos.x += BLOCK(1);
-		break;
-
-	case SOUTH:
-		pos.z -= BLOCK(1);
-		break;
-
-	case WEST:
-		pos.x -= BLOCK(1);
-		break;
-	}
-
-	auto pointColl = GetCollision(pos.x, pos.y - blockHeight, pos.z, item->RoomNumber);
-
-	auto* room = &g_Level.Rooms[pointColl.RoomNumber];
-	if (GetSector(room, pos.x - room->x, pos.z - room->z)->Stopper)
-		return false;
-
-	if (pointColl.Position.FloorSlope || pointColl.Position.DiagonalStep ||
-		pointColl.Block->FloorSlope(0) != Vector2::Zero || pointColl.Block->FloorSlope(1) != Vector2::Zero)
-		return false;
-
-	if (pushable->canFall)
-	{
-		if (pointColl.Position.Floor < pos.y)
-			return false;
-	}
-	else
-	{
-		if (pointColl.Position.Floor != pos.y)
-			return false;
-	}
-
-	int ceiling = pos.y - blockHeight + 100;
-
-	if (GetCollision(pos.x, ceiling, pos.z, item->RoomNumber).Position.Ceiling > ceiling)
-		return false;
-
-	auto prevPos = item->Pose.Position;
-	item->Pose.Position = pos;
-	GetCollidedObjects(item, BLOCK(0.25f), true, &CollidedItems[0], &CollidedMeshes[0], true);
-	item->Pose.Position = prevPos;
-
-	if (CollidedMeshes[0])
-		return false;
-
-	for (int i = 0; i < MAX_COLLIDED_OBJECTS; i++)
-	{
-		if (!CollidedItems[i])
-			break;
-
-		if (Objects[CollidedItems[i]->ObjectNumber].isPickup)
-			continue;
-
-		if (Objects[CollidedItems[i]->ObjectNumber].floor == nullptr)
-			return false;
-		
-		const auto& object = Objects[CollidedItems[i]->ObjectNumber];
-		int collidedIndex = CollidedItems[i] - g_Level.Items.data(); // Index of CollidedItems[i].
-
-		auto colPos = CollidedItems[i]->Pose.Position;
-
-		// Check if floor function returns nullopt.
-		if (object.floor(collidedIndex, colPos.x, colPos.y, colPos.z) == std::nullopt)
-			return false;
-	}
-
-	return true;
-}
-
-bool TestBlockPull(ItemInfo* item, int blockHeight, int quadrant)
-{
-	if (!TestBlockMovable(item, blockHeight))
-		return false;
-
-	auto offset = Vector3i::Zero;
-	switch (quadrant)
-	{
-	case NORTH:
-		offset = Vector3(0, 0, -BLOCK(1));
-		break;
-
-	case EAST:
-		offset = Vector3(-BLOCK(1), 0, 0);
-		break;
-
-	case SOUTH:
-		offset = Vector3(0, 0, BLOCK(1));
-		break;
-
-	case WEST:
-		offset = Vector3(BLOCK(1), 0, 0);
-		break;
-	}
-
-	auto pos = item->Pose.Position + offset;
-
-	short roomNumber = item->RoomNumber;
-	auto* room = &g_Level.Rooms[roomNumber];
-	if (GetSector(room, pos.x - room->x, pos.z - room->z)->Stopper)
-		return false;
-
-	auto probe = GetCollision(pos.x, pos.y - blockHeight, pos.z, item->RoomNumber);
-
-	if (probe.Position.Floor != pos.y)
-		return false;
-
-	if (probe.Position.FloorSlope || probe.Position.DiagonalStep ||
-		probe.Block->FloorSlope(0) != Vector2::Zero || probe.Block->FloorSlope(1) != Vector2::Zero)
-		return false;
-
-	int ceiling = pos.y - blockHeight + 100;
-
-	if (GetCollision(pos.x, ceiling, pos.z, item->RoomNumber).Position.Ceiling > ceiling)
-		return false;
-
-	int oldX = item->Pose.Position.x;
-	int oldZ = item->Pose.Position.z;
-	item->Pose.Position.x = pos.x;
-	item->Pose.Position.z = pos.z;
-	GetCollidedObjects(item, BLOCK(0.25f), true, &CollidedItems[0], &CollidedMeshes[0], true);
-	item->Pose.Position.x = oldX;
-	item->Pose.Position.z = oldZ;
-
-	if (CollidedMeshes[0])
-		return false;
-
-	for (int i = 0; i < MAX_COLLIDED_OBJECTS; i++)
-	{
-		if (!CollidedItems[i])
-			break;
-
-		if (Objects[CollidedItems[i]->ObjectNumber].isPickup)
-			continue;
-
-		if (Objects[CollidedItems[i]->ObjectNumber].floor == nullptr)
-			return false;
-		else
-		{
-			const auto& object = Objects[CollidedItems[i]->ObjectNumber];
-			int collidedIndex = CollidedItems[i] - g_Level.Items.data();
-
-			int xCol = CollidedItems[i]->Pose.Position.x;
-			int yCol = CollidedItems[i]->Pose.Position.y;
-			int zCol = CollidedItems[i]->Pose.Position.z;
-
-			if (object.floor(collidedIndex, xCol, yCol, zCol) == std::nullopt)
-				return false;
-		}
-	}
-
-	auto playerOffset = Vector3i::Zero;
-	switch (quadrant)
-	{
-	case NORTH:
-		playerOffset.z = GetBestFrame(LaraItem)->offsetZ;
-		break;
-
-	case EAST:
-		playerOffset.x = GetBestFrame(LaraItem)->offsetZ;
-		break;
-
-	case SOUTH:
-		playerOffset.z = -GetBestFrame(LaraItem)->offsetZ;
-		break;
-
-	case WEST:
-		playerOffset.x = -GetBestFrame(LaraItem)->offsetZ;
-		break;
-	}
-
-	pos = LaraItem->Pose.Position + offset + playerOffset;
-	roomNumber = LaraItem->RoomNumber;
-
-	probe = GetCollision(pos.x, pos.y - LARA_HEIGHT, pos.z, LaraItem->RoomNumber);
-
-	room = &g_Level.Rooms[roomNumber];
-	if (GetSector(room, pos.x - room->x, pos.z - room->z)->Stopper)
-		return false;
-
-	if (probe.Position.Floor != pos.y)
-		return false;
-
-	if (probe.Block->CeilingHeight(pos.x, pos.z) > pos.y - LARA_HEIGHT)
-		return false;
-
-	oldX = LaraItem->Pose.Position.x;
-	oldZ = LaraItem->Pose.Position.z;
-	LaraItem->Pose.Position.x = pos.x;
-	LaraItem->Pose.Position.z = pos.z;
-	GetCollidedObjects(LaraItem, LARA_RADIUS, true, &CollidedItems[0], &CollidedMeshes[0], true);
-	LaraItem->Pose.Position.x = oldX;
-	LaraItem->Pose.Position.z = oldZ;
-
-	if (CollidedMeshes[0])
-		return false;
-
-	for (int i = 0; i < MAX_COLLIDED_OBJECTS; i++)
-	{
-		if (!CollidedItems[i])
-			break;
-
-		if (CollidedItems[i] == item) // If collided item is not pushblock in which lara embedded
-			continue;
-
-		if (Objects[CollidedItems[i]->ObjectNumber].isPickup)
-			continue;
-
-		if (Objects[CollidedItems[i]->ObjectNumber].floor == nullptr)
-			return false;
-		else
-		{
-			const auto& object = Objects[CollidedItems[i]->ObjectNumber];
-			int collidedIndex = CollidedItems[i] - g_Level.Items.data();
-			int xCol = CollidedItems[i]->Pose.Position.x;
-			int yCol = CollidedItems[i]->Pose.Position.y;
-			int zCol = CollidedItems[i]->Pose.Position.z;
-
-			if (object.floor(collidedIndex, xCol, yCol, zCol) == std::nullopt)
-				return false;
-		}
-	}
-
-	return true;
-}
-
-void MoveStackXZ(short itemNumber)
-{
-	auto* item = &g_Level.Items[itemNumber];
-
-	short probedRoomNumber = GetCollision(item).RoomNumber;
-	if (probedRoomNumber != item->RoomNumber)
-		ItemNewRoom(itemNumber, probedRoomNumber);
-
-	auto* stackItem = item;
-	while (stackItem->ItemFlags[1] != NO_ITEM)
-	{
-		int stackIndex = stackItem->ItemFlags[1];
-		stackItem = &g_Level.Items[stackIndex];
-
-		stackItem->Pose.Position.x = item->Pose.Position.x;
-		stackItem->Pose.Position.z = item->Pose.Position.z;
-
-		probedRoomNumber = GetCollision(item).RoomNumber;
-		if (probedRoomNumber != stackItem->RoomNumber)
-			ItemNewRoom(stackIndex, probedRoomNumber);
-	}
-}
-
-void MoveStackY(short itemNumber, int y)
-{
-	auto* itemPtr = &g_Level.Items[itemNumber];
-
-	short probedRoomNumber = GetCollision(itemPtr).RoomNumber;
-	if (probedRoomNumber != itemPtr->RoomNumber)
-		ItemNewRoom(itemNumber, probedRoomNumber);
-
-	// Move stack together with bottom pushable->
-	while (itemPtr->ItemFlags[1] != NO_ITEM)
-	{
-		int stackIndex = itemPtr->ItemFlags[1];
-		itemPtr = &g_Level.Items[stackIndex];
-
-		itemPtr->Pose.Position.y += y;
-
-		probedRoomNumber = GetCollision(itemPtr).RoomNumber;
-		if (probedRoomNumber != itemPtr->RoomNumber)
-			ItemNewRoom(stackIndex, probedRoomNumber);
-	}
-}
-
-void AddBridgeStack(short itemNumber)
-{
-	auto* item = &g_Level.Items[itemNumber];
-	const auto* pushable = GetPushableInfo(item);
-
-	if (pushable->hasFloorCeiling)
-		TEN::Floordata::AddBridge(itemNumber);
-
-	int stackIndex = g_Level.Items[itemNumber].ItemFlags[1];
-	while (stackIndex != NO_ITEM)
-	{
-		if (pushable->hasFloorCeiling)
-			TEN::Floordata::AddBridge(stackIndex);
-
-		stackIndex = g_Level.Items[stackIndex].ItemFlags[1];
-	}
-}
-
-void RemoveBridgeStack(short itemNumber)
-{
-	auto* item = &g_Level.Items[itemNumber];
-	const auto* pushable = GetPushableInfo(item);
-
-	if (pushable->hasFloorCeiling)
-		TEN::Floordata::RemoveBridge(itemNumber);
-
-	int stackIndex = g_Level.Items[itemNumber].ItemFlags[1];
-	while (stackIndex != NO_ITEM)
-	{
-		if (pushable->hasFloorCeiling)
-			TEN::Floordata::RemoveBridge(stackIndex);
-
-		stackIndex = g_Level.Items[stackIndex].ItemFlags[1];
-	}
-}
-
-void RemoveFromStack(short itemNumber) 
-{
-	// Unlink pushable from stack.
-	for (int i = 0; i < g_Level.NumItems; i++)
-	{
-		if (i == itemNumber)
-			continue;
-
-		auto& itemBelow = g_Level.Items[i];
-
-		int objectNumber = itemBelow.ObjectNumber;
-		if (objectNumber >= ID_PUSHABLE_OBJECT1 && objectNumber <= ID_PUSHABLE_OBJECT10)
-		{
-			if (itemBelow.ItemFlags[1] == itemNumber)
-				itemBelow.ItemFlags[1] = NO_ITEM;
-		}
-	}
-}
-
-int FindStack(short itemNumber)
-{
-	int stackTop = NO_ITEM;		// Index of heighest pushable in stack.
-	int stackYmin = CLICK(256); // Set starting height.
-
-	// Check for pushable directly below current one.
-	for (int i = 0; i < g_Level.NumItems; i++)
-	{
-		if (i == itemNumber)
-			continue;
-
-		auto* itemBelow = &g_Level.Items[i];
-
-		int objectNumber = itemBelow->ObjectNumber;
-		if (objectNumber >= ID_PUSHABLE_OBJECT1 && objectNumber <= ID_PUSHABLE_OBJECT10)
-		{
-			const auto* item = &g_Level.Items[itemNumber];
-
-			auto pos = item->Pose.Position;
-
-			if (itemBelow->Pose.Position.x == pos.x &&
-				itemBelow->Pose.Position.z == pos.z)
-			{
-				// Set heighest pushable so far as top of stack.
-				int belowY = itemBelow->Pose.Position.y;
-				if (belowY > pos.y && belowY < stackYmin)
+				if (lara->Control.IsMoving && lara->InteractedItem == itemNumber)
 				{
-					stackTop = i;
-					stackYmin = itemBelow->Pose.Position.y;
+					lara->Control.IsMoving = false;
+					lara->Control.HandStatus = HandStatus::Free;
 				}
+
+				pushableItem->Pose.Orientation.y = yOrient;
 			}
 		}
 	}
 
-	if (stackTop != NO_ITEM)
-		g_Level.Items[stackTop].ItemFlags[1] = itemNumber;
-
-	return stackTop;
-}
-
-int GetStackHeight(ItemInfo* item)
-{
-	auto* pushable = GetPushableInfo(item);
-
-	int height = pushable->height;
-
-	auto* stackItem = item;
-	while (stackItem->ItemFlags[1] != NO_ITEM)
+	void PushLoop(ItemInfo* item)
 	{
-		stackItem = &g_Level.Items[stackItem->ItemFlags[1]];
-		height += pushable->height;
+		auto* pushable = GetPushableInfo(item);
+
+		pushable->MovementState = PushableMovementState::Moving;
 	}
 
-	return height;
-}
-
-bool CheckStackLimit(ItemInfo* item)
-{
-	auto* pushable = GetPushableInfo(item);
-
-	int limit = pushable->stackLimit;
-	int count = 1;
-
-	auto* stackItem = item;
-	while (stackItem->ItemFlags[1] != NO_ITEM)
+	void PushEnd(ItemInfo* item)
 	{
-		stackItem = &g_Level.Items[stackItem->ItemFlags[1]];
-		count++;
+		auto* pushable = GetPushableInfo(item);
 
-		if (count > limit)
+		if (pushable->MovementState == PushableMovementState::Moving)
+			pushable->MovementState = PushableMovementState::Stopping;
+	}
+
+	bool TestBlockMovable(ItemInfo* item, int blockHeight)
+	{
+		RemoveBridge(item->Index);
+		auto pointColl = GetCollision(item);
+		AddBridge(item->Index);
+
+		if (pointColl.Block->IsWall(pointColl.Block->SectorPlane(item->Pose.Position.x, item->Pose.Position.z)))
 			return false;
+
+		if (pointColl.Position.Floor != item->Pose.Position.y)
+			return false;
+
+		return true;
 	}
 
-	return true;
-}
-
-std::optional<int> PushableBlockFloor(short itemNumber, int x, int y, int z)
-{
-	auto* item = &g_Level.Items[itemNumber];
-	const auto* pushable = GetPushableInfo(item);
-
-	auto boxHeight = GetBridgeItemIntersect(itemNumber, x, y, z, false);
-	
-	if (item->Status != ITEM_INVISIBLE && pushable->hasFloorCeiling && boxHeight.has_value())
+	bool TestBlockPush(ItemInfo* item, int blockHeight, int quadrant)
 	{
-		const auto height = item->Pose.Position.y - (item->TriggerFlags & 0x1F) * CLICK(1);
-		return std::optional{height};
+		if (!TestBlockMovable(item, blockHeight))
+			return false;
+
+		const auto& pushable = GetPushableInfo(item);
+
+		auto pos = item->Pose.Position;
+		switch (quadrant)
+		{
+		case NORTH:
+			pos.z += BLOCK(1);
+			break;
+
+		case EAST:
+			pos.x += BLOCK(1);
+			break;
+
+		case SOUTH:
+			pos.z -= BLOCK(1);
+			break;
+
+		case WEST:
+			pos.x -= BLOCK(1);
+			break;
+		}
+
+		auto pointColl = GetCollision(pos.x, pos.y - blockHeight, pos.z, item->RoomNumber);
+
+		auto* room = &g_Level.Rooms[pointColl.RoomNumber];
+		if (GetSector(room, pos.x - room->x, pos.z - room->z)->Stopper)
+			return false;
+
+		if (pointColl.Position.FloorSlope || pointColl.Position.DiagonalStep ||
+			pointColl.Block->FloorSlope(0) != Vector2::Zero || pointColl.Block->FloorSlope(1) != Vector2::Zero)
+			return false;
+
+		if (pushable->canFall)
+		{
+			if (pointColl.Position.Floor < pos.y)
+				return false;
+		}
+		else
+		{
+			if (pointColl.Position.Floor != pos.y)
+				return false;
+		}
+
+		int ceiling = pos.y - blockHeight + 100;
+
+		if (GetCollision(pos.x, ceiling, pos.z, item->RoomNumber).Position.Ceiling > ceiling)
+			return false;
+
+		auto prevPos = item->Pose.Position;
+		item->Pose.Position = pos;
+		GetCollidedObjects(item, BLOCK(0.25f), true, &CollidedItems[0], &CollidedMeshes[0], true);
+		item->Pose.Position = prevPos;
+
+		if (CollidedMeshes[0])
+			return false;
+
+		for (int i = 0; i < MAX_COLLIDED_OBJECTS; i++)
+		{
+			if (!CollidedItems[i])
+				break;
+
+			if (Objects[CollidedItems[i]->ObjectNumber].isPickup)
+				continue;
+
+			if (Objects[CollidedItems[i]->ObjectNumber].floor == nullptr)
+				return false;
+		
+			const auto& object = Objects[CollidedItems[i]->ObjectNumber];
+			int collidedIndex = CollidedItems[i] - g_Level.Items.data(); // Index of CollidedItems[i].
+
+			auto colPos = CollidedItems[i]->Pose.Position;
+
+			// Check if floor function returns nullopt.
+			if (object.floor(collidedIndex, colPos.x, colPos.y, colPos.z) == std::nullopt)
+				return false;
+		}
+
+		return true;
 	}
 
-	return std::nullopt;
-}
+	bool TestBlockPull(ItemInfo* item, int blockHeight, int quadrant)
+	{
+		if (!TestBlockMovable(item, blockHeight))
+			return false;
 
-std::optional<int> PushableBlockCeiling(short itemNumber, int x, int y, int z)
-{
-	auto* item = &g_Level.Items[itemNumber];
-	const auto* pushable = GetPushableInfo(item);
+		auto offset = Vector3i::Zero;
+		switch (quadrant)
+		{
+		case NORTH:
+			offset = Vector3(0, 0, -BLOCK(1));
+			break;
 
-	auto boxHeight = GetBridgeItemIntersect(itemNumber, x, y, z, true);
+		case EAST:
+			offset = Vector3(-BLOCK(1), 0, 0);
+			break;
 
-	if (item->Status != ITEM_INVISIBLE && pushable->hasFloorCeiling && boxHeight.has_value())
-		return std::optional{item->Pose.Position.y};
+		case SOUTH:
+			offset = Vector3(0, 0, BLOCK(1));
+			break;
 
-	return std::nullopt;
-}
+		case WEST:
+			offset = Vector3(BLOCK(1), 0, 0);
+			break;
+		}
 
-int PushableBlockFloorBorder(short itemNumber)
-{
-	const auto* item = &g_Level.Items[itemNumber];
+		auto pos = item->Pose.Position + offset;
 
-	const auto height = item->Pose.Position.y - (item->TriggerFlags & 0x1F) * CLICK(1);
-	return height;
-}
+		short roomNumber = item->RoomNumber;
+		auto* room = &g_Level.Rooms[roomNumber];
+		if (GetSector(room, pos.x - room->x, pos.z - room->z)->Stopper)
+			return false;
 
-int PushableBlockCeilingBorder(short itemNumber)
-{
-	const auto* item = &g_Level.Items[itemNumber];
+		auto probe = GetCollision(pos.x, pos.y - blockHeight, pos.z, item->RoomNumber);
 
-	return item->Pose.Position.y;
+		if (probe.Position.Floor != pos.y)
+			return false;
+
+		if (probe.Position.FloorSlope || probe.Position.DiagonalStep ||
+			probe.Block->FloorSlope(0) != Vector2::Zero || probe.Block->FloorSlope(1) != Vector2::Zero)
+			return false;
+
+		int ceiling = pos.y - blockHeight + 100;
+
+		if (GetCollision(pos.x, ceiling, pos.z, item->RoomNumber).Position.Ceiling > ceiling)
+			return false;
+
+		int oldX = item->Pose.Position.x;
+		int oldZ = item->Pose.Position.z;
+		item->Pose.Position.x = pos.x;
+		item->Pose.Position.z = pos.z;
+		GetCollidedObjects(item, BLOCK(0.25f), true, &CollidedItems[0], &CollidedMeshes[0], true);
+		item->Pose.Position.x = oldX;
+		item->Pose.Position.z = oldZ;
+
+		if (CollidedMeshes[0])
+			return false;
+
+		for (int i = 0; i < MAX_COLLIDED_OBJECTS; i++)
+		{
+			if (!CollidedItems[i])
+				break;
+
+			if (Objects[CollidedItems[i]->ObjectNumber].isPickup)
+				continue;
+
+			if (Objects[CollidedItems[i]->ObjectNumber].floor == nullptr)
+				return false;
+			else
+			{
+				const auto& object = Objects[CollidedItems[i]->ObjectNumber];
+				int collidedIndex = CollidedItems[i] - g_Level.Items.data();
+
+				int xCol = CollidedItems[i]->Pose.Position.x;
+				int yCol = CollidedItems[i]->Pose.Position.y;
+				int zCol = CollidedItems[i]->Pose.Position.z;
+
+				if (object.floor(collidedIndex, xCol, yCol, zCol) == std::nullopt)
+					return false;
+			}
+		}
+
+		auto playerOffset = Vector3i::Zero;
+		switch (quadrant)
+		{
+		case NORTH:
+			playerOffset.z = GetBestFrame(LaraItem)->offsetZ;
+			break;
+
+		case EAST:
+			playerOffset.x = GetBestFrame(LaraItem)->offsetZ;
+			break;
+
+		case SOUTH:
+			playerOffset.z = -GetBestFrame(LaraItem)->offsetZ;
+			break;
+
+		case WEST:
+			playerOffset.x = -GetBestFrame(LaraItem)->offsetZ;
+			break;
+		}
+
+		pos = LaraItem->Pose.Position + offset + playerOffset;
+		roomNumber = LaraItem->RoomNumber;
+
+		probe = GetCollision(pos.x, pos.y - LARA_HEIGHT, pos.z, LaraItem->RoomNumber);
+
+		room = &g_Level.Rooms[roomNumber];
+		if (GetSector(room, pos.x - room->x, pos.z - room->z)->Stopper)
+			return false;
+
+		if (probe.Position.Floor != pos.y)
+			return false;
+
+		if (probe.Block->CeilingHeight(pos.x, pos.z) > pos.y - LARA_HEIGHT)
+			return false;
+
+		oldX = LaraItem->Pose.Position.x;
+		oldZ = LaraItem->Pose.Position.z;
+		LaraItem->Pose.Position.x = pos.x;
+		LaraItem->Pose.Position.z = pos.z;
+		GetCollidedObjects(LaraItem, LARA_RADIUS, true, &CollidedItems[0], &CollidedMeshes[0], true);
+		LaraItem->Pose.Position.x = oldX;
+		LaraItem->Pose.Position.z = oldZ;
+
+		if (CollidedMeshes[0])
+			return false;
+
+		for (int i = 0; i < MAX_COLLIDED_OBJECTS; i++)
+		{
+			if (!CollidedItems[i])
+				break;
+
+			if (CollidedItems[i] == item) // If collided item is not pushblock in which lara embedded
+				continue;
+
+			if (Objects[CollidedItems[i]->ObjectNumber].isPickup)
+				continue;
+
+			if (Objects[CollidedItems[i]->ObjectNumber].floor == nullptr)
+				return false;
+			else
+			{
+				const auto& object = Objects[CollidedItems[i]->ObjectNumber];
+				int collidedIndex = CollidedItems[i] - g_Level.Items.data();
+				int xCol = CollidedItems[i]->Pose.Position.x;
+				int yCol = CollidedItems[i]->Pose.Position.y;
+				int zCol = CollidedItems[i]->Pose.Position.z;
+
+				if (object.floor(collidedIndex, xCol, yCol, zCol) == std::nullopt)
+					return false;
+			}
+		}
+
+		return true;
+	}
+
+	void MoveStackXZ(short itemNumber)
+	{
+		auto* item = &g_Level.Items[itemNumber];
+
+		short probedRoomNumber = GetCollision(item).RoomNumber;
+		if (probedRoomNumber != item->RoomNumber)
+			ItemNewRoom(itemNumber, probedRoomNumber);
+
+		auto* stackItem = item;
+		while (stackItem->ItemFlags[1] != NO_ITEM)
+		{
+			int stackIndex = stackItem->ItemFlags[1];
+			stackItem = &g_Level.Items[stackIndex];
+
+			stackItem->Pose.Position.x = item->Pose.Position.x;
+			stackItem->Pose.Position.z = item->Pose.Position.z;
+
+			probedRoomNumber = GetCollision(item).RoomNumber;
+			if (probedRoomNumber != stackItem->RoomNumber)
+				ItemNewRoom(stackIndex, probedRoomNumber);
+		}
+	}
+
+	void MoveStackY(short itemNumber, int y)
+	{
+		auto* itemPtr = &g_Level.Items[itemNumber];
+
+		short probedRoomNumber = GetCollision(itemPtr).RoomNumber;
+		if (probedRoomNumber != itemPtr->RoomNumber)
+			ItemNewRoom(itemNumber, probedRoomNumber);
+
+		// Move stack together with bottom pushable->
+		while (itemPtr->ItemFlags[1] != NO_ITEM)
+		{
+			int stackIndex = itemPtr->ItemFlags[1];
+			itemPtr = &g_Level.Items[stackIndex];
+
+			itemPtr->Pose.Position.y += y;
+
+			probedRoomNumber = GetCollision(itemPtr).RoomNumber;
+			if (probedRoomNumber != itemPtr->RoomNumber)
+				ItemNewRoom(stackIndex, probedRoomNumber);
+		}
+	}
+
+	void AddBridgeStack(short itemNumber)
+	{
+		auto* item = &g_Level.Items[itemNumber];
+		const auto* pushable = GetPushableInfo(item);
+
+		if (pushable->hasFloorCeiling)
+			TEN::Floordata::AddBridge(itemNumber);
+
+		int stackIndex = g_Level.Items[itemNumber].ItemFlags[1];
+		while (stackIndex != NO_ITEM)
+		{
+			if (pushable->hasFloorCeiling)
+				TEN::Floordata::AddBridge(stackIndex);
+
+			stackIndex = g_Level.Items[stackIndex].ItemFlags[1];
+		}
+	}
+
+	void RemoveBridgeStack(short itemNumber)
+	{
+		auto* item = &g_Level.Items[itemNumber];
+		const auto* pushable = GetPushableInfo(item);
+
+		if (pushable->hasFloorCeiling)
+			TEN::Floordata::RemoveBridge(itemNumber);
+
+		int stackIndex = g_Level.Items[itemNumber].ItemFlags[1];
+		while (stackIndex != NO_ITEM)
+		{
+			if (pushable->hasFloorCeiling)
+				TEN::Floordata::RemoveBridge(stackIndex);
+
+			stackIndex = g_Level.Items[stackIndex].ItemFlags[1];
+		}
+	}
+
+	void RemoveFromStack(short itemNumber) 
+	{
+		// Unlink pushable from stack.
+		for (int i = 0; i < g_Level.NumItems; i++)
+		{
+			if (i == itemNumber)
+				continue;
+
+			auto& itemBelow = g_Level.Items[i];
+
+			int objectNumber = itemBelow.ObjectNumber;
+			if (objectNumber >= ID_PUSHABLE_OBJECT1 && objectNumber <= ID_PUSHABLE_OBJECT10)
+			{
+				if (itemBelow.ItemFlags[1] == itemNumber)
+					itemBelow.ItemFlags[1] = NO_ITEM;
+			}
+		}
+	}
+
+	int FindStack(short itemNumber)
+	{
+		int stackTop = NO_ITEM;		// Index of heighest pushable in stack.
+		int stackYmin = CLICK(256); // Set starting height.
+
+		// Check for pushable directly below current one.
+		for (int i = 0; i < g_Level.NumItems; i++)
+		{
+			if (i == itemNumber)
+				continue;
+
+			auto* itemBelow = &g_Level.Items[i];
+
+			int objectNumber = itemBelow->ObjectNumber;
+			if (objectNumber >= ID_PUSHABLE_OBJECT1 && objectNumber <= ID_PUSHABLE_OBJECT10)
+			{
+				const auto* item = &g_Level.Items[itemNumber];
+
+				auto pos = item->Pose.Position;
+
+				if (itemBelow->Pose.Position.x == pos.x &&
+					itemBelow->Pose.Position.z == pos.z)
+				{
+					// Set heighest pushable so far as top of stack.
+					int belowY = itemBelow->Pose.Position.y;
+					if (belowY > pos.y && belowY < stackYmin)
+					{
+						stackTop = i;
+						stackYmin = itemBelow->Pose.Position.y;
+					}
+				}
+			}
+		}
+
+		if (stackTop != NO_ITEM)
+			g_Level.Items[stackTop].ItemFlags[1] = itemNumber;
+
+		return stackTop;
+	}
+
+	int GetStackHeight(ItemInfo* item)
+	{
+		auto* pushable = GetPushableInfo(item);
+
+		int height = pushable->height;
+
+		auto* stackItem = item;
+		while (stackItem->ItemFlags[1] != NO_ITEM)
+		{
+			stackItem = &g_Level.Items[stackItem->ItemFlags[1]];
+			height += pushable->height;
+		}
+
+		return height;
+	}
+
+	bool CheckStackLimit(ItemInfo* item)
+	{
+		auto* pushable = GetPushableInfo(item);
+
+		int limit = pushable->stackLimit;
+		int count = 1;
+
+		auto* stackItem = item;
+		while (stackItem->ItemFlags[1] != NO_ITEM)
+		{
+			stackItem = &g_Level.Items[stackItem->ItemFlags[1]];
+			count++;
+
+			if (count > limit)
+				return false;
+		}
+
+		return true;
+	}
+
+	std::optional<int> PushableBlockFloor(short itemNumber, int x, int y, int z)
+	{
+		auto* item = &g_Level.Items[itemNumber];
+		const auto* pushable = GetPushableInfo(item);
+
+		auto boxHeight = GetBridgeItemIntersect(itemNumber, x, y, z, false);
+	
+		if (item->Status != ITEM_INVISIBLE && pushable->hasFloorCeiling && boxHeight.has_value())
+		{
+			const auto height = item->Pose.Position.y - (item->TriggerFlags & 0x1F) * CLICK(1);
+			return std::optional{height};
+		}
+
+		return std::nullopt;
+	}
+
+	std::optional<int> PushableBlockCeiling(short itemNumber, int x, int y, int z)
+	{
+		auto* item = &g_Level.Items[itemNumber];
+		const auto* pushable = GetPushableInfo(item);
+
+		auto boxHeight = GetBridgeItemIntersect(itemNumber, x, y, z, true);
+
+		if (item->Status != ITEM_INVISIBLE && pushable->hasFloorCeiling && boxHeight.has_value())
+			return std::optional{item->Pose.Position.y};
+
+		return std::nullopt;
+	}
+
+	int PushableBlockFloorBorder(short itemNumber)
+	{
+		const auto* item = &g_Level.Items[itemNumber];
+
+		const auto height = item->Pose.Position.y - (item->TriggerFlags & 0x1F) * CLICK(1);
+		return height;
+	}
+
+	int PushableBlockCeilingBorder(short itemNumber)
+	{
+		const auto* item = &g_Level.Items[itemNumber];
+
+		return item->Pose.Position.y;
+	}
 }

--- a/TombEngine/Objects/TR5/Object/tr5_pushableblock.cpp
+++ b/TombEngine/Objects/TR5/Object/tr5_pushableblock.cpp
@@ -199,7 +199,7 @@ void PushableBlockControl(short itemNumber)
 	switch (LaraItem->Animation.AnimNumber)
 	{
 	case LA_PUSHABLE_PUSH:
-		displaceBox -= CLICK(0.4f);
+		displaceBox -= LARA_PUSHABLE_PUSH_BBOX_Z2;
 
 		if (LaraItem->Animation.FrameNumber == g_Level.Anims[LaraItem->Animation.AnimNumber].frameBase)
 		{
@@ -286,7 +286,7 @@ void PushableBlockControl(short itemNumber)
 		break;
 
 	case LA_PUSHABLE_PULL:
-		displaceBox -= CLICK(0.2f);
+		displaceBox -= LARA_PUSHABLE_PULL_BBOX_Z2;
 
 		if (LaraItem->Animation.FrameNumber == g_Level.Anims[LaraItem->Animation.AnimNumber].frameBase)
 		{

--- a/TombEngine/Objects/TR5/Object/tr5_pushableblock.cpp
+++ b/TombEngine/Objects/TR5/Object/tr5_pushableblock.cpp
@@ -10,7 +10,6 @@
 #include "Game/Lara/lara_helpers.h"
 #include "Game/control/box.h"
 #include "Game/control/flipeffect.h"
-#include "Objects/TR5/Object/tr5_pushableblock_info.h"
 #include "Sound/sound.h"
 #include "Specific/Input/Input.h"
 #include "Specific/level.h"
@@ -19,515 +18,503 @@
 using namespace TEN::Floordata;
 using namespace TEN::Input;
 
-enum class PushableMovementState
+namespace TEN::Entities::Generic
 {
-	None,
-	Moving,
-	Stopping
-};
-
-static auto PushableBlockPos = Vector3i::Zero;
-ObjectCollisionBounds PushableBlockBounds = 
-{
-	GameBoundingBox(
-		0, 0,
-		-CLICK(0.25f), 0,
-		0, 0),
-	std::pair(
-		EulerAngles(ANGLE(-10.0f), ANGLE(-30.0f), ANGLE(-10.0f)),
-		EulerAngles(ANGLE(10.0f), ANGLE(30.0f), ANGLE(10.0f)))
-};
-
-void ClearMovableBlockSplitters(int x, int y, int z, short roomNumber)
-{
-	FloorInfo* floor = GetFloor(x, y, z, &roomNumber);
-	if (floor->Box == NO_BOX)
-		return;
-
-	g_Level.Boxes[floor->Box].flags &= ~BLOCKED;
-	short height = g_Level.Boxes[floor->Box].height;
-	short baseRoomNumber = roomNumber;
-	
-	floor = GetFloor(x + BLOCK(1), y, z, &roomNumber);
-	if (floor->Box != NO_BOX)
+	static auto PushableBlockPos = Vector3i::Zero;
+	ObjectCollisionBounds PushableBlockBounds = 
 	{
-		if (g_Level.Boxes[floor->Box].height == height && (g_Level.Boxes[floor->Box].flags & BLOCKABLE) && (g_Level.Boxes[floor->Box].flags & BLOCKED))
-			ClearMovableBlockSplitters(x + BLOCK(1), y, z, roomNumber);
+		GameBoundingBox(
+			0, 0,
+			-CLICK(0.25f), 0,
+			0, 0),
+		std::pair(
+			EulerAngles(ANGLE(-10.0f), ANGLE(-30.0f), ANGLE(-10.0f)),
+			EulerAngles(ANGLE(10.0f), ANGLE(30.0f), ANGLE(10.0f)))
+	};
+
+	PushableInfo& GetPushableInfo(ItemInfo& item)
+	{
+		return (PushableInfo&)item.Data;
 	}
 
-	roomNumber = baseRoomNumber;
-	floor = GetFloor(x - BLOCK(1), y, z, &roomNumber);
-	if (floor->Box != NO_BOX)
+	void InitialisePushableBlock(short itemNumber)
 	{
-		if (g_Level.Boxes[floor->Box].height == height && (g_Level.Boxes[floor->Box].flags & BLOCKABLE) && (g_Level.Boxes[floor->Box].flags & BLOCKED))
-			ClearMovableBlockSplitters(x - BLOCK(1), y, z, roomNumber);
-	}
+		auto* item = &g_Level.Items[itemNumber];
+		item->ItemFlags[1] = NO_ITEM; // need to use itemFlags[1] to hold linked index for now
 
-	roomNumber = baseRoomNumber;
-	floor = GetFloor(x, y, z + BLOCK(1), &roomNumber);
-	if (floor->Box != NO_BOX)
-	{
-		if (g_Level.Boxes[floor->Box].height == height && (g_Level.Boxes[floor->Box].flags & BLOCKABLE) && (g_Level.Boxes[floor->Box].flags & BLOCKED))
-			ClearMovableBlockSplitters(x, y, z + BLOCK(1), roomNumber);
-	}
+		// allocate new pushable info
+		item->Data = PushableInfo();
+		auto* pushable = (PushableInfo*)item->Data;
 
-	roomNumber = baseRoomNumber;
-	floor = GetFloor(x, y, z - BLOCK(1), &roomNumber);
-	if (floor->Box != NO_BOX)
-	{
-		if (g_Level.Boxes[floor->Box].height == height && (g_Level.Boxes[floor->Box].flags & BLOCKABLE) && (g_Level.Boxes[floor->Box].flags & BLOCKED))
-			ClearMovableBlockSplitters(x, y, z - BLOCK(1), roomNumber);
-	}
-}
+		pushable->stackLimit = 3; // LUA
+		pushable->gravity = 8; // LUA
+		pushable->weight = 100; // LUA
+		pushable->moveX = item->Pose.Position.x;
+		pushable->moveZ = item->Pose.Position.z;
 
-void InitialisePushableBlock(short itemNumber)
-{
-	auto* item = &g_Level.Items[itemNumber];
-	item->ItemFlags[1] = NO_ITEM; // need to use itemFlags[1] to hold linked index for now
-	
-	// allocate new pushable info
-	item->Data = PushableInfo();
-	auto* pushable = (PushableInfo*)item->Data;
-	
-	pushable->stackLimit = 3; // LUA
-	pushable->gravity = 8; // LUA
-	pushable->weight = 100; // LUA
-	pushable->moveX = item->Pose.Position.x;
-	pushable->moveZ = item->Pose.Position.z;
+		// read flags from OCB
+		int OCB = item->TriggerFlags;
 
-	// read flags from OCB
-	int OCB = item->TriggerFlags;
+		pushable->canFall = OCB & 0x20;
+		pushable->disablePull = OCB & 0x80;
+		pushable->disablePush = OCB & 0x100;
+		pushable->disableW = pushable->disableE = OCB & 0x200;
+		pushable->disableN = pushable->disableS = OCB & 0x400;
 
-	pushable->canFall = OCB & 0x20;
-	pushable->disablePull = OCB & 0x80;
-	pushable->disablePush = OCB & 0x100;
-	pushable->disableW = pushable->disableE = OCB & 0x200;
-	pushable->disableN = pushable->disableS = OCB & 0x400;
-	
-	pushable->climb = 0; // maybe there will be better way to handle this than OCBs?
-	/*
-	pushable->climb |= (OCB & 0x800) ? CLIMB_WEST : 0;
-	pushable->climb |= (OCB & 0x1000) ? CLIMB_NORTH : 0;
-	pushable->climb |= (OCB & 0x2000) ? CLIMB_EAST : 0;
-	pushable->climb |= (OCB & 0x4000) ? CLIMB_SOUTH : 0;
-	*/
-	pushable->hasFloorCeiling = false;
+		pushable->climb = 0; // maybe there will be better way to handle this than OCBs?
+		/*
+		pushable->climb |= (OCB & 0x800) ? CLIMB_WEST : 0;
+		pushable->climb |= (OCB & 0x1000) ? CLIMB_NORTH : 0;
+		pushable->climb |= (OCB & 0x2000) ? CLIMB_EAST : 0;
+		pushable->climb |= (OCB & 0x4000) ? CLIMB_SOUTH : 0;
+		*/
+		pushable->hasFloorCeiling = false;
 
-	int height;
-	if (OCB & 0x40 && (OCB & 0x1F) >= 2)
-	{
-		pushable->hasFloorCeiling = true;
-		TEN::Floordata::AddBridge(itemNumber);
-		height = (OCB & 0x1F) * CLICK(1);
-	}
-	else
-	{
-		height = -GameBoundingBox(item).Y1;
-	}
-
-	pushable->height = height;
-
-	// TODO: Attributes.
-	pushable->loopSound = SFX_TR4_PUSHABLE_SOUND;
-	pushable->stopSound = SFX_TR4_PUSH_BLOCK_END;
-	pushable->fallSound = SFX_TR4_BOULDER_FALL;
-
-	FindStack(itemNumber); // Check for stack formation when pushables are initialized.
-}
-
-void PushableBlockControl(short itemNumber)
-{
-	auto* item = &g_Level.Items[itemNumber];
-	auto* pushable = (PushableInfo*)item->Data;
-
-	Lara.InteractedItem = itemNumber;
-
-	auto pos = Vector3i::Zero;
-
-	short quadrant = (unsigned short)(LaraItem->Pose.Orientation.y + ANGLE(45.0f)) / ANGLE(90.0f);
-
-	int x, z;
-	int blockHeight = GetStackHeight(item);
-
-	// Control block falling.
-	if (item->Animation.IsAirborne)
-	{
-		int floorHeight = GetCollision(item->Pose.Position.x, item->Pose.Position.y + 10, item->Pose.Position.z, item->RoomNumber).Position.Floor;
-
-		if (item->Pose.Position.y < (floorHeight - item->Animation.Velocity.y))
+		int height;
+		if (OCB & 0x40 && (OCB & 0x1F) >= 2)
 		{
-			if ((item->Animation.Velocity.y + pushable->gravity) < 128)
-				item->Animation.Velocity.y += pushable->gravity;
-			else
-				item->Animation.Velocity.y++;
-			item->Pose.Position.y += item->Animation.Velocity.y;
-
-			MoveStackY(itemNumber, item->Animation.Velocity.y);
+			pushable->hasFloorCeiling = true;
+			TEN::Floordata::AddBridge(itemNumber);
+			height = (OCB & 0x1F) * CLICK(1);
 		}
 		else
 		{
-			item->Animation.IsAirborne = false;
-			int relY = floorHeight - item->Pose.Position.y;
-			item->Pose.Position.y = floorHeight;
-
-			if (item->Animation.Velocity.y >= 96)
-				FloorShake(item);
-
-			item->Animation.Velocity.y = 0;
-			SoundEffect(pushable->fallSound, &item->Pose, SoundEnvironment::Always);
-
-			MoveStackY(itemNumber, relY);
-			AddBridgeStack(itemNumber);
-
-			if (FindStack(itemNumber) == NO_ITEM) // if fallen on some existing pushables, don't test triggers
-				TestTriggers(item, true, item->Flags & IFLAG_ACTIVATION_MASK);
-			
-			RemoveActiveItem(itemNumber);
-			item->Status = ITEM_NOT_ACTIVE;
-
-			if (pushable->hasFloorCeiling)
-			{
-				//AlterFloorHeight(item, -((item->triggerFlags - 64) * 256));
-				AdjustStopperFlag(item, item->ItemFlags[0] + 0x8000, false);
-			}
+			height = -GameBoundingBox(item).Y1;
 		}
 
-		return;
+		pushable->height = height;
+
+		// TODO: Attributes.
+		pushable->loopSound = SFX_TR4_PUSHABLE_SOUND;
+		pushable->stopSound = SFX_TR4_PUSH_BLOCK_END;
+		pushable->fallSound = SFX_TR4_BOULDER_FALL;
+
+		FindStack(itemNumber); // Check for stack formation when pushables are initialized.
 	}
 
-	int displaceBox = GameBoundingBox(LaraItem).Z2; // Move pushable based on bbox->Z2 of Lara
-	auto prevPos = item->Pose.Position;
-
-	switch (LaraItem->Animation.AnimNumber)
+	void ClearMovableBlockSplitters(int x, int y, int z, short roomNumber)
 	{
-	case LA_PUSHABLE_PUSH:
-		displaceBox -= LARA_PUSHABLE_PUSH_BBOX_Z2;
+		FloorInfo* floor = GetFloor(x, y, z, &roomNumber);
+		if (floor->Box == NO_BOX)
+			return;
 
-		if (LaraItem->Animation.FrameNumber == g_Level.Anims[LaraItem->Animation.AnimNumber].frameBase)
+		g_Level.Boxes[floor->Box].flags &= ~BLOCKED;
+		int height = g_Level.Boxes[floor->Box].height;
+		int baseRoomNumber = roomNumber;
+	
+		floor = GetFloor(x + BLOCK(1), y, z, &roomNumber);
+		if (floor->Box != NO_BOX)
 		{
-			RemoveFromStack(itemNumber);
-			RemoveBridgeStack(itemNumber);
+			if (g_Level.Boxes[floor->Box].height == height && (g_Level.Boxes[floor->Box].flags & BLOCKABLE) && (g_Level.Boxes[floor->Box].flags & BLOCKED))
+				ClearMovableBlockSplitters(x + BLOCK(1), y, z, roomNumber);
 		}
 
-		switch (quadrant) 
+		roomNumber = baseRoomNumber;
+		floor = GetFloor(x - BLOCK(1), y, z, &roomNumber);
+		if (floor->Box != NO_BOX)
 		{
-		case NORTH:
-			z = pushable->moveZ + displaceBox;
-
-			if (abs(item->Pose.Position.z - z) < BLOCK(0.5f) && item->Pose.Position.z < z)
-				item->Pose.Position.z = z;
-				
-			break;
-
-		case EAST:
-			x = pushable->moveX + displaceBox;
-
-			if (abs(item->Pose.Position.x - x) < BLOCK(0.5f) && item->Pose.Position.x < x)
-				item->Pose.Position.x = x;
-
-			break;
-
-		case SOUTH:
-			z = pushable->moveZ - displaceBox;
-
-			if (abs(item->Pose.Position.z - z) < BLOCK(0.5f) && item->Pose.Position.z > z)
-				item->Pose.Position.z = z;
-				
-			break;
-
-		case WEST:
-			x = pushable->moveX - displaceBox;
-
-			if (abs(item->Pose.Position.x - x) < BLOCK(0.5f) && item->Pose.Position.x > x)
-				item->Pose.Position.x = x;
-				
-			break;
-
-		default:
-			break;
+			if (g_Level.Boxes[floor->Box].height == height && (g_Level.Boxes[floor->Box].flags & BLOCKABLE) && (g_Level.Boxes[floor->Box].flags & BLOCKED))
+				ClearMovableBlockSplitters(x - BLOCK(1), y, z, roomNumber);
 		}
 
-		MoveStackXZ(itemNumber);
-
-		if (LaraItem->Animation.FrameNumber == g_Level.Anims[LaraItem->Animation.AnimNumber].frameEnd - 1)
+		roomNumber = baseRoomNumber;
+		floor = GetFloor(x, y, z + BLOCK(1), &roomNumber);
+		if (floor->Box != NO_BOX)
 		{
-			if (pushable->canFall) // check if pushable is about to fall
+			if (g_Level.Boxes[floor->Box].height == height && (g_Level.Boxes[floor->Box].flags & BLOCKABLE) && (g_Level.Boxes[floor->Box].flags & BLOCKED))
+				ClearMovableBlockSplitters(x, y, z + BLOCK(1), roomNumber);
+		}
+
+		roomNumber = baseRoomNumber;
+		floor = GetFloor(x, y, z - BLOCK(1), &roomNumber);
+		if (floor->Box != NO_BOX)
+		{
+			if (g_Level.Boxes[floor->Box].height == height && (g_Level.Boxes[floor->Box].flags & BLOCKABLE) && (g_Level.Boxes[floor->Box].flags & BLOCKED))
+				ClearMovableBlockSplitters(x, y, z - BLOCK(1), roomNumber);
+		}
+	}
+
+	void PushableBlockControl(short itemNumber)
+	{
+		auto* item = &g_Level.Items[itemNumber];
+		auto& pushable = GetPushableInfo(*item);
+
+		Lara.InteractedItem = itemNumber;
+
+		auto pos = Vector3i::Zero;
+
+		int quadrant = GetQuadrant(LaraItem->Pose.Orientation.y);
+
+		int x, z;
+		int blockHeight = GetStackHeight(item);
+
+		// Control block falling.
+		if (item->Animation.IsAirborne)
+		{
+			int floorHeight = GetCollision(item->Pose.Position.x, item->Pose.Position.y + 10, item->Pose.Position.z, item->RoomNumber).Position.Floor;
+
+			if (item->Pose.Position.y < (floorHeight - item->Animation.Velocity.y))
 			{
-				int floorHeight = GetCollision(item->Pose.Position.x, item->Pose.Position.y + 10, item->Pose.Position.z, item->RoomNumber).Position.Floor;
-				if (floorHeight > item->Pose.Position.y)
-				{
-					item->Pose.Position.x = item->Pose.Position.x & 0xFFFFFE00 | 0x200;
-					item->Pose.Position.z = item->Pose.Position.z & 0xFFFFFE00 | 0x200;
-					MoveStackXZ(itemNumber);
-					LaraItem->Animation.TargetState = LS_IDLE;
-
-					pushable->MovementState = PushableMovementState::None;
-
-					item->Animation.IsAirborne = true; // Do fall.
-					return;
-				}
-			}
-
-			if (IsHeld(In::Action))
-			{
-				if (!TestBlockPush(item, blockHeight, quadrant))
-				{
-					LaraItem->Animation.TargetState = LS_IDLE;
-				}
+				if ((item->Animation.Velocity.y + pushable.gravity) < 128)
+					item->Animation.Velocity.y += pushable.gravity;
 				else
-				{
-					item->Pose.Position.x = pushable->moveX = item->Pose.Position.x & 0xFFFFFE00 | 0x200;
-					item->Pose.Position.z = pushable->moveZ = item->Pose.Position.z & 0xFFFFFE00 | 0x200;
-					TestTriggers(item, true, item->Flags & IFLAG_ACTIVATION_MASK);
-				}
+					item->Animation.Velocity.y++;
+				item->Pose.Position.y += item->Animation.Velocity.y;
+
+				MoveStackY(itemNumber, item->Animation.Velocity.y);
 			}
 			else
 			{
-				LaraItem->Animation.TargetState = LS_IDLE;
-			}
-		}
+				item->Animation.IsAirborne = false;
+				int relY = floorHeight - item->Pose.Position.y;
+				item->Pose.Position.y = floorHeight;
 
-		break;
+				if (item->Animation.Velocity.y >= 96)
+					FloorShake(item);
 
-	case LA_PUSHABLE_PULL:
-		displaceBox -= LARA_PUSHABLE_PULL_BBOX_Z2;
+				item->Animation.Velocity.y = 0;
+				SoundEffect(pushable.fallSound, &item->Pose, SoundEnvironment::Always);
 
-		if (LaraItem->Animation.FrameNumber == g_Level.Anims[LaraItem->Animation.AnimNumber].frameBase)
-		{
-			RemoveFromStack(itemNumber);
-			RemoveBridgeStack(itemNumber);
-		}
+				MoveStackY(itemNumber, relY);
+				AddBridgeStack(itemNumber);
 
-		switch (quadrant)
-		{
-		case NORTH:
-			z = pushable->moveZ + displaceBox;
-			if (abs(item->Pose.Position.z - z) < BLOCK(0.5f) && item->Pose.Position.z > z)
-				item->Pose.Position.z = z;
-
-			break;
-
-		case EAST:
-			x = pushable->moveX + displaceBox;
-			if (abs(item->Pose.Position.x - x) < BLOCK(0.5f) && item->Pose.Position.x > x)
-				item->Pose.Position.x = x;
-
-			break;
-
-		case SOUTH:
-			z = pushable->moveZ - displaceBox;
-			if (abs(item->Pose.Position.z - z) < BLOCK(0.5f) && item->Pose.Position.z < z)
-				item->Pose.Position.z = z;
-
-			break;
-
-		case WEST:
-			x = pushable->moveX - displaceBox;
-			if (abs(item->Pose.Position.x - x) < BLOCK(0.5f) && item->Pose.Position.x < x)
-				item->Pose.Position.x = x;
-
-			break;
-
-		default:
-			break;
-		}
-
-		MoveStackXZ(itemNumber);
-
-		if (LaraItem->Animation.FrameNumber == g_Level.Anims[LaraItem->Animation.AnimNumber].frameEnd - 1)
-		{
-			if (IsHeld(In::Action))
-			{
-				if (!TestBlockPull(item, blockHeight, quadrant))
-				{
-					LaraItem->Animation.TargetState = LS_IDLE;
-				}
-				else
-				{
-					item->Pose.Position.x = pushable->moveX = item->Pose.Position.x & 0xFFFFFE00 | 0x200;
-					item->Pose.Position.z = pushable->moveZ = item->Pose.Position.z & 0xFFFFFE00 | 0x200;
+				if (FindStack(itemNumber) == NO_ITEM) // if fallen on some existing pushables, don't test triggers
 					TestTriggers(item, true, item->Flags & IFLAG_ACTIVATION_MASK);
+			
+				RemoveActiveItem(itemNumber);
+				item->Status = ITEM_NOT_ACTIVE;
+
+				if (pushable.hasFloorCeiling)
+				{
+					//AlterFloorHeight(item, -((item->triggerFlags - 64) * 256));
+					AdjustStopperFlag(item, item->ItemFlags[0] + 0x8000, false);
 				}
 			}
-			else
-			{
-				LaraItem->Animation.TargetState = LS_IDLE;
-			}
+
+			return;
 		}
 
-		break;
+		int displaceBox = GameBoundingBox(LaraItem).Z2; // Move pushable based on bbox->Z2 of Lara
+		auto prevPos = item->Pose.Position;
 
-	case LA_PUSHABLE_GRAB:
-	case LA_PUSHABLE_RELEASE:
-	case LA_PUSHABLE_PUSH_TO_STAND:
-	case LA_PUSHABLE_PULL_TO_STAND:
-		break;
-
-	default:
-		if (item->Status == ITEM_ACTIVE)
+		switch (LaraItem->Animation.AnimNumber)
 		{
-			item->Pose.Position.x = item->Pose.Position.x & 0xFFFFFE00 | 0x200;
-			item->Pose.Position.z = item->Pose.Position.z & 0xFFFFFE00 | 0x200;
+		case LA_PUSHABLE_PUSH:
+			displaceBox -= LARA_PUSHABLE_PUSH_BBOX_Z2;
+
+			if (LaraItem->Animation.FrameNumber == g_Level.Anims[LaraItem->Animation.AnimNumber].frameBase)
+			{
+				RemoveFromStack(itemNumber);
+				RemoveBridgeStack(itemNumber);
+			}
+
+			switch (quadrant) 
+			{
+			case NORTH:
+				z = pushable.moveZ + displaceBox;
+
+				if (abs(item->Pose.Position.z - z) < BLOCK(0.5f) && item->Pose.Position.z < z)
+					item->Pose.Position.z = z;
+				
+				break;
+
+			case EAST:
+				x = pushable.moveX + displaceBox;
+
+				if (abs(item->Pose.Position.x - x) < BLOCK(0.5f) && item->Pose.Position.x < x)
+					item->Pose.Position.x = x;
+
+				break;
+
+			case SOUTH:
+				z = pushable.moveZ - displaceBox;
+
+				if (abs(item->Pose.Position.z - z) < BLOCK(0.5f) && item->Pose.Position.z > z)
+					item->Pose.Position.z = z;
+				
+				break;
+
+			case WEST:
+				x = pushable.moveX - displaceBox;
+
+				if (abs(item->Pose.Position.x - x) < BLOCK(0.5f) && item->Pose.Position.x > x)
+					item->Pose.Position.x = x;
+				
+				break;
+
+			default:
+				break;
+			}
 
 			MoveStackXZ(itemNumber);
-			FindStack(itemNumber);
-			AddBridgeStack(itemNumber);
 
-			TestTriggers(item, true, item->Flags & IFLAG_ACTIVATION_MASK);
+			if (LaraItem->Animation.FrameNumber == g_Level.Anims[LaraItem->Animation.AnimNumber].frameEnd - 1)
+			{
+				if (pushable.canFall) // check if pushable is about to fall
+				{
+					int floorHeight = GetCollision(item->Pose.Position.x, item->Pose.Position.y + 10, item->Pose.Position.z, item->RoomNumber).Position.Floor;
+					if (floorHeight > item->Pose.Position.y)
+					{
+						item->Pose.Position.x = item->Pose.Position.x & 0xFFFFFE00 | 0x200;
+						item->Pose.Position.z = item->Pose.Position.z & 0xFFFFFE00 | 0x200;
+						MoveStackXZ(itemNumber);
+						LaraItem->Animation.TargetState = LS_IDLE;
 
-			RemoveActiveItem(itemNumber);
-			item->Status = ITEM_NOT_ACTIVE;
+						pushable.MovementState = PushableMovementState::None;
+
+						item->Animation.IsAirborne = true; // Do fall.
+						return;
+					}
+				}
+
+				if (IsHeld(In::Action))
+				{
+					if (!TestBlockPush(item, blockHeight, quadrant))
+					{
+						LaraItem->Animation.TargetState = LS_IDLE;
+					}
+					else
+					{
+						item->Pose.Position.x = pushable.moveX = item->Pose.Position.x & 0xFFFFFE00 | 0x200;
+						item->Pose.Position.z = pushable.moveZ = item->Pose.Position.z & 0xFFFFFE00 | 0x200;
+						TestTriggers(item, true, item->Flags & IFLAG_ACTIVATION_MASK);
+					}
+				}
+				else
+				{
+					LaraItem->Animation.TargetState = LS_IDLE;
+				}
+			}
+
+			break;
+
+		case LA_PUSHABLE_PULL:
+			displaceBox -= LARA_PUSHABLE_PULL_BBOX_Z2;
+
+			if (LaraItem->Animation.FrameNumber == g_Level.Anims[LaraItem->Animation.AnimNumber].frameBase)
+			{
+				RemoveFromStack(itemNumber);
+				RemoveBridgeStack(itemNumber);
+			}
+
+			switch (quadrant)
+			{
+			case NORTH:
+				z = pushable.moveZ + displaceBox;
+				if (abs(item->Pose.Position.z - z) < BLOCK(0.5f) && item->Pose.Position.z > z)
+					item->Pose.Position.z = z;
+
+				break;
+
+			case EAST:
+				x = pushable.moveX + displaceBox;
+				if (abs(item->Pose.Position.x - x) < BLOCK(0.5f) && item->Pose.Position.x > x)
+					item->Pose.Position.x = x;
+
+				break;
+
+			case SOUTH:
+				z = pushable.moveZ - displaceBox;
+				if (abs(item->Pose.Position.z - z) < BLOCK(0.5f) && item->Pose.Position.z < z)
+					item->Pose.Position.z = z;
+
+				break;
+
+			case WEST:
+				x = pushable.moveX - displaceBox;
+				if (abs(item->Pose.Position.x - x) < BLOCK(0.5f) && item->Pose.Position.x < x)
+					item->Pose.Position.x = x;
+
+				break;
+
+			default:
+				break;
+			}
+
+			MoveStackXZ(itemNumber);
+
+			if (LaraItem->Animation.FrameNumber == g_Level.Anims[LaraItem->Animation.AnimNumber].frameEnd - 1)
+			{
+				if (IsHeld(In::Action))
+				{
+					if (!TestBlockPull(item, blockHeight, quadrant))
+					{
+						LaraItem->Animation.TargetState = LS_IDLE;
+					}
+					else
+					{
+						item->Pose.Position.x = pushable.moveX = item->Pose.Position.x & 0xFFFFFE00 | 0x200;
+						item->Pose.Position.z = pushable.moveZ = item->Pose.Position.z & 0xFFFFFE00 | 0x200;
+						TestTriggers(item, true, item->Flags & IFLAG_ACTIVATION_MASK);
+					}
+				}
+				else
+				{
+					LaraItem->Animation.TargetState = LS_IDLE;
+				}
+			}
+
+			break;
+
+		case LA_PUSHABLE_GRAB:
+		case LA_PUSHABLE_RELEASE:
+		case LA_PUSHABLE_PUSH_TO_STAND:
+		case LA_PUSHABLE_PULL_TO_STAND:
+			break;
+
+		default:
+			if (item->Status == ITEM_ACTIVE)
+			{
+				item->Pose.Position.x = item->Pose.Position.x & 0xFFFFFE00 | 0x200;
+				item->Pose.Position.z = item->Pose.Position.z & 0xFFFFFE00 | 0x200;
+
+				MoveStackXZ(itemNumber);
+				FindStack(itemNumber);
+				AddBridgeStack(itemNumber);
+
+				TestTriggers(item, true, item->Flags & IFLAG_ACTIVATION_MASK);
+
+				RemoveActiveItem(itemNumber);
+				item->Status = ITEM_NOT_ACTIVE;
+
+				if (pushable.hasFloorCeiling)
+				{
+					//AlterFloorHeight(item, -((item->triggerFlags - 64) * 256));
+					AdjustStopperFlag(item, item->ItemFlags[0] + 0x8000, false);
+				}
+			}
+
+			break;
+		}
+
+		// Set pushable movement state.
+		float distance = Vector3i::Distance(item->Pose.Position, prevPos);
+		if (distance > 0.0f)
+			PushLoop(item);
+		else
+			PushEnd(item);
+
+		// Do sound effects.
+		if (pushable.MovementState == PushableMovementState::Moving)
+		{
+			SoundEffect(pushable.loopSound, &item->Pose, SoundEnvironment::Always);
+		}
+		else if (pushable.MovementState == PushableMovementState::Stopping)
+		{
+			pushable.MovementState = PushableMovementState::None;
+			SoundEffect(pushable.stopSound, &item->Pose, SoundEnvironment::Always);
+		}
+	}
+
+	void PushableBlockCollision(short itemNumber, ItemInfo* laraItem, CollisionInfo* coll)
+	{
+		auto* lara = GetLaraInfo(laraItem);
+		auto* pushableItem = &g_Level.Items[itemNumber];
+		auto* pushable = (PushableInfo*)pushableItem->Data;
+
+		int blockHeight = GetStackHeight(pushableItem);
+	
+		if ((!IsHeld(In::Action) ||
+			laraItem->Animation.ActiveState != LS_IDLE ||
+			laraItem->Animation.AnimNumber != LA_STAND_IDLE ||
+			laraItem->Animation.IsAirborne ||
+			lara->Control.HandStatus != HandStatus::Free ||
+			pushableItem->Status == ITEM_INVISIBLE ||
+			pushableItem->TriggerFlags < 0) &&
+			(!lara->Control.IsMoving || lara->InteractedItem != itemNumber))
+		{
+			if (laraItem->Animation.ActiveState != LS_PUSHABLE_GRAB ||
+				!TestLastFrame(laraItem, LA_PUSHABLE_GRAB) ||
+				lara->NextCornerPos.Position.x != itemNumber)
+			{
+				if (!pushable->hasFloorCeiling)
+					ObjectCollision(itemNumber, laraItem, coll);
+
+				return;
+			}
+
+			short quadrant = (unsigned short)(LaraItem->Pose.Orientation.y + ANGLE(45.0f)) / ANGLE(90.0f);
+
+			bool quadrantDisabled = false;
+			switch (quadrant)
+			{
+			case NORTH:
+				quadrantDisabled = pushable->disableN;
+				break;
+			case EAST:
+				quadrantDisabled = pushable->disableE;
+				break;
+			case SOUTH:
+				quadrantDisabled = pushable->disableS;
+				break;
+			case WEST:
+				quadrantDisabled = pushable->disableW;
+				break;
+			}
+
+			if (quadrantDisabled)
+				return;
+
+			if (!CheckStackLimit(pushableItem))
+				return;
+
+			if (IsHeld(In::Forward))
+			{
+				if (!TestBlockPush(pushableItem, blockHeight, quadrant) || pushable->disablePush)
+					return;
+
+				laraItem->Animation.TargetState = LS_PUSHABLE_PUSH;
+			}
+			else if (IsHeld(In::Back))
+			{
+				if (!TestBlockPull(pushableItem, blockHeight, quadrant) || pushable->disablePull)
+					return;
+
+				laraItem->Animation.TargetState = LS_PUSHABLE_PULL;
+			}
+			else
+			{
+				return;
+			}
+
+			pushableItem->Status = ITEM_ACTIVE;
+			AddActiveItem(itemNumber);
+			ResetLaraFlex(laraItem);
+		
+			pushable->moveX = pushableItem->Pose.Position.x;
+			pushable->moveZ = pushableItem->Pose.Position.z;
 
 			if (pushable->hasFloorCeiling)
 			{
-				//AlterFloorHeight(item, -((item->triggerFlags - 64) * 256));
-				AdjustStopperFlag(item, item->ItemFlags[0] + 0x8000, false);
+				//AlterFloorHeight(item, ((item->triggerFlags - 64) * 256));
+				AdjustStopperFlag(pushableItem, pushableItem->ItemFlags[0], false);
 			}
-		}
-
-		break;
-	}
-
-	// Set pushable movement state.
-
-	auto distance = (prevPos - item->Pose.Position).ToVector3().Length();
-	if (distance > 0.0f)
-		PushLoop(item);
-	else
-		PushEnd(item);
-
-	// Do sound effects.
-
-	if (pushable->MovementState == PushableMovementState::Moving)
-	{
-		SoundEffect(pushable->loopSound, &item->Pose, SoundEnvironment::Always);
-	}
-	else if (pushable->MovementState == PushableMovementState::Stopping)
-	{
-		pushable->MovementState = PushableMovementState::None;
-		SoundEffect(pushable->stopSound, &item->Pose, SoundEnvironment::Always);
-	}
-}
-
-void PushableBlockCollision(short itemNumber, ItemInfo* laraItem, CollisionInfo* coll)
-{
-	auto* lara = GetLaraInfo(laraItem);
-	auto* pushableItem = &g_Level.Items[itemNumber];
-	auto* pushable = (PushableInfo*)pushableItem->Data;
-
-	int blockHeight = GetStackHeight(pushableItem);
-	
-	if ((!IsHeld(In::Action) ||
-		laraItem->Animation.ActiveState != LS_IDLE ||
-		laraItem->Animation.AnimNumber != LA_STAND_IDLE ||
-		laraItem->Animation.IsAirborne ||
-		lara->Control.HandStatus != HandStatus::Free ||
-		pushableItem->Status == ITEM_INVISIBLE ||
-		pushableItem->TriggerFlags < 0) &&
-		(!lara->Control.IsMoving || lara->InteractedItem != itemNumber))
-	{
-		if (laraItem->Animation.ActiveState != LS_PUSHABLE_GRAB ||
-			!TestLastFrame(laraItem, LA_PUSHABLE_GRAB) ||
-			lara->NextCornerPos.Position.x != itemNumber)
-		{
-			if (!pushable->hasFloorCeiling)
-				ObjectCollision(itemNumber, laraItem, coll);
-
-			return;
-		}
-
-		short quadrant = (unsigned short)(LaraItem->Pose.Orientation.y + ANGLE(45.0f)) / ANGLE(90.0f);
-
-		bool quadrantDisabled = false;
-		switch (quadrant)
-		{
-		case NORTH:
-			quadrantDisabled = pushable->disableN;
-			break;
-		case EAST:
-			quadrantDisabled = pushable->disableE;
-			break;
-		case SOUTH:
-			quadrantDisabled = pushable->disableS;
-			break;
-		case WEST:
-			quadrantDisabled = pushable->disableW;
-			break;
-		}
-
-		if (quadrantDisabled)
-			return;
-
-		if (!CheckStackLimit(pushableItem))
-			return;
-
-		if (IsHeld(In::Forward))
-		{
-			if (!TestBlockPush(pushableItem, blockHeight, quadrant) || pushable->disablePush)
-				return;
-
-			laraItem->Animation.TargetState = LS_PUSHABLE_PUSH;
-		}
-		else if (IsHeld(In::Back))
-		{
-			if (!TestBlockPull(pushableItem, blockHeight, quadrant) || pushable->disablePull)
-				return;
-
-			laraItem->Animation.TargetState = LS_PUSHABLE_PULL;
 		}
 		else
 		{
-			return;
-		}
+			auto bounds = GameBoundingBox(pushableItem);
+			PushableBlockBounds.BoundingBox.X1 = (bounds.X1 / 2) - 100;
+			PushableBlockBounds.BoundingBox.X2 = (bounds.X2 / 2) + 100;
+			PushableBlockBounds.BoundingBox.Z1 = bounds.Z1 - 200;
+			PushableBlockBounds.BoundingBox.Z2 = 0;
 
-		pushableItem->Status = ITEM_ACTIVE;
-		AddActiveItem(itemNumber);
-		ResetLaraFlex(laraItem);
-		
-		pushable->moveX = pushableItem->Pose.Position.x;
-		pushable->moveZ = pushableItem->Pose.Position.z;
+			short rot = pushableItem->Pose.Orientation.y;
+			pushableItem->Pose.Orientation.y = (laraItem->Pose.Orientation.y + ANGLE(45.0f)) & 0xC000;
 
-		if (pushable->hasFloorCeiling)
-		{
-			//AlterFloorHeight(item, ((item->triggerFlags - 64) * 256));
-			AdjustStopperFlag(pushableItem, pushableItem->ItemFlags[0], false);
-		}
-	}
-	else
-	{
-		auto bounds = GameBoundingBox(pushableItem);
-		PushableBlockBounds.BoundingBox.X1 = (bounds.X1 / 2) - 100;
-		PushableBlockBounds.BoundingBox.X2 = (bounds.X2 / 2) + 100;
-		PushableBlockBounds.BoundingBox.Z1 = bounds.Z1 - 200;
-		PushableBlockBounds.BoundingBox.Z2 = 0;
-
-		short rot = pushableItem->Pose.Orientation.y;
-		pushableItem->Pose.Orientation.y = (laraItem->Pose.Orientation.y + ANGLE(45.0f)) & 0xC000;
-
-		if (TestLaraPosition(PushableBlockBounds, pushableItem, laraItem))
-		{
-			unsigned short quadrant = (unsigned short)((pushableItem->Pose.Orientation.y / 0x4000) + ((rot + 0x2000) / 0x4000));
-			if (quadrant & 1)
-				PushableBlockPos.z = bounds.X1 - CLICK(0.4f);
-			else
-				PushableBlockPos.z = bounds.Z1 - CLICK(0.4f);
-
-			if (pushable->hasFloorCeiling)
-			{					
-				// For now don't use auto-align function because it can collide with climb up moves of Lara
-
-				SetAnimation(laraItem, LA_PUSHABLE_GRAB);
-				laraItem->Pose.Orientation = pushableItem->Pose.Orientation;
-				lara->Control.IsMoving = false;
-				lara->Control.HandStatus = HandStatus::Busy;
-				lara->NextCornerPos.Position.x = itemNumber;
-				pushableItem->Pose.Orientation.y = rot;
-			}
-			else
+			if (TestLaraPosition(PushableBlockBounds, pushableItem, laraItem))
 			{
-				if (MoveLaraPosition(PushableBlockPos, pushableItem, laraItem))
-				{
+				unsigned short quadrant = (unsigned short)((pushableItem->Pose.Orientation.y / 0x4000) + ((rot + 0x2000) / 0x4000));
+				if (quadrant & 1)
+					PushableBlockPos.z = bounds.X1 - CLICK(0.4f);
+				else
+					PushableBlockPos.z = bounds.Z1 - CLICK(0.4f);
+
+				if (pushable->hasFloorCeiling)
+				{					
+					// For now don't use auto-align function because it can collide with climb up moves of Lara
+
 					SetAnimation(laraItem, LA_PUSHABLE_GRAB);
+					laraItem->Pose.Orientation = pushableItem->Pose.Orientation;
 					lara->Control.IsMoving = false;
 					lara->Control.HandStatus = HandStatus::Busy;
 					lara->NextCornerPos.Position.x = itemNumber;
@@ -535,521 +522,528 @@ void PushableBlockCollision(short itemNumber, ItemInfo* laraItem, CollisionInfo*
 				}
 				else
 				{
-					lara->InteractedItem = itemNumber;
-					pushableItem->Pose.Orientation.y = rot;
+					if (MoveLaraPosition(PushableBlockPos, pushableItem, laraItem))
+					{
+						SetAnimation(laraItem, LA_PUSHABLE_GRAB);
+						lara->Control.IsMoving = false;
+						lara->Control.HandStatus = HandStatus::Busy;
+						lara->NextCornerPos.Position.x = itemNumber;
+						pushableItem->Pose.Orientation.y = rot;
+					}
+					else
+					{
+						lara->InteractedItem = itemNumber;
+						pushableItem->Pose.Orientation.y = rot;
+					}
 				}
 			}
-		}
-		else
-		{
-			if (lara->Control.IsMoving && lara->InteractedItem == itemNumber)
+			else
 			{
-				lara->Control.IsMoving = false;
-				lara->Control.HandStatus = HandStatus::Free;
-			}
+				if (lara->Control.IsMoving && lara->InteractedItem == itemNumber)
+				{
+					lara->Control.IsMoving = false;
+					lara->Control.HandStatus = HandStatus::Free;
+				}
 
-			pushableItem->Pose.Orientation.y = rot;
+				pushableItem->Pose.Orientation.y = rot;
+			}
 		}
 	}
-}
 
-void PushLoop(ItemInfo* item)
-{
-	auto* pushable = (PushableInfo*)item->Data;
+	void PushLoop(ItemInfo* item)
+	{
+		auto* pushable = (PushableInfo*)item->Data;
 
-	pushable->MovementState = PushableMovementState::Moving;
-}
+		pushable->MovementState = PushableMovementState::Moving;
+	}
 
-void PushEnd(ItemInfo* item)
-{
-	auto* pushable = (PushableInfo*)item->Data;
+	void PushEnd(ItemInfo* item)
+	{
+		auto* pushable = (PushableInfo*)item->Data;
 
-	if (pushable->MovementState == PushableMovementState::Moving)
-		pushable->MovementState = PushableMovementState::Stopping;
-}
+		if (pushable->MovementState == PushableMovementState::Moving)
+			pushable->MovementState = PushableMovementState::Stopping;
+	}
 
-bool TestBlockMovable(ItemInfo* item, int blockHeight)
-{
-	RemoveBridge(item->Index);
-	auto pointColl = GetCollision(item);
-	AddBridge(item->Index);
+	bool TestBlockMovable(ItemInfo* item, int blockHeight)
+	{
+		RemoveBridge(item->Index);
+		auto pointColl = GetCollision(item);
+		AddBridge(item->Index);
 
-	if (pointColl.Block->IsWall(pointColl.Block->SectorPlane(item->Pose.Position.x, item->Pose.Position.z)))
-		return false;
+		if (pointColl.Block->IsWall(pointColl.Block->SectorPlane(item->Pose.Position.x, item->Pose.Position.z)))
+			return false;
 
-	if (pointColl.Position.Floor != item->Pose.Position.y)
-		return false;
+		if (pointColl.Position.Floor != item->Pose.Position.y)
+			return false;
 
-	return true;
-}
+		return true;
+	}
 
-bool TestBlockPush(ItemInfo* item, int blockHeight, unsigned short quadrant)
-{
-	if (!TestBlockMovable(item, blockHeight))
-		return false;
+	bool TestBlockPush(ItemInfo* item, int blockHeight, unsigned short quadrant)
+	{
+		if (!TestBlockMovable(item, blockHeight))
+			return false;
 
-	auto* pushable = (PushableInfo*)item->Data;
+		auto* pushable = (PushableInfo*)item->Data;
 
-	int x = item->Pose.Position.x;
-	int y = item->Pose.Position.y;
-	int z = item->Pose.Position.z;
+		int x = item->Pose.Position.x;
+		int y = item->Pose.Position.y;
+		int z = item->Pose.Position.z;
 	
-	switch (quadrant)
-	{
-	case NORTH:
-		z += BLOCK(1);
-		break;
-
-	case EAST:
-		x += BLOCK(1);
-		break;
-
-	case SOUTH:
-		z -= BLOCK(1);
-		break;
-
-	case WEST:
-		x -= BLOCK(1);
-		break;
-	}
-
-	auto probe = GetCollision(x, y - blockHeight, z, item->RoomNumber);
-
-	auto* room = &g_Level.Rooms[probe.RoomNumber];
-	if (GetSector(room, x - room->x, z - room->z)->Stopper)
-		return false;
-
-	if (probe.Position.FloorSlope || probe.Position.DiagonalStep ||
-		probe.Block->FloorSlope(0) != Vector2::Zero || probe.Block->FloorSlope(1) != Vector2::Zero)
-		return false;
-
-	if (pushable->canFall)
-	{
-		if (probe.Position.Floor < y)
-			return false;
-	}
-	else
-	{
-		if (probe.Position.Floor != y)
-			return false;
-	}
-
-	int ceiling = y - blockHeight + 100;
-
-	if (GetCollision(x, ceiling, z, item->RoomNumber).Position.Ceiling > ceiling)
-		return false;
-
-	int oldX = item->Pose.Position.x;
-	int oldZ = item->Pose.Position.z;
-	item->Pose.Position.x = x;
-	item->Pose.Position.z = z;
-	GetCollidedObjects(item, BLOCK(0.25f), true, &CollidedItems[0], &CollidedMeshes[0], true);
-	item->Pose.Position.x = oldX;
-	item->Pose.Position.z = oldZ;
-
-	if (CollidedMeshes[0])
-		return false;
-
-	for (int i = 0; i < MAX_COLLIDED_OBJECTS; i++)
-	{
-		if (!CollidedItems[i])
+		switch (quadrant)
+		{
+		case NORTH:
+			z += BLOCK(1);
 			break;
 
-		if (Objects[CollidedItems[i]->ObjectNumber].isPickup)
-			continue;
+		case EAST:
+			x += BLOCK(1);
+			break;
 
-		if (Objects[CollidedItems[i]->ObjectNumber].floor == nullptr)
+		case SOUTH:
+			z -= BLOCK(1);
+			break;
+
+		case WEST:
+			x -= BLOCK(1);
+			break;
+		}
+
+		auto probe = GetCollision(x, y - blockHeight, z, item->RoomNumber);
+
+		auto* room = &g_Level.Rooms[probe.RoomNumber];
+		if (GetSector(room, x - room->x, z - room->z)->Stopper)
 			return false;
+
+		if (probe.Position.FloorSlope || probe.Position.DiagonalStep ||
+			probe.Block->FloorSlope(0) != Vector2::Zero || probe.Block->FloorSlope(1) != Vector2::Zero)
+			return false;
+
+		if (pushable->canFall)
+		{
+			if (probe.Position.Floor < y)
+				return false;
+		}
 		else
 		{
+			if (probe.Position.Floor != y)
+				return false;
+		}
+
+		int ceiling = y - blockHeight + 100;
+
+		if (GetCollision(x, ceiling, z, item->RoomNumber).Position.Ceiling > ceiling)
+			return false;
+
+		int oldX = item->Pose.Position.x;
+		int oldZ = item->Pose.Position.z;
+		item->Pose.Position.x = x;
+		item->Pose.Position.z = z;
+		GetCollidedObjects(item, BLOCK(0.25f), true, &CollidedItems[0], &CollidedMeshes[0], true);
+		item->Pose.Position.x = oldX;
+		item->Pose.Position.z = oldZ;
+
+		if (CollidedMeshes[0])
+			return false;
+
+		for (int i = 0; i < MAX_COLLIDED_OBJECTS; i++)
+		{
+			if (!CollidedItems[i])
+				break;
+
+			if (Objects[CollidedItems[i]->ObjectNumber].isPickup)
+				continue;
+
+			if (Objects[CollidedItems[i]->ObjectNumber].floor == nullptr)
+				return false;
+		
 			const auto& object = Objects[CollidedItems[i]->ObjectNumber];
 			int collidedIndex = CollidedItems[i] - g_Level.Items.data(); // index of CollidedItems[i]
 
-			int xCol = CollidedItems[i]->Pose.Position.x;
-			int yCol = CollidedItems[i]->Pose.Position.y;
-			int zCol = CollidedItems[i]->Pose.Position.z;
+			auto colPos = CollidedItems[i]->Pose.Position;
 
-			// check if floor function returns nullopt
-			if (object.floor(collidedIndex, xCol, yCol, zCol) == std::nullopt)
+			// Check if floor function returns nullopt.
+			if (object.floor(collidedIndex, colPos.x, colPos.y, colPos.z) == std::nullopt)
 				return false;
 		}
+
+		return true;
 	}
 
-	return true;
-}
-
-bool TestBlockPull(ItemInfo* item, int blockHeight, short quadrant)
-{
-	if (!TestBlockMovable(item, blockHeight))
-		return false;
-
-	int xadd = 0;
-	int zadd = 0;
-
-	switch (quadrant)
+	bool TestBlockPull(ItemInfo* item, int blockHeight, short quadrant)
 	{
-	case NORTH:
-		zadd = -BLOCK(1);
-		break;
+		if (!TestBlockMovable(item, blockHeight))
+			return false;
 
-	case EAST:
-		xadd = -BLOCK(1);
-		break;
+		int xadd = 0;
+		int zadd = 0;
 
-	case SOUTH:
-		zadd = BLOCK(1);
-		break;
-
-	case WEST:
-		xadd = BLOCK(1);
-		break;
-	}
-
-	int x = item->Pose.Position.x + xadd;
-	int y = item->Pose.Position.y;
-	int z = item->Pose.Position.z + zadd;
-
-	short roomNumber = item->RoomNumber;
-	auto* room = &g_Level.Rooms[roomNumber];
-	if (GetSector(room, x - room->x, z - room->z)->Stopper)
-		return false;
-
-	auto probe = GetCollision(x, y - blockHeight, z, item->RoomNumber);
-
-	if (probe.Position.Floor != y)
-		return false;
-
-	if (probe.Position.FloorSlope || probe.Position.DiagonalStep ||
-		probe.Block->FloorSlope(0) != Vector2::Zero || probe.Block->FloorSlope(1) != Vector2::Zero)
-		return false;
-
-	int ceiling = y - blockHeight + 100;
-
-	if (GetCollision(x, ceiling, z, item->RoomNumber).Position.Ceiling > ceiling)
-		return false;
-
-	int oldX = item->Pose.Position.x;
-	int oldZ = item->Pose.Position.z;
-	item->Pose.Position.x = x;
-	item->Pose.Position.z = z;
-	GetCollidedObjects(item, BLOCK(0.25f), true, &CollidedItems[0], &CollidedMeshes[0], true);
-	item->Pose.Position.x = oldX;
-	item->Pose.Position.z = oldZ;
-
-	if (CollidedMeshes[0])
-		return false;
-
-	for (int i = 0; i < MAX_COLLIDED_OBJECTS; i++)
-	{
-		if (!CollidedItems[i])
+		switch (quadrant)
+		{
+		case NORTH:
+			zadd = -BLOCK(1);
 			break;
 
-		if (Objects[CollidedItems[i]->ObjectNumber].isPickup)
-			continue;
-
-		if (Objects[CollidedItems[i]->ObjectNumber].floor == nullptr)
-			return false;
-		else
-		{
-			const auto& object = Objects[CollidedItems[i]->ObjectNumber];
-			int collidedIndex = CollidedItems[i] - g_Level.Items.data();
-
-			int xCol = CollidedItems[i]->Pose.Position.x;
-			int yCol = CollidedItems[i]->Pose.Position.y;
-			int zCol = CollidedItems[i]->Pose.Position.z;
-
-			if (object.floor(collidedIndex, xCol, yCol, zCol) == std::nullopt)
-				return false;
-		}
-	}
-
-	int xAddLara = 0, zAddLara = 0;
-	switch (quadrant)
-	{
-	case NORTH:
-		zAddLara = GetBestFrame(LaraItem)->offsetZ;
-		break;
-	case EAST:
-		xAddLara = GetBestFrame(LaraItem)->offsetZ;
-		break;
-	case SOUTH:
-		zAddLara = -GetBestFrame(LaraItem)->offsetZ;
-		break;
-	case WEST:
-		xAddLara = -GetBestFrame(LaraItem)->offsetZ;
-		break;
-	}
-
-	x = LaraItem->Pose.Position.x + xadd + xAddLara;
-	z = LaraItem->Pose.Position.z + zadd + zAddLara;
-
-	roomNumber = LaraItem->RoomNumber;
-
-	probe = GetCollision(x, y - LARA_HEIGHT, z, LaraItem->RoomNumber);
-
-	room = &g_Level.Rooms[roomNumber];
-	if (GetSector(room, x - room->x, z - room->z)->Stopper)
-		return false;
-
-	if (probe.Position.Floor != y)
-		return false;
-
-	if (probe.Block->CeilingHeight(x, z) > y - LARA_HEIGHT)
-		return false;
-
-	oldX = LaraItem->Pose.Position.x;
-	oldZ = LaraItem->Pose.Position.z;
-	LaraItem->Pose.Position.x = x;
-	LaraItem->Pose.Position.z = z;
-	GetCollidedObjects(LaraItem, LARA_RADIUS, true, &CollidedItems[0], &CollidedMeshes[0], true);
-	LaraItem->Pose.Position.x = oldX;
-	LaraItem->Pose.Position.z = oldZ;
-
-	if (CollidedMeshes[0])
-		return false;
-
-	for (int i = 0; i < MAX_COLLIDED_OBJECTS; i++)
-	{
-		if (!CollidedItems[i])
+		case EAST:
+			xadd = -BLOCK(1);
 			break;
 
-		if (CollidedItems[i] == item) // If collided item is not pushblock in which lara embedded
-			continue;
+		case SOUTH:
+			zadd = BLOCK(1);
+			break;
 
-		if (Objects[CollidedItems[i]->ObjectNumber].isPickup)
-			continue;
+		case WEST:
+			xadd = BLOCK(1);
+			break;
+		}
 
-		if (Objects[CollidedItems[i]->ObjectNumber].floor == nullptr)
+		int x = item->Pose.Position.x + xadd;
+		int y = item->Pose.Position.y;
+		int z = item->Pose.Position.z + zadd;
+
+		short roomNumber = item->RoomNumber;
+		auto* room = &g_Level.Rooms[roomNumber];
+		if (GetSector(room, x - room->x, z - room->z)->Stopper)
 			return false;
-		else
-		{
-			const auto& object = Objects[CollidedItems[i]->ObjectNumber];
-			int collidedIndex = CollidedItems[i] - g_Level.Items.data();
-			int xCol = CollidedItems[i]->Pose.Position.x;
-			int yCol = CollidedItems[i]->Pose.Position.y;
-			int zCol = CollidedItems[i]->Pose.Position.z;
 
-			if (object.floor(collidedIndex, xCol, yCol, zCol) == std::nullopt)
+		auto probe = GetCollision(x, y - blockHeight, z, item->RoomNumber);
+
+		if (probe.Position.Floor != y)
+			return false;
+
+		if (probe.Position.FloorSlope || probe.Position.DiagonalStep ||
+			probe.Block->FloorSlope(0) != Vector2::Zero || probe.Block->FloorSlope(1) != Vector2::Zero)
+			return false;
+
+		int ceiling = y - blockHeight + 100;
+
+		if (GetCollision(x, ceiling, z, item->RoomNumber).Position.Ceiling > ceiling)
+			return false;
+
+		int oldX = item->Pose.Position.x;
+		int oldZ = item->Pose.Position.z;
+		item->Pose.Position.x = x;
+		item->Pose.Position.z = z;
+		GetCollidedObjects(item, BLOCK(0.25f), true, &CollidedItems[0], &CollidedMeshes[0], true);
+		item->Pose.Position.x = oldX;
+		item->Pose.Position.z = oldZ;
+
+		if (CollidedMeshes[0])
+			return false;
+
+		for (int i = 0; i < MAX_COLLIDED_OBJECTS; i++)
+		{
+			if (!CollidedItems[i])
+				break;
+
+			if (Objects[CollidedItems[i]->ObjectNumber].isPickup)
+				continue;
+
+			if (Objects[CollidedItems[i]->ObjectNumber].floor == nullptr)
 				return false;
-		}
-	}
-
-	return true;
-}
-
-void MoveStackXZ(short itemNumber)
-{
-	auto* item = &g_Level.Items[itemNumber];
-
-	short probedRoomNumber = GetCollision(item).RoomNumber;
-	if (probedRoomNumber != item->RoomNumber)
-		ItemNewRoom(itemNumber, probedRoomNumber);
-
-	auto* stackItem = item;
-	while (stackItem->ItemFlags[1] != NO_ITEM) // move pushblock stack together with bottom pushblock
-	{
-		int stackIndex = stackItem->ItemFlags[1];
-		stackItem = &g_Level.Items[stackIndex];
-
-		stackItem->Pose.Position.x = item->Pose.Position.x;
-		stackItem->Pose.Position.z = item->Pose.Position.z;
-
-		probedRoomNumber = GetCollision(item).RoomNumber;
-		if (probedRoomNumber != stackItem->RoomNumber)
-			ItemNewRoom(stackIndex, probedRoomNumber);
-	}
-}
-
-void MoveStackY(short itemNumber, int y)
-{
-	auto* item = &g_Level.Items[itemNumber];
-
-	short probedRoomNumber = GetCollision(item).RoomNumber;
-	if (probedRoomNumber != item->RoomNumber)
-		ItemNewRoom(itemNumber, probedRoomNumber);
-
-	while (item->ItemFlags[1] != NO_ITEM) // move pushblock stack together with bottom pushblock
-	{
-		int stackIndex = item->ItemFlags[1];
-		item = &g_Level.Items[stackIndex];
-
-		item->Pose.Position.y += y;
-
-		probedRoomNumber = GetCollision(item).RoomNumber;
-		if (probedRoomNumber != item->RoomNumber)
-			ItemNewRoom(stackIndex, probedRoomNumber);
-	}
-}
-
-void AddBridgeStack(short itemNumber)
-{
-	auto* item = &g_Level.Items[itemNumber];
-	auto* pushable = (PushableInfo*)item->Data;
-
-	if (pushable->hasFloorCeiling)
-		TEN::Floordata::AddBridge(itemNumber);
-
-	int stackIndex = g_Level.Items[itemNumber].ItemFlags[1];
-	while (stackIndex != NO_ITEM)
-	{
-		auto* stackItem = &g_Level.Items[stackIndex];
-
-		if (pushable->hasFloorCeiling)
-			TEN::Floordata::AddBridge(stackIndex);
-
-		stackIndex = g_Level.Items[stackIndex].ItemFlags[1];
-	}
-}
-
-void RemoveBridgeStack(short itemNumber)
-{
-	auto* item = &g_Level.Items[itemNumber];
-	auto* pushable = (PushableInfo*)item->Data;
-
-	if (pushable->hasFloorCeiling)
-		TEN::Floordata::RemoveBridge(itemNumber);
-
-	int stackIndex = g_Level.Items[itemNumber].ItemFlags[1];
-	while (stackIndex != NO_ITEM)
-	{
-		auto* stackItem = &g_Level.Items[stackIndex];
-
-		if (pushable->hasFloorCeiling)
-			TEN::Floordata::RemoveBridge(stackIndex);
-
-		stackIndex = g_Level.Items[stackIndex].ItemFlags[1];
-	}
-}
-
-void RemoveFromStack(short itemNumber) // unlink pushable from stack if linked
-{
-	for (int i = 0; i < g_Level.NumItems; i++)
-	{
-		if (i == itemNumber)
-			continue;
-
-		auto* itemBelow = &g_Level.Items[i];
-
-		int objectNumber = itemBelow->ObjectNumber;
-		if (objectNumber >= ID_PUSHABLE_OBJECT1 && objectNumber <= ID_PUSHABLE_OBJECT10)
-		{
-			if (itemBelow->ItemFlags[1] == itemNumber)
-				itemBelow->ItemFlags[1] = NO_ITEM;
-		}
-	}
-}
-
-int FindStack(short itemNumber)
-{
-	int stackTop = NO_ITEM; // index of heighest (Position.y) pushable in stack
-	int stackYmin = CLICK(256); // set starting height
-
-	//Check for pushable directly below current one in same sector
-	for (int i = 0; i < g_Level.NumItems; i++)
-	{
-		if (i == itemNumber)
-			continue;
-
-		auto* itemBelow = &g_Level.Items[i];
-
-		int objectNumber = itemBelow->ObjectNumber;
-		if (objectNumber >= ID_PUSHABLE_OBJECT1 && objectNumber <= ID_PUSHABLE_OBJECT10)
-		{
-			auto* item = &g_Level.Items[itemNumber];
-			int x = item->Pose.Position.x;
-			int y = item->Pose.Position.y;
-			int z = item->Pose.Position.z;
-
-			if (itemBelow->Pose.Position.x == x && itemBelow->Pose.Position.z == z)
+			else
 			{
-				int belowY = itemBelow->Pose.Position.y;
-				if (belowY > y && belowY < stackYmin)
-				{
-					// set heighest pushable so far as top of stack
-					stackTop = i;
-					stackYmin = itemBelow->Pose.Position.y;
-				}
+				const auto& object = Objects[CollidedItems[i]->ObjectNumber];
+				int collidedIndex = CollidedItems[i] - g_Level.Items.data();
+
+				int xCol = CollidedItems[i]->Pose.Position.x;
+				int yCol = CollidedItems[i]->Pose.Position.y;
+				int zCol = CollidedItems[i]->Pose.Position.z;
+
+				if (object.floor(collidedIndex, xCol, yCol, zCol) == std::nullopt)
+					return false;
+			}
+		}
+
+		int xAddLara = 0, zAddLara = 0;
+		switch (quadrant)
+		{
+		case NORTH:
+			zAddLara = GetBestFrame(LaraItem)->offsetZ;
+			break;
+		case EAST:
+			xAddLara = GetBestFrame(LaraItem)->offsetZ;
+			break;
+		case SOUTH:
+			zAddLara = -GetBestFrame(LaraItem)->offsetZ;
+			break;
+		case WEST:
+			xAddLara = -GetBestFrame(LaraItem)->offsetZ;
+			break;
+		}
+
+		x = LaraItem->Pose.Position.x + xadd + xAddLara;
+		z = LaraItem->Pose.Position.z + zadd + zAddLara;
+
+		roomNumber = LaraItem->RoomNumber;
+
+		probe = GetCollision(x, y - LARA_HEIGHT, z, LaraItem->RoomNumber);
+
+		room = &g_Level.Rooms[roomNumber];
+		if (GetSector(room, x - room->x, z - room->z)->Stopper)
+			return false;
+
+		if (probe.Position.Floor != y)
+			return false;
+
+		if (probe.Block->CeilingHeight(x, z) > y - LARA_HEIGHT)
+			return false;
+
+		oldX = LaraItem->Pose.Position.x;
+		oldZ = LaraItem->Pose.Position.z;
+		LaraItem->Pose.Position.x = x;
+		LaraItem->Pose.Position.z = z;
+		GetCollidedObjects(LaraItem, LARA_RADIUS, true, &CollidedItems[0], &CollidedMeshes[0], true);
+		LaraItem->Pose.Position.x = oldX;
+		LaraItem->Pose.Position.z = oldZ;
+
+		if (CollidedMeshes[0])
+			return false;
+
+		for (int i = 0; i < MAX_COLLIDED_OBJECTS; i++)
+		{
+			if (!CollidedItems[i])
+				break;
+
+			if (CollidedItems[i] == item) // If collided item is not pushblock in which lara embedded
+				continue;
+
+			if (Objects[CollidedItems[i]->ObjectNumber].isPickup)
+				continue;
+
+			if (Objects[CollidedItems[i]->ObjectNumber].floor == nullptr)
+				return false;
+			else
+			{
+				const auto& object = Objects[CollidedItems[i]->ObjectNumber];
+				int collidedIndex = CollidedItems[i] - g_Level.Items.data();
+				int xCol = CollidedItems[i]->Pose.Position.x;
+				int yCol = CollidedItems[i]->Pose.Position.y;
+				int zCol = CollidedItems[i]->Pose.Position.z;
+
+				if (object.floor(collidedIndex, xCol, yCol, zCol) == std::nullopt)
+					return false;
+			}
+		}
+
+		return true;
+	}
+
+	void MoveStackXZ(short itemNumber)
+	{
+		auto* item = &g_Level.Items[itemNumber];
+
+		short probedRoomNumber = GetCollision(item).RoomNumber;
+		if (probedRoomNumber != item->RoomNumber)
+			ItemNewRoom(itemNumber, probedRoomNumber);
+
+		auto* stackItem = item;
+		while (stackItem->ItemFlags[1] != NO_ITEM) // move pushblock stack together with bottom pushblock
+		{
+			int stackIndex = stackItem->ItemFlags[1];
+			stackItem = &g_Level.Items[stackIndex];
+
+			stackItem->Pose.Position.x = item->Pose.Position.x;
+			stackItem->Pose.Position.z = item->Pose.Position.z;
+
+			probedRoomNumber = GetCollision(item).RoomNumber;
+			if (probedRoomNumber != stackItem->RoomNumber)
+				ItemNewRoom(stackIndex, probedRoomNumber);
+		}
+	}
+
+	void MoveStackY(short itemNumber, int y)
+	{
+		auto* item = &g_Level.Items[itemNumber];
+
+		short probedRoomNumber = GetCollision(item).RoomNumber;
+		if (probedRoomNumber != item->RoomNumber)
+			ItemNewRoom(itemNumber, probedRoomNumber);
+
+		while (item->ItemFlags[1] != NO_ITEM) // move pushblock stack together with bottom pushblock
+		{
+			int stackIndex = item->ItemFlags[1];
+			item = &g_Level.Items[stackIndex];
+
+			item->Pose.Position.y += y;
+
+			probedRoomNumber = GetCollision(item).RoomNumber;
+			if (probedRoomNumber != item->RoomNumber)
+				ItemNewRoom(stackIndex, probedRoomNumber);
+		}
+	}
+
+	void AddBridgeStack(short itemNumber)
+	{
+		auto* item = &g_Level.Items[itemNumber];
+		auto* pushable = (PushableInfo*)item->Data;
+
+		if (pushable->hasFloorCeiling)
+			TEN::Floordata::AddBridge(itemNumber);
+
+		int stackIndex = g_Level.Items[itemNumber].ItemFlags[1];
+		while (stackIndex != NO_ITEM)
+		{
+			auto* stackItem = &g_Level.Items[stackIndex];
+
+			if (pushable->hasFloorCeiling)
+				TEN::Floordata::AddBridge(stackIndex);
+
+			stackIndex = g_Level.Items[stackIndex].ItemFlags[1];
+		}
+	}
+
+	void RemoveBridgeStack(short itemNumber)
+	{
+		auto* item = &g_Level.Items[itemNumber];
+		auto* pushable = (PushableInfo*)item->Data;
+
+		if (pushable->hasFloorCeiling)
+			TEN::Floordata::RemoveBridge(itemNumber);
+
+		int stackIndex = g_Level.Items[itemNumber].ItemFlags[1];
+		while (stackIndex != NO_ITEM)
+		{
+			auto* stackItem = &g_Level.Items[stackIndex];
+
+			if (pushable->hasFloorCeiling)
+				TEN::Floordata::RemoveBridge(stackIndex);
+
+			stackIndex = g_Level.Items[stackIndex].ItemFlags[1];
+		}
+	}
+
+	void RemoveFromStack(short itemNumber) // unlink pushable from stack if linked
+	{
+		for (int i = 0; i < g_Level.NumItems; i++)
+		{
+			if (i == itemNumber)
+				continue;
+
+			auto* itemBelow = &g_Level.Items[i];
+
+			int objectNumber = itemBelow->ObjectNumber;
+			if (objectNumber >= ID_PUSHABLE_OBJECT1 && objectNumber <= ID_PUSHABLE_OBJECT10)
+			{
+				if (itemBelow->ItemFlags[1] == itemNumber)
+					itemBelow->ItemFlags[1] = NO_ITEM;
 			}
 		}
 	}
 
-	if (stackTop != NO_ITEM)
-		g_Level.Items[stackTop].ItemFlags[1] = itemNumber;
-
-	return stackTop;
-}
-
-int GetStackHeight(ItemInfo* item)
-{
-	auto* pushable = (PushableInfo*)item->Data;
-
-	int height = pushable->height;
-
-	auto* stackItem = item;
-	while (stackItem->ItemFlags[1] != NO_ITEM)
+	int FindStack(short itemNumber)
 	{
-		stackItem = &g_Level.Items[stackItem->ItemFlags[1]];
-		height += pushable->height;
+		int stackTop = NO_ITEM; // index of heighest (Position.y) pushable in stack
+		int stackYmin = CLICK(256); // set starting height
+
+		//Check for pushable directly below current one in same sector
+		for (int i = 0; i < g_Level.NumItems; i++)
+		{
+			if (i == itemNumber)
+				continue;
+
+			auto* itemBelow = &g_Level.Items[i];
+
+			int objectNumber = itemBelow->ObjectNumber;
+			if (objectNumber >= ID_PUSHABLE_OBJECT1 && objectNumber <= ID_PUSHABLE_OBJECT10)
+			{
+				auto* item = &g_Level.Items[itemNumber];
+				int x = item->Pose.Position.x;
+				int y = item->Pose.Position.y;
+				int z = item->Pose.Position.z;
+
+				if (itemBelow->Pose.Position.x == x && itemBelow->Pose.Position.z == z)
+				{
+					int belowY = itemBelow->Pose.Position.y;
+					if (belowY > y && belowY < stackYmin)
+					{
+						// set heighest pushable so far as top of stack
+						stackTop = i;
+						stackYmin = itemBelow->Pose.Position.y;
+					}
+				}
+			}
+		}
+
+		if (stackTop != NO_ITEM)
+			g_Level.Items[stackTop].ItemFlags[1] = itemNumber;
+
+		return stackTop;
 	}
 
-	return height;
-}
-
-bool CheckStackLimit(ItemInfo* item)
-{
-	auto* pushable = (PushableInfo*)item->Data;
-
-	int limit = pushable->stackLimit;
-	
-	int count = 1;
-	auto* stackItem = item;
-	while (stackItem->ItemFlags[1] != NO_ITEM)
+	int GetStackHeight(ItemInfo* item)
 	{
-		stackItem = &g_Level.Items[stackItem->ItemFlags[1]];
-		count++;
+		auto* pushable = (PushableInfo*)item->Data;
 
-		if (count > limit)
-			return false;
+		int height = pushable->height;
+
+		auto* stackItem = item;
+		while (stackItem->ItemFlags[1] != NO_ITEM)
+		{
+			stackItem = &g_Level.Items[stackItem->ItemFlags[1]];
+			height += pushable->height;
+		}
+
+		return height;
 	}
 
-	return true;
-}
-
-std::optional<int> PushableBlockFloor(short itemNumber, int x, int y, int z)
-{
-	const auto& item = g_Level.Items[itemNumber];
-	const auto& pushable = (PushableInfo&)item.Data;
-	auto bboxHeight = GetBridgeItemIntersect(itemNumber, x, y, z, false);
-	
-	if (item.Status != ITEM_INVISIBLE && pushable.hasFloorCeiling && bboxHeight.has_value())
+	bool CheckStackLimit(ItemInfo* item)
 	{
+		auto* pushable = (PushableInfo*)item->Data;
+
+		int limit = pushable->stackLimit;
+	
+		int count = 1;
+		auto* stackItem = item;
+		while (stackItem->ItemFlags[1] != NO_ITEM)
+		{
+			stackItem = &g_Level.Items[stackItem->ItemFlags[1]];
+			count++;
+
+			if (count > limit)
+				return false;
+		}
+
+		return true;
+	}
+
+	std::optional<int> PushableBlockFloor(short itemNumber, int x, int y, int z)
+	{
+		const auto& item = g_Level.Items[itemNumber];
+		const auto& pushable = (PushableInfo&)item.Data;
+		auto bboxHeight = GetBridgeItemIntersect(itemNumber, x, y, z, false);
+	
+		if (item.Status != ITEM_INVISIBLE && pushable.hasFloorCeiling && bboxHeight.has_value())
+		{
+			const auto height = item.Pose.Position.y - (item.TriggerFlags & 0x1F) * CLICK(1);
+			return std::optional{height};
+		}
+		return std::nullopt;
+	}
+
+	std::optional<int> PushableBlockCeiling(short itemNumber, int x, int y, int z)
+	{
+		const auto& item = g_Level.Items[itemNumber];
+		const auto& pushable = (PushableInfo&)item.Data;
+		auto bboxHeight = GetBridgeItemIntersect(itemNumber, x, y, z, true);
+
+		if (item.Status != ITEM_INVISIBLE && pushable.hasFloorCeiling && bboxHeight.has_value())
+			return std::optional{item.Pose.Position.y};
+
+		return std::nullopt;
+	}
+
+	int PushableBlockFloorBorder(short itemNumber)
+	{
+		const auto& item = g_Level.Items[itemNumber];
 		const auto height = item.Pose.Position.y - (item.TriggerFlags & 0x1F) * CLICK(1);
-		return std::optional{height};
+		return height;
 	}
-	return std::nullopt;
-}
 
-std::optional<int> PushableBlockCeiling(short itemNumber, int x, int y, int z)
-{
-	const auto& item = g_Level.Items[itemNumber];
-	const auto& pushable = (PushableInfo&)item.Data;
-	auto bboxHeight = GetBridgeItemIntersect(itemNumber, x, y, z, true);
-
-	if (item.Status != ITEM_INVISIBLE && pushable.hasFloorCeiling && bboxHeight.has_value())
-		return std::optional{item.Pose.Position.y};
-
-	return std::nullopt;
-}
-
-int PushableBlockFloorBorder(short itemNumber)
-{
-	const auto& item = g_Level.Items[itemNumber];
-	const auto height = item.Pose.Position.y - (item.TriggerFlags & 0x1F) * CLICK(1);
-	return height;
-}
-
-int PushableBlockCeilingBorder(short itemNumber)
-{
-	const auto& item = g_Level.Items[itemNumber];
-	return item.Pose.Position.y;
+	int PushableBlockCeilingBorder(short itemNumber)
+	{
+		const auto& item = g_Level.Items[itemNumber];
+		return item.Pose.Position.y;
+	}
 }

--- a/TombEngine/Objects/TR5/Object/tr5_pushableblock.cpp
+++ b/TombEngine/Objects/TR5/Object/tr5_pushableblock.cpp
@@ -442,27 +442,27 @@ void PushableBlockCollision(short itemNumber, ItemInfo* laraItem, CollisionInfo*
 		}
 
 		int quadrant = GetQuadrant(LaraItem->Pose.Orientation.y);
-		bool quadrantDisabled = false;
+		bool isQuadrantDisabled = false;
 		switch (quadrant)
 		{
 		case NORTH:
-			quadrantDisabled = pushable->disableN;
+			isQuadrantDisabled = pushable->disableN;
 			break;
 
 		case EAST:
-			quadrantDisabled = pushable->disableE;
+			isQuadrantDisabled = pushable->disableE;
 			break;
 
 		case SOUTH:
-			quadrantDisabled = pushable->disableS;
+			isQuadrantDisabled = pushable->disableS;
 			break;
 
 		case WEST:
-			quadrantDisabled = pushable->disableW;
+			isQuadrantDisabled = pushable->disableW;
 			break;
 		}
 
-		if (quadrantDisabled)
+		if (isQuadrantDisabled)
 			return;
 
 		if (!CheckStackLimit(pushableItem))
@@ -509,19 +509,30 @@ void PushableBlockCollision(short itemNumber, ItemInfo* laraItem, CollisionInfo*
 		PushableBlockBounds.BoundingBox.Z2 = 0;
 
 		short yOrient = pushableItem->Pose.Orientation.y;
-		pushableItem->Pose.Orientation.y = (laraItem->Pose.Orientation.y + ANGLE(45.0f)) & 0xC000;
+		pushableItem->Pose.Orientation.y = GetQuadrant(laraItem->Pose.Orientation.y) * ANGLE(90.0f);
 
 		if (TestLaraPosition(PushableBlockBounds, pushableItem, laraItem))
 		{
-			int quadrant = int((pushableItem->Pose.Orientation.y / 0x4000) + ((yOrient + 0x2000) / 0x4000));
-			if (quadrant & 1)
-				PushableBlockPos.z = bounds.X1 - CLICK(0.4f);
-			else
+			int quadrant = GetQuadrant(pushableItem->Pose.Orientation.y);
+			switch (quadrant)
+			{
+			case NORTH:
+			case SOUTH:
 				PushableBlockPos.z = bounds.Z1 - CLICK(0.4f);
+				break;
+
+			case EAST:
+			case WEST:
+				PushableBlockPos.z = bounds.X1 - CLICK(0.4f);
+				break;
+
+			default:
+				break;
+			}
 
 			if (pushable->hasFloorCeiling)
 			{					
-				// Don't use auto align function because it interferes with vaulting.
+				// NOTE: Not using auto align function because it interferes with vaulting.
 
 				SetAnimation(laraItem, LA_PUSHABLE_GRAB);
 				laraItem->Pose.Orientation = pushableItem->Pose.Orientation;

--- a/TombEngine/Objects/TR5/Object/tr5_pushableblock.cpp
+++ b/TombEngine/Objects/TR5/Object/tr5_pushableblock.cpp
@@ -180,7 +180,7 @@ void PushableBlockControl(short itemNumber)
 			MoveStackY(itemNumber, relY);
 			AddBridgeStack(itemNumber);
 
-			// If fallen on top of existing pushabl, don't test triggers.
+			// If fallen on top of existing pushable, don't test triggers.
 			if (FindStack(itemNumber) == NO_ITEM)
 				TestTriggers(item, true, item->Flags & IFLAG_ACTIVATION_MASK);
 			

--- a/TombEngine/Objects/TR5/Object/tr5_pushableblock.cpp
+++ b/TombEngine/Objects/TR5/Object/tr5_pushableblock.cpp
@@ -18,516 +18,524 @@
 using namespace TEN::Floordata;
 using namespace TEN::Input;
 
-namespace TEN::Entities::Generic
+constexpr auto PUSHABLE_FALL_VELOCITY_MAX	 = BLOCK(1 / 8.0f);
+constexpr auto PUSHABLE_FALL_RUMBLE_VELOCITY = 96.0f;
+
+// TODO: Derive from anim data.
+constexpr auto PUSHABLE_BOX_OFFSET_PUSH = 1108 - BLOCK(1);
+constexpr auto PUSHABLE_BOX_OFFSET_PULL = BLOCK(1) - 944;
+
+static auto PushableBlockPos = Vector3i::Zero;
+ObjectCollisionBounds PushableBlockBounds = 
 {
-	constexpr auto PUSHABLE_FALL_VELOCITY_MAX	 = BLOCK(1 / 8.0f);
-	constexpr auto PUSHABLE_FALL_RUMBLE_VELOCITY = 96.0f;
+	GameBoundingBox(
+		0, 0,
+		-CLICK(0.25f), 0,
+		0, 0),
+	std::pair(
+		EulerAngles(ANGLE(-10.0f), -LARA_GRAB_THRESHOLD, ANGLE(-10.0f)),
+		EulerAngles(ANGLE(10.0f), LARA_GRAB_THRESHOLD, ANGLE(10.0f)))
+};
 
-	// TODO: Derive from anim data.
-	constexpr auto PUSHABLE_BOX_OFFSET_PUSH = 1108 - BLOCK(1);
-	constexpr auto PUSHABLE_BOX_OFFSET_PULL = BLOCK(1) - 944;
+PushableInfo* GetPushableInfo(ItemInfo* item)
+{
+	return (PushableInfo*)item->Data;
+}
 
-	static auto PushableBlockPos = Vector3i::Zero;
-	ObjectCollisionBounds PushableBlockBounds = 
+void InitialisePushableBlock(short itemNumber)
+{
+	auto* item = &g_Level.Items[itemNumber];
+	item->Data = PushableInfo();
+	auto* pushable = GetPushableInfo(item);
+
+	item->ItemFlags[1] = NO_ITEM; // NOTE: ItemFlags[1] stores linked index.
+
+	pushable->moveX = item->Pose.Position.x;
+	pushable->moveZ = item->Pose.Position.z;
+
+	// TODO: Attributes.
+	pushable->stackLimit = 3;
+	pushable->gravity = 8;
+	pushable->weight = 100;
+	pushable->loopSound = SFX_TR4_PUSHABLE_SOUND;
+	pushable->stopSound = SFX_TR4_PUSH_BLOCK_END;
+	pushable->fallSound = SFX_TR4_BOULDER_FALL;
+
+	// Read OCB flags.
+	int ocb = item->TriggerFlags;
+
+	pushable->canFall = ocb & 0x20;
+	pushable->disablePull = ocb & 0x80;
+	pushable->disablePush = ocb & 0x100;
+	pushable->disableW = pushable->disableE = ocb & 0x200;
+	pushable->disableN = pushable->disableS = ocb & 0x400;
+
+	// TODO: Must be a better way.
+	pushable->climb = 0;
+	/*
+	pushable->climb |= (OCB & 0x800) ? CLIMB_WEST : 0;
+	pushable->climb |= (OCB & 0x1000) ? CLIMB_NORTH : 0;
+	pushable->climb |= (OCB & 0x2000) ? CLIMB_EAST : 0;
+	pushable->climb |= (OCB & 0x4000) ? CLIMB_SOUTH : 0;
+	*/
+	pushable->hasFloorCeiling = false;
+
+	int height = 0;
+	if (ocb & 0x40 && (ocb & 0x1F) >= 2)
 	{
-		GameBoundingBox(
-			0, 0,
-			-CLICK(0.25f), 0,
-			0, 0),
-		std::pair(
-			EulerAngles(ANGLE(-10.0f), -LARA_GRAB_THRESHOLD, ANGLE(-10.0f)),
-			EulerAngles(ANGLE(10.0f), LARA_GRAB_THRESHOLD, ANGLE(10.0f)))
-	};
-
-	PushableInfo& GetPushableInfo(ItemInfo& item)
+		pushable->hasFloorCeiling = true;
+		TEN::Floordata::AddBridge(itemNumber);
+		height = (ocb & 0x1F) * CLICK(1);
+	}
+	else
 	{
-		return (PushableInfo&)item.Data;
+		height = -GameBoundingBox(item).Y1;
 	}
 
-	void InitialisePushableBlock(short itemNumber)
+	pushable->height = height;
+
+	// Check for stack formation.
+	FindStack(itemNumber);
+}
+
+void ClearMovableBlockSplitters(const Vector3i& pos, short roomNumber)
+{
+	FloorInfo* floor = GetFloor(pos.x, pos.y, pos.z, &roomNumber);
+	if (floor->Box == NO_BOX)
+		return;
+
+	g_Level.Boxes[floor->Box].flags &= ~BLOCKED;
+	int height = g_Level.Boxes[floor->Box].height;
+	int baseRoomNumber = roomNumber;
+	
+	floor = GetFloor(pos.x + BLOCK(1), pos.y, pos.z, &roomNumber);
+	if (floor->Box != NO_BOX)
 	{
-		auto& item = g_Level.Items[itemNumber];
-		item.Data = PushableInfo();
-		auto& pushable = GetPushableInfo(item);
+		if (g_Level.Boxes[floor->Box].height == height && (g_Level.Boxes[floor->Box].flags & BLOCKABLE) && (g_Level.Boxes[floor->Box].flags & BLOCKED))
+			ClearMovableBlockSplitters(Vector3i(pos.x + BLOCK(1), pos.y, pos.z), roomNumber);
+	}
 
-		item.ItemFlags[1] = NO_ITEM; // NOTE: ItemFlags[1] stores linked index.
+	roomNumber = baseRoomNumber;
+	floor = GetFloor(pos.x - BLOCK(1), pos.y, pos.z, &roomNumber);
+	if (floor->Box != NO_BOX)
+	{
+		if (g_Level.Boxes[floor->Box].height == height && (g_Level.Boxes[floor->Box].flags & BLOCKABLE) && (g_Level.Boxes[floor->Box].flags & BLOCKED))
+			ClearMovableBlockSplitters(Vector3i(pos.x - BLOCK(1), pos.y, pos.z), roomNumber);
+	}
 
-		pushable.moveX = item.Pose.Position.x;
-		pushable.moveZ = item.Pose.Position.z;
+	roomNumber = baseRoomNumber;
+	floor = GetFloor(pos.x, pos.y, pos.z + BLOCK(1), &roomNumber);
+	if (floor->Box != NO_BOX)
+	{
+		if (g_Level.Boxes[floor->Box].height == height && (g_Level.Boxes[floor->Box].flags & BLOCKABLE) && (g_Level.Boxes[floor->Box].flags & BLOCKED))
+			ClearMovableBlockSplitters(Vector3i(pos.x, pos.y, pos.z + BLOCK(1)), roomNumber);
+	}
 
-		// TODO: Attributes.
-		pushable.stackLimit = 3;
-		pushable.gravity = 8;
-		pushable.weight = 100;
-		pushable.loopSound = SFX_TR4_PUSHABLE_SOUND;
-		pushable.stopSound = SFX_TR4_PUSH_BLOCK_END;
-		pushable.fallSound = SFX_TR4_BOULDER_FALL;
+	roomNumber = baseRoomNumber;
+	floor = GetFloor(pos.x, pos.y, pos.z - BLOCK(1), &roomNumber);
+	if (floor->Box != NO_BOX)
+	{
+		if (g_Level.Boxes[floor->Box].height == height && (g_Level.Boxes[floor->Box].flags & BLOCKABLE) && (g_Level.Boxes[floor->Box].flags & BLOCKED))
+			ClearMovableBlockSplitters(Vector3i(pos.x, pos.y, pos.z - BLOCK(1)), roomNumber);
+	}
+}
 
-		// Read OCB flags.
-		int ocb = item.TriggerFlags;
+void PushableBlockControl(short itemNumber)
+{
+	auto* item = &g_Level.Items[itemNumber];
+	auto* pushable = GetPushableInfo(item);
 
-		pushable.canFall = ocb & 0x20;
-		pushable.disablePull = ocb & 0x80;
-		pushable.disablePush = ocb & 0x100;
-		pushable.disableW = pushable.disableE = ocb & 0x200;
-		pushable.disableN = pushable.disableS = ocb & 0x400;
+	Lara.InteractedItem = itemNumber;
 
-		// TODO: Must be a better way.
-		pushable.climb = 0;
-		/*
-		pushable.climb |= (OCB & 0x800) ? CLIMB_WEST : 0;
-		pushable.climb |= (OCB & 0x1000) ? CLIMB_NORTH : 0;
-		pushable.climb |= (OCB & 0x2000) ? CLIMB_EAST : 0;
-		pushable.climb |= (OCB & 0x4000) ? CLIMB_SOUTH : 0;
-		*/
-		pushable.hasFloorCeiling = false;
+	auto pos = Vector3i::Zero;
 
-		int height = 0;
-		if (ocb & 0x40 && (ocb & 0x1F) >= 2)
+	int quadrant = GetQuadrant(LaraItem->Pose.Orientation.y);
+
+	int x, z;
+	int blockHeight = GetStackHeight(item);
+
+	// Control block falling.
+	if (item->Animation.IsAirborne)
+	{
+		int floorHeight = GetCollision(item->Pose.Position.x, item->Pose.Position.y + 10, item->Pose.Position.z, item->RoomNumber).Position.Floor;
+
+		if (item->Pose.Position.y < (floorHeight - item->Animation.Velocity.y))
 		{
-			pushable.hasFloorCeiling = true;
-			TEN::Floordata::AddBridge(itemNumber);
-			height = (ocb & 0x1F) * CLICK(1);
+			if ((item->Animation.Velocity.y + pushable->gravity) < PUSHABLE_FALL_VELOCITY_MAX)
+				item->Animation.Velocity.y += pushable->gravity;
+			else
+				item->Animation.Velocity.y++;
+			item->Pose.Position.y += item->Animation.Velocity.y;
+
+			MoveStackY(itemNumber, item->Animation.Velocity.y);
 		}
 		else
 		{
-			height = -GameBoundingBox(&item).Y1;
-		}
+			item->Animation.IsAirborne = false;
+			int relY = floorHeight - item->Pose.Position.y;
+			item->Pose.Position.y = floorHeight;
 
-		pushable.height = height;
+			if (item->Animation.Velocity.y >= PUSHABLE_FALL_RUMBLE_VELOCITY)
+				FloorShake(item);
 
-		// Check for stack formation.
-		FindStack(itemNumber);
-	}
+			item->Animation.Velocity.y = 0.0f;
+			SoundEffect(pushable->fallSound, &item->Pose, SoundEnvironment::Always);
 
-	void ClearMovableBlockSplitters(const Vector3i& pos, short roomNumber)
-	{
-		FloorInfo* floor = GetFloor(pos.x, pos.y, pos.z, &roomNumber);
-		if (floor->Box == NO_BOX)
-			return;
+			MoveStackY(itemNumber, relY);
+			AddBridgeStack(itemNumber);
 
-		g_Level.Boxes[floor->Box].flags &= ~BLOCKED;
-		int height = g_Level.Boxes[floor->Box].height;
-		int baseRoomNumber = roomNumber;
-	
-		floor = GetFloor(pos.x + BLOCK(1), pos.y, pos.z, &roomNumber);
-		if (floor->Box != NO_BOX)
-		{
-			if (g_Level.Boxes[floor->Box].height == height && (g_Level.Boxes[floor->Box].flags & BLOCKABLE) && (g_Level.Boxes[floor->Box].flags & BLOCKED))
-				ClearMovableBlockSplitters(Vector3i(pos.x + BLOCK(1), pos.y, pos.z), roomNumber);
-		}
-
-		roomNumber = baseRoomNumber;
-		floor = GetFloor(pos.x - BLOCK(1), pos.y, pos.z, &roomNumber);
-		if (floor->Box != NO_BOX)
-		{
-			if (g_Level.Boxes[floor->Box].height == height && (g_Level.Boxes[floor->Box].flags & BLOCKABLE) && (g_Level.Boxes[floor->Box].flags & BLOCKED))
-				ClearMovableBlockSplitters(Vector3i(pos.x - BLOCK(1), pos.y, pos.z), roomNumber);
-		}
-
-		roomNumber = baseRoomNumber;
-		floor = GetFloor(pos.x, pos.y, pos.z + BLOCK(1), &roomNumber);
-		if (floor->Box != NO_BOX)
-		{
-			if (g_Level.Boxes[floor->Box].height == height && (g_Level.Boxes[floor->Box].flags & BLOCKABLE) && (g_Level.Boxes[floor->Box].flags & BLOCKED))
-				ClearMovableBlockSplitters(Vector3i(pos.x, pos.y, pos.z + BLOCK(1)), roomNumber);
-		}
-
-		roomNumber = baseRoomNumber;
-		floor = GetFloor(pos.x, pos.y, pos.z - BLOCK(1), &roomNumber);
-		if (floor->Box != NO_BOX)
-		{
-			if (g_Level.Boxes[floor->Box].height == height && (g_Level.Boxes[floor->Box].flags & BLOCKABLE) && (g_Level.Boxes[floor->Box].flags & BLOCKED))
-				ClearMovableBlockSplitters(Vector3i(pos.x, pos.y, pos.z - BLOCK(1)), roomNumber);
-		}
-	}
-
-	void PushableBlockControl(short itemNumber)
-	{
-		auto* item = &g_Level.Items[itemNumber];
-		auto& pushable = GetPushableInfo(*item);
-
-		Lara.InteractedItem = itemNumber;
-
-		auto pos = Vector3i::Zero;
-
-		int quadrant = GetQuadrant(LaraItem->Pose.Orientation.y);
-
-		int x, z;
-		int blockHeight = GetStackHeight(*item);
-
-		// Control block falling.
-		if (item->Animation.IsAirborne)
-		{
-			int floorHeight = GetCollision(item->Pose.Position.x, item->Pose.Position.y + 10, item->Pose.Position.z, item->RoomNumber).Position.Floor;
-
-			if (item->Pose.Position.y < (floorHeight - item->Animation.Velocity.y))
-			{
-				if ((item->Animation.Velocity.y + pushable.gravity) < PUSHABLE_FALL_VELOCITY_MAX)
-					item->Animation.Velocity.y += pushable.gravity;
-				else
-					item->Animation.Velocity.y++;
-				item->Pose.Position.y += item->Animation.Velocity.y;
-
-				MoveStackY(itemNumber, item->Animation.Velocity.y);
-			}
-			else
-			{
-				item->Animation.IsAirborne = false;
-				int relY = floorHeight - item->Pose.Position.y;
-				item->Pose.Position.y = floorHeight;
-
-				if (item->Animation.Velocity.y >= PUSHABLE_FALL_RUMBLE_VELOCITY)
-					FloorShake(item);
-
-				item->Animation.Velocity.y = 0.0f;
-				SoundEffect(pushable.fallSound, &item->Pose, SoundEnvironment::Always);
-
-				MoveStackY(itemNumber, relY);
-				AddBridgeStack(itemNumber);
-
-				// If fallen on top of existing pushabl, don't test triggers.
-				if (FindStack(itemNumber) == NO_ITEM)
-					TestTriggers(item, true, item->Flags & IFLAG_ACTIVATION_MASK);
-			
-				RemoveActiveItem(itemNumber);
-				item->Status = ITEM_NOT_ACTIVE;
-
-				if (pushable.hasFloorCeiling)
-				{
-					//AlterFloorHeight(item, -((item->triggerFlags - 64) * 256));
-					AdjustStopperFlag(item, item->ItemFlags[0] + 0x8000, false);
-				}
-			}
-
-			return;
-		}
-
-		// Move pushable based on player bounds.Z2.
-		int displaceBox = GameBoundingBox(LaraItem).Z2;
-		auto prevPos = item->Pose.Position;
-
-		switch (LaraItem->Animation.AnimNumber)
-		{
-		case LA_PUSHABLE_PUSH:
-			displaceBox -= PUSHABLE_BOX_OFFSET_PUSH;
-
-			if (LaraItem->Animation.FrameNumber == g_Level.Anims[LaraItem->Animation.AnimNumber].frameBase)
-			{
-				RemoveFromStack(itemNumber);
-				RemoveBridgeStack(itemNumber);
-			}
-
-			switch (quadrant) 
-			{
-			case NORTH:
-				z = pushable.moveZ + displaceBox;
-
-				if (abs(item->Pose.Position.z - z) < BLOCK(0.5f) && item->Pose.Position.z < z)
-					item->Pose.Position.z = z;
-				
-				break;
-
-			case EAST:
-				x = pushable.moveX + displaceBox;
-
-				if (abs(item->Pose.Position.x - x) < BLOCK(0.5f) && item->Pose.Position.x < x)
-					item->Pose.Position.x = x;
-
-				break;
-
-			case SOUTH:
-				z = pushable.moveZ - displaceBox;
-
-				if (abs(item->Pose.Position.z - z) < BLOCK(0.5f) && item->Pose.Position.z > z)
-					item->Pose.Position.z = z;
-				
-				break;
-
-			case WEST:
-				x = pushable.moveX - displaceBox;
-
-				if (abs(item->Pose.Position.x - x) < BLOCK(0.5f) && item->Pose.Position.x > x)
-					item->Pose.Position.x = x;
-				
-				break;
-
-			default:
-				break;
-			}
-
-			MoveStackXZ(itemNumber);
-
-			if (LaraItem->Animation.FrameNumber == g_Level.Anims[LaraItem->Animation.AnimNumber].frameEnd - 1)
-			{
-				// Check if pushable is about to fall.
-				if (pushable.canFall)
-				{
-					int floorHeight = GetCollision(item->Pose.Position.x, item->Pose.Position.y + 10, item->Pose.Position.z, item->RoomNumber).Position.Floor;
-					if (floorHeight > item->Pose.Position.y)
-					{
-						item->Pose.Position.x = item->Pose.Position.x & 0xFFFFFE00 | 0x200;
-						item->Pose.Position.z = item->Pose.Position.z & 0xFFFFFE00 | 0x200;
-						MoveStackXZ(itemNumber);
-						LaraItem->Animation.TargetState = LS_IDLE;
-
-						pushable.MovementState = PushableMovementState::None;
-
-						item->Animation.IsAirborne = true;
-						return;
-					}
-				}
-
-				if (IsHeld(In::Action))
-				{
-					if (!TestBlockPush(item, blockHeight, quadrant))
-					{
-						LaraItem->Animation.TargetState = LS_IDLE;
-					}
-					else
-					{
-						item->Pose.Position.x = pushable.moveX = item->Pose.Position.x & 0xFFFFFE00 | 0x200;
-						item->Pose.Position.z = pushable.moveZ = item->Pose.Position.z & 0xFFFFFE00 | 0x200;
-						TestTriggers(item, true, item->Flags & IFLAG_ACTIVATION_MASK);
-					}
-				}
-				else
-				{
-					LaraItem->Animation.TargetState = LS_IDLE;
-				}
-			}
-
-			break;
-
-		case LA_PUSHABLE_PULL:
-			displaceBox -= PUSHABLE_BOX_OFFSET_PULL;
-
-			if (LaraItem->Animation.FrameNumber == g_Level.Anims[LaraItem->Animation.AnimNumber].frameBase)
-			{
-				RemoveFromStack(itemNumber);
-				RemoveBridgeStack(itemNumber);
-			}
-
-			switch (quadrant)
-			{
-			case NORTH:
-				z = pushable.moveZ + displaceBox;
-				if (abs(item->Pose.Position.z - z) < BLOCK(0.5f) && item->Pose.Position.z > z)
-					item->Pose.Position.z = z;
-
-				break;
-
-			case EAST:
-				x = pushable.moveX + displaceBox;
-				if (abs(item->Pose.Position.x - x) < BLOCK(0.5f) && item->Pose.Position.x > x)
-					item->Pose.Position.x = x;
-
-				break;
-
-			case SOUTH:
-				z = pushable.moveZ - displaceBox;
-				if (abs(item->Pose.Position.z - z) < BLOCK(0.5f) && item->Pose.Position.z < z)
-					item->Pose.Position.z = z;
-
-				break;
-
-			case WEST:
-				x = pushable.moveX - displaceBox;
-				if (abs(item->Pose.Position.x - x) < BLOCK(0.5f) && item->Pose.Position.x < x)
-					item->Pose.Position.x = x;
-
-				break;
-
-			default:
-				break;
-			}
-
-			MoveStackXZ(itemNumber);
-
-			if (LaraItem->Animation.FrameNumber == g_Level.Anims[LaraItem->Animation.AnimNumber].frameEnd - 1)
-			{
-				if (IsHeld(In::Action))
-				{
-					if (!TestBlockPull(item, blockHeight, quadrant))
-					{
-						LaraItem->Animation.TargetState = LS_IDLE;
-					}
-					else
-					{
-						item->Pose.Position.x = pushable.moveX = item->Pose.Position.x & 0xFFFFFE00 | 0x200;
-						item->Pose.Position.z = pushable.moveZ = item->Pose.Position.z & 0xFFFFFE00 | 0x200;
-						TestTriggers(item, true, item->Flags & IFLAG_ACTIVATION_MASK);
-					}
-				}
-				else
-				{
-					LaraItem->Animation.TargetState = LS_IDLE;
-				}
-			}
-
-			break;
-
-		case LA_PUSHABLE_GRAB:
-		case LA_PUSHABLE_RELEASE:
-		case LA_PUSHABLE_PUSH_TO_STAND:
-		case LA_PUSHABLE_PULL_TO_STAND:
-			break;
-
-		default:
-			if (item->Status == ITEM_ACTIVE)
-			{
-				item->Pose.Position.x = item->Pose.Position.x & 0xFFFFFE00 | 0x200;
-				item->Pose.Position.z = item->Pose.Position.z & 0xFFFFFE00 | 0x200;
-
-				MoveStackXZ(itemNumber);
-				FindStack(itemNumber);
-				AddBridgeStack(itemNumber);
-
+			// If fallen on top of existing pushabl, don't test triggers.
+			if (FindStack(itemNumber) == NO_ITEM)
 				TestTriggers(item, true, item->Flags & IFLAG_ACTIVATION_MASK);
-
-				RemoveActiveItem(itemNumber);
-				item->Status = ITEM_NOT_ACTIVE;
-
-				if (pushable.hasFloorCeiling)
-				{
-					//AlterFloorHeight(item, -((item->triggerFlags - 64) * 256));
-					AdjustStopperFlag(item, item->ItemFlags[0] + 0x8000, false);
-				}
-			}
-
-			break;
-		}
-
-		// Set pushable movement state.
-		float distance = Vector3i::Distance(item->Pose.Position, prevPos);
-		if (distance > 0.0f)
-			PushLoop(*item);
-		else
-			PushEnd(*item);
-
-		// Do sound effects.
-		if (pushable.MovementState == PushableMovementState::Moving)
-		{
-			SoundEffect(pushable.loopSound, &item->Pose, SoundEnvironment::Always);
-		}
-		else if (pushable.MovementState == PushableMovementState::Stopping)
-		{
-			pushable.MovementState = PushableMovementState::None;
-			SoundEffect(pushable.stopSound, &item->Pose, SoundEnvironment::Always);
-		}
-	}
-
-	void PushableBlockCollision(short itemNumber, ItemInfo* laraItem, CollisionInfo* coll)
-	{
-		auto* pushableItem = &g_Level.Items[itemNumber];
-		auto* pushable = (PushableInfo*)pushableItem->Data;
-		auto* lara = GetLaraInfo(laraItem);
-
-		int blockHeight = GetStackHeight(*pushableItem);
-	
-		if ((!IsHeld(In::Action) ||
-			laraItem->Animation.ActiveState != LS_IDLE ||
-			laraItem->Animation.AnimNumber != LA_STAND_IDLE ||
-			laraItem->Animation.IsAirborne ||
-			lara->Control.HandStatus != HandStatus::Free ||
-			pushableItem->Status == ITEM_INVISIBLE ||
-			pushableItem->TriggerFlags < 0) &&
-			(!lara->Control.IsMoving || lara->InteractedItem != itemNumber))
-		{
-			if (laraItem->Animation.ActiveState != LS_PUSHABLE_GRAB ||
-				!TestLastFrame(laraItem, LA_PUSHABLE_GRAB) ||
-				lara->NextCornerPos.Position.x != itemNumber)
-			{
-				if (!pushable->hasFloorCeiling)
-					ObjectCollision(itemNumber, laraItem, coll);
-
-				return;
-			}
-
-			int quadrant = GetQuadrant(LaraItem->Pose.Orientation.y);
-			bool quadrantDisabled = false;
-			switch (quadrant)
-			{
-			case NORTH:
-				quadrantDisabled = pushable->disableN;
-				break;
-
-			case EAST:
-				quadrantDisabled = pushable->disableE;
-				break;
-
-			case SOUTH:
-				quadrantDisabled = pushable->disableS;
-				break;
-
-			case WEST:
-				quadrantDisabled = pushable->disableW;
-				break;
-			}
-
-			if (quadrantDisabled)
-				return;
-
-			if (!CheckStackLimit(*pushableItem))
-				return;
-
-			if (IsHeld(In::Forward))
-			{
-				if (!TestBlockPush(pushableItem, blockHeight, quadrant) || pushable->disablePush)
-					return;
-
-				laraItem->Animation.TargetState = LS_PUSHABLE_PUSH;
-			}
-			else if (IsHeld(In::Back))
-			{
-				if (!TestBlockPull(pushableItem, blockHeight, quadrant) || pushable->disablePull)
-					return;
-
-				laraItem->Animation.TargetState = LS_PUSHABLE_PULL;
-			}
-			else
-			{
-				return;
-			}
-
-			pushableItem->Status = ITEM_ACTIVE;
-			AddActiveItem(itemNumber);
-			ResetLaraFlex(laraItem);
-		
-			pushable->moveX = pushableItem->Pose.Position.x;
-			pushable->moveZ = pushableItem->Pose.Position.z;
+			
+			RemoveActiveItem(itemNumber);
+			item->Status = ITEM_NOT_ACTIVE;
 
 			if (pushable->hasFloorCeiling)
 			{
-				//AlterFloorHeight(item, ((item->triggerFlags - 64) * 256));
-				AdjustStopperFlag(pushableItem, pushableItem->ItemFlags[0], false);
+				//AlterFloorHeight(item, -((item->triggerFlags - 64) * 256));
+				AdjustStopperFlag(item, item->ItemFlags[0] + 0x8000, false);
 			}
+		}
+
+		return;
+	}
+
+	// Move pushable based on player bounds.Z2.
+	int displaceBox = GameBoundingBox(LaraItem).Z2;
+	auto prevPos = item->Pose.Position;
+
+	switch (LaraItem->Animation.AnimNumber)
+	{
+	case LA_PUSHABLE_PUSH:
+		displaceBox -= PUSHABLE_BOX_OFFSET_PUSH;
+
+		if (LaraItem->Animation.FrameNumber == g_Level.Anims[LaraItem->Animation.AnimNumber].frameBase)
+		{
+			RemoveFromStack(itemNumber);
+			RemoveBridgeStack(itemNumber);
+		}
+
+		switch (quadrant) 
+		{
+		case NORTH:
+			z = pushable->moveZ + displaceBox;
+
+			if (abs(item->Pose.Position.z - z) < BLOCK(0.5f) && item->Pose.Position.z < z)
+				item->Pose.Position.z = z;
+				
+			break;
+
+		case EAST:
+			x = pushable->moveX + displaceBox;
+
+			if (abs(item->Pose.Position.x - x) < BLOCK(0.5f) && item->Pose.Position.x < x)
+				item->Pose.Position.x = x;
+
+			break;
+
+		case SOUTH:
+			z = pushable->moveZ - displaceBox;
+
+			if (abs(item->Pose.Position.z - z) < BLOCK(0.5f) && item->Pose.Position.z > z)
+				item->Pose.Position.z = z;
+				
+			break;
+
+		case WEST:
+			x = pushable->moveX - displaceBox;
+
+			if (abs(item->Pose.Position.x - x) < BLOCK(0.5f) && item->Pose.Position.x > x)
+				item->Pose.Position.x = x;
+				
+			break;
+
+		default:
+			break;
+		}
+
+		MoveStackXZ(itemNumber);
+
+		if (LaraItem->Animation.FrameNumber == g_Level.Anims[LaraItem->Animation.AnimNumber].frameEnd - 1)
+		{
+			// Check if pushable is about to fall.
+			if (pushable->canFall)
+			{
+				int floorHeight = GetCollision(item->Pose.Position.x, item->Pose.Position.y + 10, item->Pose.Position.z, item->RoomNumber).Position.Floor;
+				if (floorHeight > item->Pose.Position.y)
+				{
+					item->Pose.Position.x = item->Pose.Position.x & 0xFFFFFE00 | 0x200;
+					item->Pose.Position.z = item->Pose.Position.z & 0xFFFFFE00 | 0x200;
+					MoveStackXZ(itemNumber);
+					LaraItem->Animation.TargetState = LS_IDLE;
+
+					pushable->MovementState = PushableMovementState::None;
+
+					item->Animation.IsAirborne = true;
+					return;
+				}
+			}
+
+			if (IsHeld(In::Action))
+			{
+				if (!TestBlockPush(item, blockHeight, quadrant))
+				{
+					LaraItem->Animation.TargetState = LS_IDLE;
+				}
+				else
+				{
+					item->Pose.Position.x = pushable->moveX = item->Pose.Position.x & 0xFFFFFE00 | 0x200;
+					item->Pose.Position.z = pushable->moveZ = item->Pose.Position.z & 0xFFFFFE00 | 0x200;
+					TestTriggers(item, true, item->Flags & IFLAG_ACTIVATION_MASK);
+				}
+			}
+			else
+			{
+				LaraItem->Animation.TargetState = LS_IDLE;
+			}
+		}
+
+		break;
+
+	case LA_PUSHABLE_PULL:
+		displaceBox -= PUSHABLE_BOX_OFFSET_PULL;
+
+		if (LaraItem->Animation.FrameNumber == g_Level.Anims[LaraItem->Animation.AnimNumber].frameBase)
+		{
+			RemoveFromStack(itemNumber);
+			RemoveBridgeStack(itemNumber);
+		}
+
+		switch (quadrant)
+		{
+		case NORTH:
+			z = pushable->moveZ + displaceBox;
+			if (abs(item->Pose.Position.z - z) < BLOCK(0.5f) && item->Pose.Position.z > z)
+				item->Pose.Position.z = z;
+
+			break;
+
+		case EAST:
+			x = pushable->moveX + displaceBox;
+			if (abs(item->Pose.Position.x - x) < BLOCK(0.5f) && item->Pose.Position.x > x)
+				item->Pose.Position.x = x;
+
+			break;
+
+		case SOUTH:
+			z = pushable->moveZ - displaceBox;
+			if (abs(item->Pose.Position.z - z) < BLOCK(0.5f) && item->Pose.Position.z < z)
+				item->Pose.Position.z = z;
+
+			break;
+
+		case WEST:
+			x = pushable->moveX - displaceBox;
+			if (abs(item->Pose.Position.x - x) < BLOCK(0.5f) && item->Pose.Position.x < x)
+				item->Pose.Position.x = x;
+
+			break;
+
+		default:
+			break;
+		}
+
+		MoveStackXZ(itemNumber);
+
+		if (LaraItem->Animation.FrameNumber == g_Level.Anims[LaraItem->Animation.AnimNumber].frameEnd - 1)
+		{
+			if (IsHeld(In::Action))
+			{
+				if (!TestBlockPull(item, blockHeight, quadrant))
+				{
+					LaraItem->Animation.TargetState = LS_IDLE;
+				}
+				else
+				{
+					item->Pose.Position.x = pushable->moveX = item->Pose.Position.x & 0xFFFFFE00 | 0x200;
+					item->Pose.Position.z = pushable->moveZ = item->Pose.Position.z & 0xFFFFFE00 | 0x200;
+					TestTriggers(item, true, item->Flags & IFLAG_ACTIVATION_MASK);
+				}
+			}
+			else
+			{
+				LaraItem->Animation.TargetState = LS_IDLE;
+			}
+		}
+
+		break;
+
+	case LA_PUSHABLE_GRAB:
+	case LA_PUSHABLE_RELEASE:
+	case LA_PUSHABLE_PUSH_TO_STAND:
+	case LA_PUSHABLE_PULL_TO_STAND:
+		break;
+
+	default:
+		if (item->Status == ITEM_ACTIVE)
+		{
+			item->Pose.Position.x = item->Pose.Position.x & 0xFFFFFE00 | 0x200;
+			item->Pose.Position.z = item->Pose.Position.z & 0xFFFFFE00 | 0x200;
+
+			MoveStackXZ(itemNumber);
+			FindStack(itemNumber);
+			AddBridgeStack(itemNumber);
+
+			TestTriggers(item, true, item->Flags & IFLAG_ACTIVATION_MASK);
+
+			RemoveActiveItem(itemNumber);
+			item->Status = ITEM_NOT_ACTIVE;
+
+			if (pushable->hasFloorCeiling)
+			{
+				//AlterFloorHeight(item, -((item->triggerFlags - 64) * 256));
+				AdjustStopperFlag(item, item->ItemFlags[0] + 0x8000, false);
+			}
+		}
+
+		break;
+	}
+
+	// Set pushable movement state.
+	float distance = Vector3i::Distance(item->Pose.Position, prevPos);
+	if (distance > 0.0f)
+		PushLoop(item);
+	else
+		PushEnd(item);
+
+	// Do sound effects.
+	if (pushable->MovementState == PushableMovementState::Moving)
+	{
+		SoundEffect(pushable->loopSound, &item->Pose, SoundEnvironment::Always);
+	}
+	else if (pushable->MovementState == PushableMovementState::Stopping)
+	{
+		pushable->MovementState = PushableMovementState::None;
+		SoundEffect(pushable->stopSound, &item->Pose, SoundEnvironment::Always);
+	}
+}
+
+void PushableBlockCollision(short itemNumber, ItemInfo* laraItem, CollisionInfo* coll)
+{
+	auto* pushableItem = &g_Level.Items[itemNumber];
+	auto* pushable = GetPushableInfo(pushableItem);
+	auto* lara = GetLaraInfo(laraItem);
+
+	int blockHeight = GetStackHeight(pushableItem);
+	
+	if ((!IsHeld(In::Action) ||
+		laraItem->Animation.ActiveState != LS_IDLE ||
+		laraItem->Animation.AnimNumber != LA_STAND_IDLE ||
+		laraItem->Animation.IsAirborne ||
+		lara->Control.HandStatus != HandStatus::Free ||
+		pushableItem->Status == ITEM_INVISIBLE ||
+		pushableItem->TriggerFlags < 0) &&
+		(!lara->Control.IsMoving || lara->InteractedItem != itemNumber))
+	{
+		if (laraItem->Animation.ActiveState != LS_PUSHABLE_GRAB ||
+			!TestLastFrame(laraItem, LA_PUSHABLE_GRAB) ||
+			lara->NextCornerPos.Position.x != itemNumber)
+		{
+			if (!pushable->hasFloorCeiling)
+				ObjectCollision(itemNumber, laraItem, coll);
+
+			return;
+		}
+
+		int quadrant = GetQuadrant(LaraItem->Pose.Orientation.y);
+		bool quadrantDisabled = false;
+		switch (quadrant)
+		{
+		case NORTH:
+			quadrantDisabled = pushable->disableN;
+			break;
+
+		case EAST:
+			quadrantDisabled = pushable->disableE;
+			break;
+
+		case SOUTH:
+			quadrantDisabled = pushable->disableS;
+			break;
+
+		case WEST:
+			quadrantDisabled = pushable->disableW;
+			break;
+		}
+
+		if (quadrantDisabled)
+			return;
+
+		if (!CheckStackLimit(pushableItem))
+			return;
+
+		if (IsHeld(In::Forward))
+		{
+			if (!TestBlockPush(pushableItem, blockHeight, quadrant) || pushable->disablePush)
+				return;
+
+			laraItem->Animation.TargetState = LS_PUSHABLE_PUSH;
+		}
+		else if (IsHeld(In::Back))
+		{
+			if (!TestBlockPull(pushableItem, blockHeight, quadrant) || pushable->disablePull)
+				return;
+
+			laraItem->Animation.TargetState = LS_PUSHABLE_PULL;
 		}
 		else
 		{
-			auto bounds = GameBoundingBox(pushableItem);
-			PushableBlockBounds.BoundingBox.X1 = (bounds.X1 / 2) - 100;
-			PushableBlockBounds.BoundingBox.X2 = (bounds.X2 / 2) + 100;
-			PushableBlockBounds.BoundingBox.Z1 = bounds.Z1 - 200;
-			PushableBlockBounds.BoundingBox.Z2 = 0;
+			return;
+		}
 
-			short yOrient = pushableItem->Pose.Orientation.y;
-			pushableItem->Pose.Orientation.y = (laraItem->Pose.Orientation.y + ANGLE(45.0f)) & 0xC000;
+		pushableItem->Status = ITEM_ACTIVE;
+		AddActiveItem(itemNumber);
+		ResetLaraFlex(laraItem);
+		
+		pushable->moveX = pushableItem->Pose.Position.x;
+		pushable->moveZ = pushableItem->Pose.Position.z;
 
-			if (TestLaraPosition(PushableBlockBounds, pushableItem, laraItem))
+		if (pushable->hasFloorCeiling)
+		{
+			//AlterFloorHeight(item, ((item->triggerFlags - 64) * 256));
+			AdjustStopperFlag(pushableItem, pushableItem->ItemFlags[0], false);
+		}
+	}
+	else
+	{
+		auto bounds = GameBoundingBox(pushableItem);
+		PushableBlockBounds.BoundingBox.X1 = (bounds.X1 / 2) - 100;
+		PushableBlockBounds.BoundingBox.X2 = (bounds.X2 / 2) + 100;
+		PushableBlockBounds.BoundingBox.Z1 = bounds.Z1 - 200;
+		PushableBlockBounds.BoundingBox.Z2 = 0;
+
+		short yOrient = pushableItem->Pose.Orientation.y;
+		pushableItem->Pose.Orientation.y = (laraItem->Pose.Orientation.y + ANGLE(45.0f)) & 0xC000;
+
+		if (TestLaraPosition(PushableBlockBounds, pushableItem, laraItem))
+		{
+			int quadrant = int((pushableItem->Pose.Orientation.y / 0x4000) + ((yOrient + 0x2000) / 0x4000));
+			if (quadrant & 1)
+				PushableBlockPos.z = bounds.X1 - CLICK(0.4f);
+			else
+				PushableBlockPos.z = bounds.Z1 - CLICK(0.4f);
+
+			if (pushable->hasFloorCeiling)
+			{					
+				// Don't use auto align function because it interferes with vaulting.
+
+				SetAnimation(laraItem, LA_PUSHABLE_GRAB);
+				laraItem->Pose.Orientation = pushableItem->Pose.Orientation;
+				lara->Control.IsMoving = false;
+				lara->Control.HandStatus = HandStatus::Busy;
+				lara->NextCornerPos.Position.x = itemNumber;
+				pushableItem->Pose.Orientation.y = yOrient;
+			}
+			else
 			{
-				int quadrant = int((pushableItem->Pose.Orientation.y / 0x4000) + ((yOrient + 0x2000) / 0x4000));
-				if (quadrant & 1)
-					PushableBlockPos.z = bounds.X1 - CLICK(0.4f);
-				else
-					PushableBlockPos.z = bounds.Z1 - CLICK(0.4f);
-
-				if (pushable->hasFloorCeiling)
-				{					
-					// Don't use auto align function because it interferes with vaulting.
-
+				if (MoveLaraPosition(PushableBlockPos, pushableItem, laraItem))
+				{
 					SetAnimation(laraItem, LA_PUSHABLE_GRAB);
-					laraItem->Pose.Orientation = pushableItem->Pose.Orientation;
 					lara->Control.IsMoving = false;
 					lara->Control.HandStatus = HandStatus::Busy;
 					lara->NextCornerPos.Position.x = itemNumber;
@@ -535,522 +543,511 @@ namespace TEN::Entities::Generic
 				}
 				else
 				{
-					if (MoveLaraPosition(PushableBlockPos, pushableItem, laraItem))
-					{
-						SetAnimation(laraItem, LA_PUSHABLE_GRAB);
-						lara->Control.IsMoving = false;
-						lara->Control.HandStatus = HandStatus::Busy;
-						lara->NextCornerPos.Position.x = itemNumber;
-						pushableItem->Pose.Orientation.y = yOrient;
-					}
-					else
-					{
-						lara->InteractedItem = itemNumber;
-						pushableItem->Pose.Orientation.y = yOrient;
-					}
+					lara->InteractedItem = itemNumber;
+					pushableItem->Pose.Orientation.y = yOrient;
 				}
 			}
-			else
-			{
-				if (lara->Control.IsMoving && lara->InteractedItem == itemNumber)
-				{
-					lara->Control.IsMoving = false;
-					lara->Control.HandStatus = HandStatus::Free;
-				}
-
-				pushableItem->Pose.Orientation.y = yOrient;
-			}
-		}
-	}
-
-	void PushLoop(ItemInfo& item)
-	{
-		auto& pushable = GetPushableInfo(item);
-
-		pushable.MovementState = PushableMovementState::Moving;
-	}
-
-	void PushEnd(ItemInfo& item)
-	{
-		auto& pushable = GetPushableInfo(item);
-
-		if (pushable.MovementState == PushableMovementState::Moving)
-			pushable.MovementState = PushableMovementState::Stopping;
-	}
-
-	bool TestBlockMovable(ItemInfo* item, int blockHeight)
-	{
-		RemoveBridge(item->Index);
-		auto pointColl = GetCollision(item);
-		AddBridge(item->Index);
-
-		if (pointColl.Block->IsWall(pointColl.Block->SectorPlane(item->Pose.Position.x, item->Pose.Position.z)))
-			return false;
-
-		if (pointColl.Position.Floor != item->Pose.Position.y)
-			return false;
-
-		return true;
-	}
-
-	bool TestBlockPush(ItemInfo* item, int blockHeight, int quadrant)
-	{
-		if (!TestBlockMovable(item, blockHeight))
-			return false;
-
-		const auto& pushable = GetPushableInfo(*item);
-
-		auto pos = item->Pose.Position;
-		switch (quadrant)
-		{
-		case NORTH:
-			pos.z += BLOCK(1);
-			break;
-
-		case EAST:
-			pos.x += BLOCK(1);
-			break;
-
-		case SOUTH:
-			pos.z -= BLOCK(1);
-			break;
-
-		case WEST:
-			pos.x -= BLOCK(1);
-			break;
-		}
-
-		auto pointColl = GetCollision(pos.x, pos.y - blockHeight, pos.z, item->RoomNumber);
-
-		auto* room = &g_Level.Rooms[pointColl.RoomNumber];
-		if (GetSector(room, pos.x - room->x, pos.z - room->z)->Stopper)
-			return false;
-
-		if (pointColl.Position.FloorSlope || pointColl.Position.DiagonalStep ||
-			pointColl.Block->FloorSlope(0) != Vector2::Zero || pointColl.Block->FloorSlope(1) != Vector2::Zero)
-			return false;
-
-		if (pushable.canFall)
-		{
-			if (pointColl.Position.Floor < pos.y)
-				return false;
 		}
 		else
 		{
-			if (pointColl.Position.Floor != pos.y)
-				return false;
+			if (lara->Control.IsMoving && lara->InteractedItem == itemNumber)
+			{
+				lara->Control.IsMoving = false;
+				lara->Control.HandStatus = HandStatus::Free;
+			}
+
+			pushableItem->Pose.Orientation.y = yOrient;
 		}
+	}
+}
 
-		int ceiling = pos.y - blockHeight + 100;
+void PushLoop(ItemInfo* item)
+{
+	auto* pushable = GetPushableInfo(item);
 
-		if (GetCollision(pos.x, ceiling, pos.z, item->RoomNumber).Position.Ceiling > ceiling)
+	pushable->MovementState = PushableMovementState::Moving;
+}
+
+void PushEnd(ItemInfo* item)
+{
+	auto* pushable = GetPushableInfo(item);
+
+	if (pushable->MovementState == PushableMovementState::Moving)
+		pushable->MovementState = PushableMovementState::Stopping;
+}
+
+bool TestBlockMovable(ItemInfo* item, int blockHeight)
+{
+	RemoveBridge(item->Index);
+	auto pointColl = GetCollision(item);
+	AddBridge(item->Index);
+
+	if (pointColl.Block->IsWall(pointColl.Block->SectorPlane(item->Pose.Position.x, item->Pose.Position.z)))
+		return false;
+
+	if (pointColl.Position.Floor != item->Pose.Position.y)
+		return false;
+
+	return true;
+}
+
+bool TestBlockPush(ItemInfo* item, int blockHeight, int quadrant)
+{
+	if (!TestBlockMovable(item, blockHeight))
+		return false;
+
+	const auto& pushable = GetPushableInfo(item);
+
+	auto pos = item->Pose.Position;
+	switch (quadrant)
+	{
+	case NORTH:
+		pos.z += BLOCK(1);
+		break;
+
+	case EAST:
+		pos.x += BLOCK(1);
+		break;
+
+	case SOUTH:
+		pos.z -= BLOCK(1);
+		break;
+
+	case WEST:
+		pos.x -= BLOCK(1);
+		break;
+	}
+
+	auto pointColl = GetCollision(pos.x, pos.y - blockHeight, pos.z, item->RoomNumber);
+
+	auto* room = &g_Level.Rooms[pointColl.RoomNumber];
+	if (GetSector(room, pos.x - room->x, pos.z - room->z)->Stopper)
+		return false;
+
+	if (pointColl.Position.FloorSlope || pointColl.Position.DiagonalStep ||
+		pointColl.Block->FloorSlope(0) != Vector2::Zero || pointColl.Block->FloorSlope(1) != Vector2::Zero)
+		return false;
+
+	if (pushable->canFall)
+	{
+		if (pointColl.Position.Floor < pos.y)
 			return false;
-
-		auto prevPos = item->Pose.Position;
-		item->Pose.Position = pos;
-		GetCollidedObjects(item, BLOCK(0.25f), true, &CollidedItems[0], &CollidedMeshes[0], true);
-		item->Pose.Position = prevPos;
-
-		if (CollidedMeshes[0])
+	}
+	else
+	{
+		if (pointColl.Position.Floor != pos.y)
 			return false;
+	}
 
-		for (int i = 0; i < MAX_COLLIDED_OBJECTS; i++)
-		{
-			if (!CollidedItems[i])
-				break;
+	int ceiling = pos.y - blockHeight + 100;
 
-			if (Objects[CollidedItems[i]->ObjectNumber].isPickup)
-				continue;
+	if (GetCollision(pos.x, ceiling, pos.z, item->RoomNumber).Position.Ceiling > ceiling)
+		return false;
 
-			if (Objects[CollidedItems[i]->ObjectNumber].floor == nullptr)
-				return false;
+	auto prevPos = item->Pose.Position;
+	item->Pose.Position = pos;
+	GetCollidedObjects(item, BLOCK(0.25f), true, &CollidedItems[0], &CollidedMeshes[0], true);
+	item->Pose.Position = prevPos;
+
+	if (CollidedMeshes[0])
+		return false;
+
+	for (int i = 0; i < MAX_COLLIDED_OBJECTS; i++)
+	{
+		if (!CollidedItems[i])
+			break;
+
+		if (Objects[CollidedItems[i]->ObjectNumber].isPickup)
+			continue;
+
+		if (Objects[CollidedItems[i]->ObjectNumber].floor == nullptr)
+			return false;
 		
+		const auto& object = Objects[CollidedItems[i]->ObjectNumber];
+		int collidedIndex = CollidedItems[i] - g_Level.Items.data(); // Index of CollidedItems[i].
+
+		auto colPos = CollidedItems[i]->Pose.Position;
+
+		// Check if floor function returns nullopt.
+		if (object.floor(collidedIndex, colPos.x, colPos.y, colPos.z) == std::nullopt)
+			return false;
+	}
+
+	return true;
+}
+
+bool TestBlockPull(ItemInfo* item, int blockHeight, int quadrant)
+{
+	if (!TestBlockMovable(item, blockHeight))
+		return false;
+
+	auto offset = Vector3i::Zero;
+	switch (quadrant)
+	{
+	case NORTH:
+		offset = Vector3(0, 0, -BLOCK(1));
+		break;
+
+	case EAST:
+		offset = Vector3(-BLOCK(1), 0, 0);
+		break;
+
+	case SOUTH:
+		offset = Vector3(0, 0, BLOCK(1));
+		break;
+
+	case WEST:
+		offset = Vector3(BLOCK(1), 0, 0);
+		break;
+	}
+
+	auto pos = item->Pose.Position + offset;
+
+	short roomNumber = item->RoomNumber;
+	auto* room = &g_Level.Rooms[roomNumber];
+	if (GetSector(room, pos.x - room->x, pos.z - room->z)->Stopper)
+		return false;
+
+	auto probe = GetCollision(pos.x, pos.y - blockHeight, pos.z, item->RoomNumber);
+
+	if (probe.Position.Floor != pos.y)
+		return false;
+
+	if (probe.Position.FloorSlope || probe.Position.DiagonalStep ||
+		probe.Block->FloorSlope(0) != Vector2::Zero || probe.Block->FloorSlope(1) != Vector2::Zero)
+		return false;
+
+	int ceiling = pos.y - blockHeight + 100;
+
+	if (GetCollision(pos.x, ceiling, pos.z, item->RoomNumber).Position.Ceiling > ceiling)
+		return false;
+
+	int oldX = item->Pose.Position.x;
+	int oldZ = item->Pose.Position.z;
+	item->Pose.Position.x = pos.x;
+	item->Pose.Position.z = pos.z;
+	GetCollidedObjects(item, BLOCK(0.25f), true, &CollidedItems[0], &CollidedMeshes[0], true);
+	item->Pose.Position.x = oldX;
+	item->Pose.Position.z = oldZ;
+
+	if (CollidedMeshes[0])
+		return false;
+
+	for (int i = 0; i < MAX_COLLIDED_OBJECTS; i++)
+	{
+		if (!CollidedItems[i])
+			break;
+
+		if (Objects[CollidedItems[i]->ObjectNumber].isPickup)
+			continue;
+
+		if (Objects[CollidedItems[i]->ObjectNumber].floor == nullptr)
+			return false;
+		else
+		{
 			const auto& object = Objects[CollidedItems[i]->ObjectNumber];
-			int collidedIndex = CollidedItems[i] - g_Level.Items.data(); // Index of CollidedItems[i].
+			int collidedIndex = CollidedItems[i] - g_Level.Items.data();
 
-			auto colPos = CollidedItems[i]->Pose.Position;
+			int xCol = CollidedItems[i]->Pose.Position.x;
+			int yCol = CollidedItems[i]->Pose.Position.y;
+			int zCol = CollidedItems[i]->Pose.Position.z;
 
-			// Check if floor function returns nullopt.
-			if (object.floor(collidedIndex, colPos.x, colPos.y, colPos.z) == std::nullopt)
+			if (object.floor(collidedIndex, xCol, yCol, zCol) == std::nullopt)
 				return false;
-		}
-
-		return true;
-	}
-
-	bool TestBlockPull(ItemInfo* item, int blockHeight, int quadrant)
-	{
-		if (!TestBlockMovable(item, blockHeight))
-			return false;
-
-		auto offset = Vector3i::Zero;
-		switch (quadrant)
-		{
-		case NORTH:
-			offset = Vector3(0, 0, -BLOCK(1));
-			break;
-
-		case EAST:
-			offset = Vector3(-BLOCK(1), 0, 0);
-			break;
-
-		case SOUTH:
-			offset = Vector3(0, 0, BLOCK(1));
-			break;
-
-		case WEST:
-			offset = Vector3(BLOCK(1), 0, 0);
-			break;
-		}
-
-		auto pos = item->Pose.Position + offset;
-
-		short roomNumber = item->RoomNumber;
-		auto* room = &g_Level.Rooms[roomNumber];
-		if (GetSector(room, pos.x - room->x, pos.z - room->z)->Stopper)
-			return false;
-
-		auto probe = GetCollision(pos.x, pos.y - blockHeight, pos.z, item->RoomNumber);
-
-		if (probe.Position.Floor != pos.y)
-			return false;
-
-		if (probe.Position.FloorSlope || probe.Position.DiagonalStep ||
-			probe.Block->FloorSlope(0) != Vector2::Zero || probe.Block->FloorSlope(1) != Vector2::Zero)
-			return false;
-
-		int ceiling = pos.y - blockHeight + 100;
-
-		if (GetCollision(pos.x, ceiling, pos.z, item->RoomNumber).Position.Ceiling > ceiling)
-			return false;
-
-		int oldX = item->Pose.Position.x;
-		int oldZ = item->Pose.Position.z;
-		item->Pose.Position.x = pos.x;
-		item->Pose.Position.z = pos.z;
-		GetCollidedObjects(item, BLOCK(0.25f), true, &CollidedItems[0], &CollidedMeshes[0], true);
-		item->Pose.Position.x = oldX;
-		item->Pose.Position.z = oldZ;
-
-		if (CollidedMeshes[0])
-			return false;
-
-		for (int i = 0; i < MAX_COLLIDED_OBJECTS; i++)
-		{
-			if (!CollidedItems[i])
-				break;
-
-			if (Objects[CollidedItems[i]->ObjectNumber].isPickup)
-				continue;
-
-			if (Objects[CollidedItems[i]->ObjectNumber].floor == nullptr)
-				return false;
-			else
-			{
-				const auto& object = Objects[CollidedItems[i]->ObjectNumber];
-				int collidedIndex = CollidedItems[i] - g_Level.Items.data();
-
-				int xCol = CollidedItems[i]->Pose.Position.x;
-				int yCol = CollidedItems[i]->Pose.Position.y;
-				int zCol = CollidedItems[i]->Pose.Position.z;
-
-				if (object.floor(collidedIndex, xCol, yCol, zCol) == std::nullopt)
-					return false;
-			}
-		}
-
-		auto playerOffset = Vector3i::Zero;
-		switch (quadrant)
-		{
-		case NORTH:
-			playerOffset.z = GetBestFrame(LaraItem)->offsetZ;
-			break;
-
-		case EAST:
-			playerOffset.x = GetBestFrame(LaraItem)->offsetZ;
-			break;
-
-		case SOUTH:
-			playerOffset.z = -GetBestFrame(LaraItem)->offsetZ;
-			break;
-
-		case WEST:
-			playerOffset.x = -GetBestFrame(LaraItem)->offsetZ;
-			break;
-		}
-
-		pos = LaraItem->Pose.Position + offset + playerOffset;
-		roomNumber = LaraItem->RoomNumber;
-
-		probe = GetCollision(pos.x, pos.y - LARA_HEIGHT, pos.z, LaraItem->RoomNumber);
-
-		room = &g_Level.Rooms[roomNumber];
-		if (GetSector(room, pos.x - room->x, pos.z - room->z)->Stopper)
-			return false;
-
-		if (probe.Position.Floor != pos.y)
-			return false;
-
-		if (probe.Block->CeilingHeight(pos.x, pos.z) > pos.y - LARA_HEIGHT)
-			return false;
-
-		oldX = LaraItem->Pose.Position.x;
-		oldZ = LaraItem->Pose.Position.z;
-		LaraItem->Pose.Position.x = pos.x;
-		LaraItem->Pose.Position.z = pos.z;
-		GetCollidedObjects(LaraItem, LARA_RADIUS, true, &CollidedItems[0], &CollidedMeshes[0], true);
-		LaraItem->Pose.Position.x = oldX;
-		LaraItem->Pose.Position.z = oldZ;
-
-		if (CollidedMeshes[0])
-			return false;
-
-		for (int i = 0; i < MAX_COLLIDED_OBJECTS; i++)
-		{
-			if (!CollidedItems[i])
-				break;
-
-			if (CollidedItems[i] == item) // If collided item is not pushblock in which lara embedded
-				continue;
-
-			if (Objects[CollidedItems[i]->ObjectNumber].isPickup)
-				continue;
-
-			if (Objects[CollidedItems[i]->ObjectNumber].floor == nullptr)
-				return false;
-			else
-			{
-				const auto& object = Objects[CollidedItems[i]->ObjectNumber];
-				int collidedIndex = CollidedItems[i] - g_Level.Items.data();
-				int xCol = CollidedItems[i]->Pose.Position.x;
-				int yCol = CollidedItems[i]->Pose.Position.y;
-				int zCol = CollidedItems[i]->Pose.Position.z;
-
-				if (object.floor(collidedIndex, xCol, yCol, zCol) == std::nullopt)
-					return false;
-			}
-		}
-
-		return true;
-	}
-
-	void MoveStackXZ(short itemNumber)
-	{
-		auto& item = g_Level.Items[itemNumber];
-
-		short probedRoomNumber = GetCollision(&item).RoomNumber;
-		if (probedRoomNumber != item.RoomNumber)
-			ItemNewRoom(itemNumber, probedRoomNumber);
-
-		auto* stackItem = &item;
-		while (stackItem->ItemFlags[1] != NO_ITEM)
-		{
-			int stackIndex = stackItem->ItemFlags[1];
-			stackItem = &g_Level.Items[stackIndex];
-
-			stackItem->Pose.Position.x = item.Pose.Position.x;
-			stackItem->Pose.Position.z = item.Pose.Position.z;
-
-			probedRoomNumber = GetCollision(&item).RoomNumber;
-			if (probedRoomNumber != stackItem->RoomNumber)
-				ItemNewRoom(stackIndex, probedRoomNumber);
 		}
 	}
 
-	void MoveStackY(short itemNumber, int y)
+	auto playerOffset = Vector3i::Zero;
+	switch (quadrant)
 	{
-		auto* itemPtr = &g_Level.Items[itemNumber];
+	case NORTH:
+		playerOffset.z = GetBestFrame(LaraItem)->offsetZ;
+		break;
 
-		short probedRoomNumber = GetCollision(itemPtr).RoomNumber;
+	case EAST:
+		playerOffset.x = GetBestFrame(LaraItem)->offsetZ;
+		break;
+
+	case SOUTH:
+		playerOffset.z = -GetBestFrame(LaraItem)->offsetZ;
+		break;
+
+	case WEST:
+		playerOffset.x = -GetBestFrame(LaraItem)->offsetZ;
+		break;
+	}
+
+	pos = LaraItem->Pose.Position + offset + playerOffset;
+	roomNumber = LaraItem->RoomNumber;
+
+	probe = GetCollision(pos.x, pos.y - LARA_HEIGHT, pos.z, LaraItem->RoomNumber);
+
+	room = &g_Level.Rooms[roomNumber];
+	if (GetSector(room, pos.x - room->x, pos.z - room->z)->Stopper)
+		return false;
+
+	if (probe.Position.Floor != pos.y)
+		return false;
+
+	if (probe.Block->CeilingHeight(pos.x, pos.z) > pos.y - LARA_HEIGHT)
+		return false;
+
+	oldX = LaraItem->Pose.Position.x;
+	oldZ = LaraItem->Pose.Position.z;
+	LaraItem->Pose.Position.x = pos.x;
+	LaraItem->Pose.Position.z = pos.z;
+	GetCollidedObjects(LaraItem, LARA_RADIUS, true, &CollidedItems[0], &CollidedMeshes[0], true);
+	LaraItem->Pose.Position.x = oldX;
+	LaraItem->Pose.Position.z = oldZ;
+
+	if (CollidedMeshes[0])
+		return false;
+
+	for (int i = 0; i < MAX_COLLIDED_OBJECTS; i++)
+	{
+		if (!CollidedItems[i])
+			break;
+
+		if (CollidedItems[i] == item) // If collided item is not pushblock in which lara embedded
+			continue;
+
+		if (Objects[CollidedItems[i]->ObjectNumber].isPickup)
+			continue;
+
+		if (Objects[CollidedItems[i]->ObjectNumber].floor == nullptr)
+			return false;
+		else
+		{
+			const auto& object = Objects[CollidedItems[i]->ObjectNumber];
+			int collidedIndex = CollidedItems[i] - g_Level.Items.data();
+			int xCol = CollidedItems[i]->Pose.Position.x;
+			int yCol = CollidedItems[i]->Pose.Position.y;
+			int zCol = CollidedItems[i]->Pose.Position.z;
+
+			if (object.floor(collidedIndex, xCol, yCol, zCol) == std::nullopt)
+				return false;
+		}
+	}
+
+	return true;
+}
+
+void MoveStackXZ(short itemNumber)
+{
+	auto* item = &g_Level.Items[itemNumber];
+
+	short probedRoomNumber = GetCollision(item).RoomNumber;
+	if (probedRoomNumber != item->RoomNumber)
+		ItemNewRoom(itemNumber, probedRoomNumber);
+
+	auto* stackItem = item;
+	while (stackItem->ItemFlags[1] != NO_ITEM)
+	{
+		int stackIndex = stackItem->ItemFlags[1];
+		stackItem = &g_Level.Items[stackIndex];
+
+		stackItem->Pose.Position.x = item->Pose.Position.x;
+		stackItem->Pose.Position.z = item->Pose.Position.z;
+
+		probedRoomNumber = GetCollision(item).RoomNumber;
+		if (probedRoomNumber != stackItem->RoomNumber)
+			ItemNewRoom(stackIndex, probedRoomNumber);
+	}
+}
+
+void MoveStackY(short itemNumber, int y)
+{
+	auto* itemPtr = &g_Level.Items[itemNumber];
+
+	short probedRoomNumber = GetCollision(itemPtr).RoomNumber;
+	if (probedRoomNumber != itemPtr->RoomNumber)
+		ItemNewRoom(itemNumber, probedRoomNumber);
+
+	// Move stack together with bottom pushable->
+	while (itemPtr->ItemFlags[1] != NO_ITEM)
+	{
+		int stackIndex = itemPtr->ItemFlags[1];
+		itemPtr = &g_Level.Items[stackIndex];
+
+		itemPtr->Pose.Position.y += y;
+
+		probedRoomNumber = GetCollision(itemPtr).RoomNumber;
 		if (probedRoomNumber != itemPtr->RoomNumber)
-			ItemNewRoom(itemNumber, probedRoomNumber);
+			ItemNewRoom(stackIndex, probedRoomNumber);
+	}
+}
 
-		// Move stack together with bottom pushable.
-		while (itemPtr->ItemFlags[1] != NO_ITEM)
+void AddBridgeStack(short itemNumber)
+{
+	auto* item = &g_Level.Items[itemNumber];
+	const auto* pushable = GetPushableInfo(item);
+
+	if (pushable->hasFloorCeiling)
+		TEN::Floordata::AddBridge(itemNumber);
+
+	int stackIndex = g_Level.Items[itemNumber].ItemFlags[1];
+	while (stackIndex != NO_ITEM)
+	{
+		if (pushable->hasFloorCeiling)
+			TEN::Floordata::AddBridge(stackIndex);
+
+		stackIndex = g_Level.Items[stackIndex].ItemFlags[1];
+	}
+}
+
+void RemoveBridgeStack(short itemNumber)
+{
+	auto* item = &g_Level.Items[itemNumber];
+	const auto* pushable = GetPushableInfo(item);
+
+	if (pushable->hasFloorCeiling)
+		TEN::Floordata::RemoveBridge(itemNumber);
+
+	int stackIndex = g_Level.Items[itemNumber].ItemFlags[1];
+	while (stackIndex != NO_ITEM)
+	{
+		if (pushable->hasFloorCeiling)
+			TEN::Floordata::RemoveBridge(stackIndex);
+
+		stackIndex = g_Level.Items[stackIndex].ItemFlags[1];
+	}
+}
+
+void RemoveFromStack(short itemNumber) 
+{
+	// Unlink pushable from stack.
+	for (int i = 0; i < g_Level.NumItems; i++)
+	{
+		if (i == itemNumber)
+			continue;
+
+		auto& itemBelow = g_Level.Items[i];
+
+		int objectNumber = itemBelow.ObjectNumber;
+		if (objectNumber >= ID_PUSHABLE_OBJECT1 && objectNumber <= ID_PUSHABLE_OBJECT10)
 		{
-			int stackIndex = itemPtr->ItemFlags[1];
-			itemPtr = &g_Level.Items[stackIndex];
-
-			itemPtr->Pose.Position.y += y;
-
-			probedRoomNumber = GetCollision(itemPtr).RoomNumber;
-			if (probedRoomNumber != itemPtr->RoomNumber)
-				ItemNewRoom(stackIndex, probedRoomNumber);
+			if (itemBelow.ItemFlags[1] == itemNumber)
+				itemBelow.ItemFlags[1] = NO_ITEM;
 		}
 	}
+}
 
-	void AddBridgeStack(short itemNumber)
+int FindStack(short itemNumber)
+{
+	int stackTop = NO_ITEM;		// Index of heighest pushable in stack.
+	int stackYmin = CLICK(256); // Set starting height.
+
+	// Check for pushable directly below current one.
+	for (int i = 0; i < g_Level.NumItems; i++)
 	{
-		auto& item = g_Level.Items[itemNumber];
-		const auto& pushable = GetPushableInfo(item);
+		if (i == itemNumber)
+			continue;
 
-		if (pushable.hasFloorCeiling)
-			TEN::Floordata::AddBridge(itemNumber);
+		auto* itemBelow = &g_Level.Items[i];
 
-		int stackIndex = g_Level.Items[itemNumber].ItemFlags[1];
-		while (stackIndex != NO_ITEM)
+		int objectNumber = itemBelow->ObjectNumber;
+		if (objectNumber >= ID_PUSHABLE_OBJECT1 && objectNumber <= ID_PUSHABLE_OBJECT10)
 		{
-			if (pushable.hasFloorCeiling)
-				TEN::Floordata::AddBridge(stackIndex);
+			const auto* item = &g_Level.Items[itemNumber];
 
-			stackIndex = g_Level.Items[stackIndex].ItemFlags[1];
-		}
-	}
+			auto pos = item->Pose.Position;
 
-	void RemoveBridgeStack(short itemNumber)
-	{
-		auto& item = g_Level.Items[itemNumber];
-		const auto& pushable = GetPushableInfo(item);
-
-		if (pushable.hasFloorCeiling)
-			TEN::Floordata::RemoveBridge(itemNumber);
-
-		int stackIndex = g_Level.Items[itemNumber].ItemFlags[1];
-		while (stackIndex != NO_ITEM)
-		{
-			if (pushable.hasFloorCeiling)
-				TEN::Floordata::RemoveBridge(stackIndex);
-
-			stackIndex = g_Level.Items[stackIndex].ItemFlags[1];
-		}
-	}
-
-	void RemoveFromStack(short itemNumber) 
-	{
-		// Unlink pushable from stack.
-		for (int i = 0; i < g_Level.NumItems; i++)
-		{
-			if (i == itemNumber)
-				continue;
-
-			auto& itemBelow = g_Level.Items[i];
-
-			int objectNumber = itemBelow.ObjectNumber;
-			if (objectNumber >= ID_PUSHABLE_OBJECT1 && objectNumber <= ID_PUSHABLE_OBJECT10)
+			if (itemBelow->Pose.Position.x == pos.x &&
+				itemBelow->Pose.Position.z == pos.z)
 			{
-				if (itemBelow.ItemFlags[1] == itemNumber)
-					itemBelow.ItemFlags[1] = NO_ITEM;
-			}
-		}
-	}
-
-	int FindStack(short itemNumber)
-	{
-		int stackTop = NO_ITEM;		// Index of heighest pushable in stack.
-		int stackYmin = CLICK(256); // Set starting height.
-
-		// Check for pushable directly below current one.
-		for (int i = 0; i < g_Level.NumItems; i++)
-		{
-			if (i == itemNumber)
-				continue;
-
-			auto* itemBelow = &g_Level.Items[i];
-
-			int objectNumber = itemBelow->ObjectNumber;
-			if (objectNumber >= ID_PUSHABLE_OBJECT1 && objectNumber <= ID_PUSHABLE_OBJECT10)
-			{
-				const auto& item = g_Level.Items[itemNumber];
-
-				auto pos = item.Pose.Position;
-
-				if (itemBelow->Pose.Position.x == pos.x &&
-					itemBelow->Pose.Position.z == pos.z)
+				// Set heighest pushable so far as top of stack.
+				int belowY = itemBelow->Pose.Position.y;
+				if (belowY > pos.y && belowY < stackYmin)
 				{
-					// Set heighest pushable so far as top of stack.
-					int belowY = itemBelow->Pose.Position.y;
-					if (belowY > pos.y && belowY < stackYmin)
-					{
-						stackTop = i;
-						stackYmin = itemBelow->Pose.Position.y;
-					}
+					stackTop = i;
+					stackYmin = itemBelow->Pose.Position.y;
 				}
 			}
 		}
-
-		if (stackTop != NO_ITEM)
-			g_Level.Items[stackTop].ItemFlags[1] = itemNumber;
-
-		return stackTop;
 	}
 
-	int GetStackHeight(ItemInfo& item)
+	if (stackTop != NO_ITEM)
+		g_Level.Items[stackTop].ItemFlags[1] = itemNumber;
+
+	return stackTop;
+}
+
+int GetStackHeight(ItemInfo* item)
+{
+	auto* pushable = GetPushableInfo(item);
+
+	int height = pushable->height;
+
+	auto* stackItem = item;
+	while (stackItem->ItemFlags[1] != NO_ITEM)
 	{
-		auto& pushable = GetPushableInfo(item);
-
-		int height = pushable.height;
-
-		auto* stackItem = &item;
-		while (stackItem->ItemFlags[1] != NO_ITEM)
-		{
-			stackItem = &g_Level.Items[stackItem->ItemFlags[1]];
-			height += pushable.height;
-		}
-
-		return height;
+		stackItem = &g_Level.Items[stackItem->ItemFlags[1]];
+		height += pushable->height;
 	}
 
-	bool CheckStackLimit(ItemInfo& item)
+	return height;
+}
+
+bool CheckStackLimit(ItemInfo* item)
+{
+	auto* pushable = GetPushableInfo(item);
+
+	unsigned int limit = pushable->stackLimit;
+	unsigned int count = 1;
+
+	auto* stackItem = item;
+	while (stackItem->ItemFlags[1] != NO_ITEM)
 	{
-		auto& pushable = GetPushableInfo(item);
+		stackItem = &g_Level.Items[stackItem->ItemFlags[1]];
+		count++;
 
-		unsigned int limit = pushable.stackLimit;
-		unsigned int count = 1;
-
-		auto* stackItem = &item;
-		while (stackItem->ItemFlags[1] != NO_ITEM)
-		{
-			stackItem = &g_Level.Items[stackItem->ItemFlags[1]];
-			count++;
-
-			if (count > limit)
-				return false;
-		}
-
-		return true;
+		if (count > limit)
+			return false;
 	}
 
-	std::optional<int> PushableBlockFloor(short itemNumber, int x, int y, int z)
-	{
-		auto& item = g_Level.Items[itemNumber];
-		const auto& pushable = GetPushableInfo(item);
+	return true;
+}
 
-		auto boxHeight = GetBridgeItemIntersect(itemNumber, x, y, z, false);
+std::optional<int> PushableBlockFloor(short itemNumber, int x, int y, int z)
+{
+	auto* item = &g_Level.Items[itemNumber];
+	const auto* pushable = GetPushableInfo(item);
+
+	auto boxHeight = GetBridgeItemIntersect(itemNumber, x, y, z, false);
 	
-		if (item.Status != ITEM_INVISIBLE && pushable.hasFloorCeiling && boxHeight.has_value())
-		{
-			const auto height = item.Pose.Position.y - (item.TriggerFlags & 0x1F) * CLICK(1);
-			return std::optional{height};
-		}
-
-		return std::nullopt;
-	}
-
-	std::optional<int> PushableBlockCeiling(short itemNumber, int x, int y, int z)
+	if (item->Status != ITEM_INVISIBLE && pushable->hasFloorCeiling && boxHeight.has_value())
 	{
-		auto& item = g_Level.Items[itemNumber];
-		const auto& pushable = GetPushableInfo(item);
-
-		auto boxHeight = GetBridgeItemIntersect(itemNumber, x, y, z, true);
-
-		if (item.Status != ITEM_INVISIBLE && pushable.hasFloorCeiling && boxHeight.has_value())
-			return std::optional{item.Pose.Position.y};
-
-		return std::nullopt;
+		const auto height = item->Pose.Position.y - (item->TriggerFlags & 0x1F) * CLICK(1);
+		return std::optional{height};
 	}
 
-	int PushableBlockFloorBorder(short itemNumber)
-	{
-		const auto& item = g_Level.Items[itemNumber];
+	return std::nullopt;
+}
 
-		const auto height = item.Pose.Position.y - (item.TriggerFlags & 0x1F) * CLICK(1);
-		return height;
-	}
+std::optional<int> PushableBlockCeiling(short itemNumber, int x, int y, int z)
+{
+	auto* item = &g_Level.Items[itemNumber];
+	const auto* pushable = GetPushableInfo(item);
 
-	int PushableBlockCeilingBorder(short itemNumber)
-	{
-		const auto& item = g_Level.Items[itemNumber];
+	auto boxHeight = GetBridgeItemIntersect(itemNumber, x, y, z, true);
 
-		return item.Pose.Position.y;
-	}
+	if (item->Status != ITEM_INVISIBLE && pushable->hasFloorCeiling && boxHeight.has_value())
+		return std::optional{item->Pose.Position.y};
+
+	return std::nullopt;
+}
+
+int PushableBlockFloorBorder(short itemNumber)
+{
+	const auto* item = &g_Level.Items[itemNumber];
+
+	const auto height = item->Pose.Position.y - (item->TriggerFlags & 0x1F) * CLICK(1);
+	return height;
+}
+
+int PushableBlockCeilingBorder(short itemNumber)
+{
+	const auto* item = &g_Level.Items[itemNumber];
+
+	return item->Pose.Position.y;
 }

--- a/TombEngine/Objects/TR5/Object/tr5_pushableblock.h
+++ b/TombEngine/Objects/TR5/Object/tr5_pushableblock.h
@@ -1,7 +1,7 @@
 #pragma once
 
-struct ItemInfo;
 struct CollisionInfo;
+struct ItemInfo;
 
 void ClearMovableBlockSplitters(int x, int y, int z, short roomNumber);
 void InitialisePushableBlock(short itemNumber);

--- a/TombEngine/Objects/TR5/Object/tr5_pushableblock.h
+++ b/TombEngine/Objects/TR5/Object/tr5_pushableblock.h
@@ -14,8 +14,9 @@ namespace TEN::Entities::Generic
 	void PushableBlockControl(short itemNumber);
 	void PushableBlockCollision(short itemNumber, ItemInfo* laraItem, CollisionInfo* coll);
 	bool TestBlockMovable(ItemInfo* item, int blockHeight);
-	bool TestBlockPush(ItemInfo* item, int blockHeight, unsigned short quadrant);
-	bool TestBlockPull(ItemInfo* item, int blockHeight, short quadrant);
+	bool TestBlockPush(ItemInfo* item, int blockHeight, int quadrant);
+	bool TestBlockPull(ItemInfo* item, int blockHeight, int quadrant);
+
 	void MoveStackXZ(short itemNumber);
 	void MoveStackY(short itemNumber, int y);
 	void RemoveBridgeStack(short itemNumber);
@@ -24,8 +25,10 @@ namespace TEN::Entities::Generic
 	int FindStack(short itemNumber);
 	int GetStackHeight(ItemInfo* item);
 	bool CheckStackLimit(ItemInfo* item);
+
 	void PushLoop(ItemInfo* item);
 	void PushEnd(ItemInfo* item);
+
 	std::optional<int> PushableBlockFloor(short itemNumber, int x, int y, int z);
 	std::optional<int> PushableBlockCeiling(short itemNumber, int x, int y, int z);
 	int PushableBlockFloorBorder(short itemNumber);

--- a/TombEngine/Objects/TR5/Object/tr5_pushableblock.h
+++ b/TombEngine/Objects/TR5/Object/tr5_pushableblock.h
@@ -18,17 +18,18 @@ namespace TEN::Entities::Generic
 	bool TestBlockPush(ItemInfo* item, int blockHeight, int quadrant);
 	bool TestBlockPull(ItemInfo* item, int blockHeight, int quadrant);
 
+	// Pushable stack utilities
 	void MoveStackXZ(short itemNumber);
 	void MoveStackY(short itemNumber, int y);
 	void RemoveBridgeStack(short itemNumber);
 	void AddBridgeStack(short itemNumber);
 	void RemoveFromStack(short itemNumber);
 	int FindStack(short itemNumber);
-	int GetStackHeight(ItemInfo* item);
-	bool CheckStackLimit(ItemInfo* item);
+	int GetStackHeight(ItemInfo& item);
+	bool CheckStackLimit(ItemInfo& item);
 
-	void PushLoop(ItemInfo* item);
-	void PushEnd(ItemInfo* item);
+	void PushLoop(ItemInfo& item);
+	void PushEnd(ItemInfo& item);
 
 	std::optional<int> PushableBlockFloor(short itemNumber, int x, int y, int z);
 	std::optional<int> PushableBlockCeiling(short itemNumber, int x, int y, int z);

--- a/TombEngine/Objects/TR5/Object/tr5_pushableblock.h
+++ b/TombEngine/Objects/TR5/Object/tr5_pushableblock.h
@@ -4,35 +4,33 @@ class Vector3i;
 struct CollisionInfo;
 struct ItemInfo;
 
-namespace TEN::Entities::Generic
-{
-	struct PushableInfo;
+// TODO: After wrapping into namespace, uncomment these two lines.
+//struct PushableInfo;
 
-	PushableInfo& GetPushableInfo(ItemInfo& item);
-	void InitialisePushableBlock(short itemNumber);
+//PushableInfo* GetPushableInfo(ItemInfo* item);
+void InitialisePushableBlock(short itemNumber);
 
-	void ClearMovableBlockSplitters(const Vector3i& pos, short roomNumber);
-	void PushableBlockControl(short itemNumber);
-	void PushableBlockCollision(short itemNumber, ItemInfo* laraItem, CollisionInfo* coll);
-	bool TestBlockMovable(ItemInfo* item, int blockHeight);
-	bool TestBlockPush(ItemInfo* item, int blockHeight, int quadrant);
-	bool TestBlockPull(ItemInfo* item, int blockHeight, int quadrant);
+void ClearMovableBlockSplitters(const Vector3i& pos, short roomNumber);
+void PushableBlockControl(short itemNumber);
+void PushableBlockCollision(short itemNumber, ItemInfo* laraItem, CollisionInfo* coll);
+bool TestBlockMovable(ItemInfo* item, int blockHeight);
+bool TestBlockPush(ItemInfo* item, int blockHeight, int quadrant);
+bool TestBlockPull(ItemInfo* item, int blockHeight, int quadrant);
 
-	// Pushable stack utilities
-	void MoveStackXZ(short itemNumber);
-	void MoveStackY(short itemNumber, int y);
-	void RemoveBridgeStack(short itemNumber);
-	void AddBridgeStack(short itemNumber);
-	void RemoveFromStack(short itemNumber);
-	int FindStack(short itemNumber);
-	int GetStackHeight(ItemInfo& item);
-	bool CheckStackLimit(ItemInfo& item);
+// Pushable stack utilities
+void MoveStackXZ(short itemNumber);
+void MoveStackY(short itemNumber, int y);
+void RemoveBridgeStack(short itemNumber);
+void AddBridgeStack(short itemNumber);
+void RemoveFromStack(short itemNumber);
+int FindStack(short itemNumber);
+int GetStackHeight(ItemInfo* item);
+bool CheckStackLimit(ItemInfo* item);
 
-	void PushLoop(ItemInfo& item);
-	void PushEnd(ItemInfo& item);
+void PushLoop(ItemInfo* item);
+void PushEnd(ItemInfo* item);
 
-	std::optional<int> PushableBlockFloor(short itemNumber, int x, int y, int z);
-	std::optional<int> PushableBlockCeiling(short itemNumber, int x, int y, int z);
-	int PushableBlockFloorBorder(short itemNumber);
-	int PushableBlockCeilingBorder(short itemNumber);
-}
+std::optional<int> PushableBlockFloor(short itemNumber, int x, int y, int z);
+std::optional<int> PushableBlockCeiling(short itemNumber, int x, int y, int z);
+int PushableBlockFloorBorder(short itemNumber);
+int PushableBlockCeilingBorder(short itemNumber);

--- a/TombEngine/Objects/TR5/Object/tr5_pushableblock.h
+++ b/TombEngine/Objects/TR5/Object/tr5_pushableblock.h
@@ -1,5 +1,6 @@
 #pragma once
 
+class Vector3i;
 struct CollisionInfo;
 struct ItemInfo;
 
@@ -10,7 +11,7 @@ namespace TEN::Entities::Generic
 	PushableInfo& GetPushableInfo(ItemInfo& item);
 	void InitialisePushableBlock(short itemNumber);
 
-	void ClearMovableBlockSplitters(int x, int y, int z, short roomNumber);
+	void ClearMovableBlockSplitters(const Vector3i& pos, short roomNumber);
 	void PushableBlockControl(short itemNumber);
 	void PushableBlockCollision(short itemNumber, ItemInfo* laraItem, CollisionInfo* coll);
 	bool TestBlockMovable(ItemInfo* item, int blockHeight);

--- a/TombEngine/Objects/TR5/Object/tr5_pushableblock.h
+++ b/TombEngine/Objects/TR5/Object/tr5_pushableblock.h
@@ -4,33 +4,35 @@ class Vector3i;
 struct CollisionInfo;
 struct ItemInfo;
 
-// TODO: After wrapping into namespace, uncomment these two lines.
-//struct PushableInfo;
+namespace TEN::Entities::Generic
+{
+	struct PushableInfo;
 
-//PushableInfo* GetPushableInfo(ItemInfo* item);
-void InitialisePushableBlock(short itemNumber);
+	PushableInfo* GetPushableInfo(ItemInfo* item);
+	void InitialisePushableBlock(short itemNumber);
 
-void ClearMovableBlockSplitters(const Vector3i& pos, short roomNumber);
-void PushableBlockControl(short itemNumber);
-void PushableBlockCollision(short itemNumber, ItemInfo* laraItem, CollisionInfo* coll);
-bool TestBlockMovable(ItemInfo* item, int blockHeight);
-bool TestBlockPush(ItemInfo* item, int blockHeight, int quadrant);
-bool TestBlockPull(ItemInfo* item, int blockHeight, int quadrant);
+	void ClearMovableBlockSplitters(const Vector3i& pos, short roomNumber);
+	void PushableBlockControl(short itemNumber);
+	void PushableBlockCollision(short itemNumber, ItemInfo* laraItem, CollisionInfo* coll);
+	bool TestBlockMovable(ItemInfo* item, int blockHeight);
+	bool TestBlockPush(ItemInfo* item, int blockHeight, int quadrant);
+	bool TestBlockPull(ItemInfo* item, int blockHeight, int quadrant);
 
-// Pushable stack utilities
-void MoveStackXZ(short itemNumber);
-void MoveStackY(short itemNumber, int y);
-void RemoveBridgeStack(short itemNumber);
-void AddBridgeStack(short itemNumber);
-void RemoveFromStack(short itemNumber);
-int FindStack(short itemNumber);
-int GetStackHeight(ItemInfo* item);
-bool CheckStackLimit(ItemInfo* item);
+	// Pushable stack utilities
+	void MoveStackXZ(short itemNumber);
+	void MoveStackY(short itemNumber, int y);
+	void RemoveBridgeStack(short itemNumber);
+	void AddBridgeStack(short itemNumber);
+	void RemoveFromStack(short itemNumber);
+	int FindStack(short itemNumber);
+	int GetStackHeight(ItemInfo* item);
+	bool CheckStackLimit(ItemInfo* item);
 
-void PushLoop(ItemInfo* item);
-void PushEnd(ItemInfo* item);
+	void PushLoop(ItemInfo* item);
+	void PushEnd(ItemInfo* item);
 
-std::optional<int> PushableBlockFloor(short itemNumber, int x, int y, int z);
-std::optional<int> PushableBlockCeiling(short itemNumber, int x, int y, int z);
-int PushableBlockFloorBorder(short itemNumber);
-int PushableBlockCeilingBorder(short itemNumber);
+	std::optional<int> PushableBlockFloor(short itemNumber, int x, int y, int z);
+	std::optional<int> PushableBlockCeiling(short itemNumber, int x, int y, int z);
+	int PushableBlockFloorBorder(short itemNumber);
+	int PushableBlockCeilingBorder(short itemNumber);
+}

--- a/TombEngine/Objects/TR5/Object/tr5_pushableblock.h
+++ b/TombEngine/Objects/TR5/Object/tr5_pushableblock.h
@@ -3,24 +3,31 @@
 struct CollisionInfo;
 struct ItemInfo;
 
-void ClearMovableBlockSplitters(int x, int y, int z, short roomNumber);
-void InitialisePushableBlock(short itemNumber);
-void PushableBlockControl(short itemNumber);
-void PushableBlockCollision(short itemNumber, ItemInfo* laraItem, CollisionInfo* coll);
-bool TestBlockMovable(ItemInfo* item, int blockHeight);
-bool TestBlockPush(ItemInfo* item, int blockHeight, unsigned short quadrant);
-bool TestBlockPull(ItemInfo* item, int blockHeight, short quadrant);
-void MoveStackXZ(short itemNumber);
-void MoveStackY(short itemNumber, int y);
-void RemoveBridgeStack(short itemNumber);
-void AddBridgeStack(short itemNumber);
-void RemoveFromStack(short itemNumber);
-int FindStack(short itemNumber);
-int GetStackHeight(ItemInfo* item);
-bool CheckStackLimit(ItemInfo* item);
-void PushLoop(ItemInfo* item);
-void PushEnd(ItemInfo* item);
-std::optional<int> PushableBlockFloor(short itemNumber, int x, int y, int z);
-std::optional<int> PushableBlockCeiling(short itemNumber, int x, int y, int z);
-int PushableBlockFloorBorder(short itemNumber);
-int PushableBlockCeilingBorder(short itemNumber);
+namespace TEN::Entities::Generic
+{
+	struct PushableInfo;
+
+	PushableInfo& GetPushableInfo(ItemInfo& item);
+	void InitialisePushableBlock(short itemNumber);
+
+	void ClearMovableBlockSplitters(int x, int y, int z, short roomNumber);
+	void PushableBlockControl(short itemNumber);
+	void PushableBlockCollision(short itemNumber, ItemInfo* laraItem, CollisionInfo* coll);
+	bool TestBlockMovable(ItemInfo* item, int blockHeight);
+	bool TestBlockPush(ItemInfo* item, int blockHeight, unsigned short quadrant);
+	bool TestBlockPull(ItemInfo* item, int blockHeight, short quadrant);
+	void MoveStackXZ(short itemNumber);
+	void MoveStackY(short itemNumber, int y);
+	void RemoveBridgeStack(short itemNumber);
+	void AddBridgeStack(short itemNumber);
+	void RemoveFromStack(short itemNumber);
+	int FindStack(short itemNumber);
+	int GetStackHeight(ItemInfo* item);
+	bool CheckStackLimit(ItemInfo* item);
+	void PushLoop(ItemInfo* item);
+	void PushEnd(ItemInfo* item);
+	std::optional<int> PushableBlockFloor(short itemNumber, int x, int y, int z);
+	std::optional<int> PushableBlockCeiling(short itemNumber, int x, int y, int z);
+	int PushableBlockFloorBorder(short itemNumber);
+	int PushableBlockCeilingBorder(short itemNumber);
+}

--- a/TombEngine/Objects/TR5/Object/tr5_pushableblock_info.h
+++ b/TombEngine/Objects/TR5/Object/tr5_pushableblock_info.h
@@ -1,36 +1,33 @@
 #pragma once
 
-namespace TEN::Entities::Generic
+enum class PushableMovementState
 {
-	enum class PushableMovementState
-	{
-		None,
-		Moving,
-		Stopping
-	};
+	None,
+	Moving,
+	Stopping
+};
 
-	struct PushableInfo
-	{
-		PushableMovementState MovementState = PushableMovementState::None;
+struct PushableInfo
+{
+	PushableMovementState MovementState = PushableMovementState::None;
 
-		int height;				// height for collision, also in floor procedure
-		int weight;
-		unsigned int stackLimit;
-		int moveX;				// used for pushable movement code
-		int moveZ;				// used for pushable movement code
-		int linkedIndex;		// using itemFlags[1] for now
-		int gravity;			// fall acceleration
-		int loopSound;			// looped sound index for movement
-		int stopSound;			// ending sound index
-		int fallSound;			// sound on hitting floor (if dropped)
-		int climb;				// not used for now
-		bool canFall;			// OCB 32
-		bool hasFloorCeiling;	// has floor and ceiling procedures (OCB 64)
-		bool disablePull;		// OCB 128
-		bool disablePush;		// OCB 256
-		bool disableW;			// OCB 512 (W+E)
-		bool disableE;			// OCB 512 (W+E)
-		bool disableN;			// OCB 1024 (N+S)
-		bool disableS;			// OCB 1024 (N+S)
-	};
-}
+	int height;				// height for collision, also in floor procedure
+	int weight;
+	unsigned int stackLimit;
+	int moveX;				// used for pushable movement code
+	int moveZ;				// used for pushable movement code
+	int linkedIndex;		// using itemFlags[1] for now
+	int gravity;			// fall acceleration
+	int loopSound;			// looped sound index for movement
+	int stopSound;			// ending sound index
+	int fallSound;			// sound on hitting floor (if dropped)
+	int climb;				// not used for now
+	bool canFall;			// OCB 32
+	bool hasFloorCeiling;	// has floor and ceiling procedures (OCB 64)
+	bool disablePull;		// OCB 128
+	bool disablePush;		// OCB 256
+	bool disableW;			// OCB 512 (W+E)
+	bool disableE;			// OCB 512 (W+E)
+	bool disableN;			// OCB 1024 (N+S)
+	bool disableS;			// OCB 1024 (N+S)
+};

--- a/TombEngine/Objects/TR5/Object/tr5_pushableblock_info.h
+++ b/TombEngine/Objects/TR5/Object/tr5_pushableblock_info.h
@@ -15,7 +15,7 @@ namespace TEN::Entities::Generic
 
 		int height;				// height for collision, also in floor procedure
 		int weight;
-		int stackLimit;
+		unsigned int stackLimit;
 		int moveX;				// used for pushable movement code
 		int moveZ;				// used for pushable movement code
 		int linkedIndex;		// using itemFlags[1] for now

--- a/TombEngine/Objects/TR5/Object/tr5_pushableblock_info.h
+++ b/TombEngine/Objects/TR5/Object/tr5_pushableblock_info.h
@@ -18,14 +18,14 @@ namespace TEN::Entities::Generic
 		int stackLimit;
 		int moveX;				// used for pushable movement code
 		int moveZ;				// used for pushable movement code
-		short linkedIndex;		// using itemFlags[1] for now
-		short gravity;			// fall acceleration
-		short loopSound;		// looped sound index for movement
-		short stopSound;		// ending sound index
-		short fallSound;		// sound on hitting floor (if dropped)
-		short climb;			// not used for now
+		int linkedIndex;		// using itemFlags[1] for now
+		int gravity;			// fall acceleration
+		int loopSound;			// looped sound index for movement
+		int stopSound;			// ending sound index
+		int fallSound;			// sound on hitting floor (if dropped)
+		int climb;				// not used for now
 		bool canFall;			// OCB 32
-		bool hasFloorCeiling;			// has floor and ceiling procedures (OCB 64)
+		bool hasFloorCeiling;	// has floor and ceiling procedures (OCB 64)
 		bool disablePull;		// OCB 128
 		bool disablePush;		// OCB 256
 		bool disableW;			// OCB 512 (W+E)

--- a/TombEngine/Objects/TR5/Object/tr5_pushableblock_info.h
+++ b/TombEngine/Objects/TR5/Object/tr5_pushableblock_info.h
@@ -1,33 +1,36 @@
 #pragma once
 
-enum class PushableMovementState
+namespace TEN::Entities::Generic
 {
-	None,
-	Moving,
-	Stopping
-};
+	enum class PushableMovementState
+	{
+		None,
+		Moving,
+		Stopping
+	};
 
-struct PushableInfo
-{
-	PushableMovementState MovementState = PushableMovementState::None;
+	struct PushableInfo
+	{
+		PushableMovementState MovementState = PushableMovementState::None;
 
-	int height;				// height for collision, also in floor procedure
-	int weight;
-	int stackLimit;
-	int moveX;				// used for pushable movement code
-	int moveZ;				// used for pushable movement code
-	int linkedIndex;		// using itemFlags[1] for now
-	int gravity;			// fall acceleration
-	int loopSound;			// looped sound index for movement
-	int stopSound;			// ending sound index
-	int fallSound;			// sound on hitting floor (if dropped)
-	int climb;				// not used for now
-	bool canFall;			// OCB 32
-	bool hasFloorCeiling;	// has floor and ceiling procedures (OCB 64)
-	bool disablePull;		// OCB 128
-	bool disablePush;		// OCB 256
-	bool disableW;			// OCB 512 (W+E)
-	bool disableE;			// OCB 512 (W+E)
-	bool disableN;			// OCB 1024 (N+S)
-	bool disableS;			// OCB 1024 (N+S)
-};
+		int height;				// height for collision, also in floor procedure
+		int weight;
+		int stackLimit;
+		int moveX;				// used for pushable movement code
+		int moveZ;				// used for pushable movement code
+		int linkedIndex;		// using itemFlags[1] for now
+		int gravity;			// fall acceleration
+		int loopSound;			// looped sound index for movement
+		int stopSound;			// ending sound index
+		int fallSound;			// sound on hitting floor (if dropped)
+		int climb;				// not used for now
+		bool canFall;			// OCB 32
+		bool hasFloorCeiling;	// has floor and ceiling procedures (OCB 64)
+		bool disablePull;		// OCB 128
+		bool disablePush;		// OCB 256
+		bool disableW;			// OCB 512 (W+E)
+		bool disableE;			// OCB 512 (W+E)
+		bool disableN;			// OCB 1024 (N+S)
+		bool disableS;			// OCB 1024 (N+S)
+	};
+}

--- a/TombEngine/Objects/TR5/Object/tr5_pushableblock_info.h
+++ b/TombEngine/Objects/TR5/Object/tr5_pushableblock_info.h
@@ -13,7 +13,7 @@ struct PushableInfo
 
 	int height;				// height for collision, also in floor procedure
 	int weight;
-	int stackLimit;
+	unsigned int stackLimit;
 	int moveX;				// used for pushable movement code
 	int moveZ;				// used for pushable movement code
 	int linkedIndex;		// using itemFlags[1] for now

--- a/TombEngine/Objects/TR5/Object/tr5_pushableblock_info.h
+++ b/TombEngine/Objects/TR5/Object/tr5_pushableblock_info.h
@@ -1,28 +1,36 @@
 #pragma once
 
-enum class PushableMovementState;
-
-struct PushableInfo
+namespace TEN::Entities::Generic
 {
-	PushableMovementState MovementState;
+	enum class PushableMovementState
+	{
+		None,
+		Moving,
+		Stopping
+	};
 
-	int height;				// height for collision, also in floor procedure
-	int weight;
-	int stackLimit;
-	int moveX;				// used for pushable movement code
-	int moveZ;				// used for pushable movement code
-	short linkedIndex;		// using itemFlags[1] for now
-	short gravity;			// fall acceleration
-	short loopSound;		// looped sound index for movement
-	short stopSound;		// ending sound index
-	short fallSound;		// sound on hitting floor (if dropped)
-	short climb;			// not used for now
-	bool canFall;			// OCB 32
-	bool hasFloorCeiling;			// has floor and ceiling procedures (OCB 64)
-	bool disablePull;		// OCB 128
-	bool disablePush;		// OCB 256
-	bool disableW;			// OCB 512 (W+E)
-	bool disableE;			// OCB 512 (W+E)
-	bool disableN;			// OCB 1024 (N+S)
-	bool disableS;			// OCB 1024 (N+S)
-};
+	struct PushableInfo
+	{
+		PushableMovementState MovementState = PushableMovementState::None;
+
+		int height;				// height for collision, also in floor procedure
+		int weight;
+		int stackLimit;
+		int moveX;				// used for pushable movement code
+		int moveZ;				// used for pushable movement code
+		short linkedIndex;		// using itemFlags[1] for now
+		short gravity;			// fall acceleration
+		short loopSound;		// looped sound index for movement
+		short stopSound;		// ending sound index
+		short fallSound;		// sound on hitting floor (if dropped)
+		short climb;			// not used for now
+		bool canFall;			// OCB 32
+		bool hasFloorCeiling;			// has floor and ceiling procedures (OCB 64)
+		bool disablePull;		// OCB 128
+		bool disablePush;		// OCB 256
+		bool disableW;			// OCB 512 (W+E)
+		bool disableE;			// OCB 512 (W+E)
+		bool disableN;			// OCB 1024 (N+S)
+		bool disableS;			// OCB 1024 (N+S)
+	};
+}

--- a/TombEngine/Objects/TR5/Object/tr5_pushableblock_info.h
+++ b/TombEngine/Objects/TR5/Object/tr5_pushableblock_info.h
@@ -13,7 +13,7 @@ struct PushableInfo
 
 	int height;				// height for collision, also in floor procedure
 	int weight;
-	unsigned int stackLimit;
+	int stackLimit;
 	int moveX;				// used for pushable movement code
 	int moveZ;				// used for pushable movement code
 	int linkedIndex;		// using itemFlags[1] for now


### PR DESCRIPTION
New constants are +1 or -1 block +/- Lara's bounding box Z2 value at the very last frame of the pushing/pulling animation. Ideally it could even be fetched from the animation itself rather than typing it in the code.

Now the block follows Lara's hands as expected, stops when it should, and stops exactly at the center of the block at the end of Lara's pulling or pushing animation.

Should be used with attached animations below.
- Also includes fixed versions of the ungrab animations.
- Also includes possibility to ungrab earlier when Lara has just started grabbing the block.

[PUSHABLE_ANIMATIONS.zip](https://github.com/MontyTRC89/TombEngine/files/10251906/PUSHABLE_ANIMATIONS.zip)
