### PR TITLE
Update cog_switch.cpp

### DIFF
--- a/TombEngine/Objects/Generic/Switches/cog_switch.cpp
+++ b/TombEngine/Objects/Generic/Switches/cog_switch.cpp
@@ -149,7 +149,8 @@ namespace TEN::Entities::Switches
 		}
 		else
 		{
-			if (switchItem->Animation.FrameNumber == g_Level.Anims[switchItem->Animation.AnimNumber].frameEnd)
+			if ((switchItem->Animation.FrameNumber == g_Level.Anims[switchItem->Animation.AnimNumber].frameEnd)
+				&& (LaraItem->Animation.AnimNumber == LA_COGWHEEL_RELEASE))
 			{
 				switchItem->Animation.ActiveState = SWITCH_OFF;
 				switchItem->Status = ITEM_NOT_ACTIVE;
@@ -157,6 +158,12 @@ namespace TEN::Entities::Switches
 				RemoveActiveItem(itemNumber);
 
 				Lara.Control.HandStatus = HandStatus::Free;
+			}
+			else
+			{
+				//If Lara is repeating the PULL animation (because player dropped after the frame check).
+				//do the wheel animation again.
+				switchItem->Animation.TargetState = SWITCH_ON;
 			}
 		}
 	}

--- a/TombEngine/Objects/Generic/Switches/cog_switch.cpp
+++ b/TombEngine/Objects/Generic/Switches/cog_switch.cpp
@@ -60,7 +60,7 @@ namespace TEN::Entities::Switches
 
 		// Door was not found, do ordinary collision and exit.
 
-		if (door == nullptr)
+		if ((door == nullptr) && (switchItem->TriggerFlags == 0x00))
 		{
 			ObjectCollision(itemNum, laraItem, coll);
 			return;
@@ -96,7 +96,7 @@ namespace TEN::Entities::Switches
 						switchItem->Animation.TargetState = SWITCH_ON;
 						switchItem->Status = ITEM_ACTIVE;
 
-						if (door != NULL)
+						if ((door != NULL) && (switchItem->TriggerFlags == 0x00))
 						{
 							if (!door->opened)
 							{
@@ -139,8 +139,11 @@ namespace TEN::Entities::Switches
 			{
 				if (LaraItem->Animation.FrameNumber == g_Level.Anims[LaraItem->Animation.AnimNumber].frameBase + 10)
 				{
-					auto* doorItem = &g_Level.Items[Lara.InteractedItem];
-					doorItem->ItemFlags[0] = COG_DOOR_TURN;
+					if (switchItem->TriggerFlags == 0x00)
+					{
+						auto* doorItem = &g_Level.Items[Lara.InteractedItem];
+						doorItem->ItemFlags[0] = COG_DOOR_TURN;
+					}
 				}
 			}
 		}
@@ -153,8 +156,8 @@ namespace TEN::Entities::Switches
 
 				RemoveActiveItem(itemNumber);
 
-				LaraItem->Animation.AnimNumber = LA_STAND_SOLID;
-				LaraItem->Animation.FrameNumber = g_Level.Anims[LaraItem->Animation.AnimNumber].frameBase;
+				LaraItem->Animation.AnimNumber = LA_COGWHEEL_RELEASE;
+				LaraItem->Animation.FrameNumber = g_Level.Anims[LaraItem->Animation.AnimNumber].frameBase + 11;
 				LaraItem->Animation.TargetState = LS_IDLE;
 				LaraItem->Animation.ActiveState = LS_IDLE;
 				Lara.Control.HandStatus = HandStatus::Free;

--- a/TombEngine/Objects/Generic/Switches/cog_switch.cpp
+++ b/TombEngine/Objects/Generic/Switches/cog_switch.cpp
@@ -131,7 +131,7 @@ namespace TEN::Entities::Switches
 		{
 			if (switchItem->Animation.TargetState == SWITCH_ON && !(TrInput & IN_ACTION))
 			{
-				LaraItem->Animation.TargetState = LS_IDLE;
+				LaraItem->Animation.TargetState = LS_COGWHEEL_UNGRAB;
 				switchItem->Animation.TargetState = SWITCH_OFF;
 			}
 
@@ -156,10 +156,6 @@ namespace TEN::Entities::Switches
 
 				RemoveActiveItem(itemNumber);
 
-				LaraItem->Animation.AnimNumber = LA_COGWHEEL_RELEASE;
-				LaraItem->Animation.FrameNumber = g_Level.Anims[LaraItem->Animation.AnimNumber].frameBase + 11;
-				LaraItem->Animation.TargetState = LS_IDLE;
-				LaraItem->Animation.ActiveState = LS_IDLE;
 				Lara.Control.HandStatus = HandStatus::Free;
 			}
 		}

--- a/TombEngine/Objects/Generic/Switches/cog_switch.cpp
+++ b/TombEngine/Objects/Generic/Switches/cog_switch.cpp
@@ -96,7 +96,7 @@ namespace TEN::Entities::Switches
 						switchItem->Animation.TargetState = SWITCH_ON;
 						switchItem->Status = ITEM_ACTIVE;
 
-						if ((door != NULL) && (!switchItem->TriggerFlags))
+						if ((door != nullptr) && (!switchItem->TriggerFlags))
 						{
 							if (!door->opened)
 							{

--- a/TombEngine/Objects/Generic/Switches/cog_switch.cpp
+++ b/TombEngine/Objects/Generic/Switches/cog_switch.cpp
@@ -60,7 +60,7 @@ namespace TEN::Entities::Switches
 
 		// Door was not found, do ordinary collision and exit.
 
-		if ((door == nullptr) && (switchItem->TriggerFlags == 0x00))
+		if ((door == nullptr) && (!switchItem->TriggerFlags))
 		{
 			ObjectCollision(itemNum, laraItem, coll);
 			return;
@@ -96,7 +96,7 @@ namespace TEN::Entities::Switches
 						switchItem->Animation.TargetState = SWITCH_ON;
 						switchItem->Status = ITEM_ACTIVE;
 
-						if ((door != NULL) && (switchItem->TriggerFlags == 0x00))
+						if ((door != NULL) && (!switchItem->TriggerFlags))
 						{
 							if (!door->opened)
 							{
@@ -139,7 +139,7 @@ namespace TEN::Entities::Switches
 			{
 				if (LaraItem->Animation.FrameNumber == g_Level.Anims[LaraItem->Animation.AnimNumber].frameBase + 10)
 				{
-					if (switchItem->TriggerFlags == 0x00)
+					if (!switchItem->TriggerFlags)
 					{
 						auto* doorItem = &g_Level.Items[Lara.InteractedItem];
 						doorItem->ItemFlags[0] = COG_DOOR_TURN;


### PR DESCRIPTION
- Fix an animation issue when Lara stopped using the cog switch

- Added a OCB condition, if OCB is 0, the cog switch will keep working as original one. (Requiring the link with a door that has a OCB2).

But if the OCB put on the cog switch, is different than 0, then it will be able to be used by Lara anytime (although it won't execute any trigger). Useful for Lua script works.