### PR TITLE
fix seth flameball missile mesh

### DIFF
--- a/TombEngine/Objects/TR4/Entity/tr4_setha.cpp
+++ b/TombEngine/Objects/TR4/Entity/tr4_setha.cpp
@@ -659,7 +659,7 @@ namespace TEN::Entities::TR4
 		fx.flag1 = flags;
 		fx.objectNumber = ID_ENERGY_BUBBLES;
 		fx.speed = Random::GenerateInt(0, 32) - ((flags == 1) ? 64 : 0) + 96;
-		fx.frameNumber = Objects[ID_ENERGY_BUBBLES].meshIndex + 2 * flags;
+		fx.frameNumber = Objects[ID_ENERGY_BUBBLES].meshIndex + 2 - flags;
 	}
 
 	void SethKillAttack(ItemInfo* item, ItemInfo* laraItem)


### PR DESCRIPTION
now the correct mesh appears on seth normal attacks and the big blue spiky ball.