### PR TITLE
Fix Big Rat death crash

### DIFF
--- a/Documentation/Changes.txt
+++ b/Documentation/Changes.txt
@@ -10,7 +10,8 @@ Version 1.0.6
 * Fix backholster weapons not updating their sound position together with player.
 * Fix black screen bug when there was an obstacle between the fixed camera and the target.
 * Fix underwater caustics not appearing without visiting options menu beforehand.
-* Fix TR4 skeleton spawn when used with OCB 3
+* Fix TR1 BIG_RAT which crashed the game when it was killed.
+* Fix TR4 SKELETON spawn when used with OCB 3
 * Fix TR4 SAS teleporting over the blocks he walks by.
 * Add undead flag to TR4 sphinx to prevent it from becoming bugged after receiving a lot of damage.
 * Add an option to activate Lua or node events from legacy triggers.

--- a/TombEngine/Objects/TR1/Entity/tr1_big_rat.cpp
+++ b/TombEngine/Objects/TR1/Entity/tr1_big_rat.cpp
@@ -81,7 +81,7 @@ namespace TEN::Entities::Creatures::TR1
 			SetAnimation(item, BIG_RAT_ANIM_IDLE);
 	}
 
-	bool IsRatOnWater(ItemInfo* item)
+	bool RatOnWater(ItemInfo* item)
 	{
 		int waterDepth = GetWaterSurface(item->Pose.Position.x, item->Pose.Position.y, item->Pose.Position.z, item->RoomNumber);
 		
@@ -117,7 +117,7 @@ namespace TEN::Entities::Creatures::TR1
 
 		if (item->HitPoints <= 0)
 		{
-			bool doWaterDeath = IsRatOnWater(item);
+			bool doWaterDeath = RatOnWater(item);
 			if (item->Animation.ActiveState != BIG_RAT_STATE_LAND_DEATH &&
 				item->Animation.ActiveState != BIG_RAT_STATE_WATER_DEATH)
 			{
@@ -157,7 +157,7 @@ namespace TEN::Entities::Creatures::TR1
 			case BIG_RAT_STATE_RUN_FORWARD:
 				creature->MaxTurn = BIG_RAT_RUN_TURN_RATE_MAX;
 
-				if (IsRatOnWater(item))
+				if (RatOnWater(item))
 				{
 					SetAnimation(item, BIG_RAT_ANIM_SWIM);
 					break;
@@ -210,7 +210,7 @@ namespace TEN::Entities::Creatures::TR1
 			case BIG_RAT_STATE_SWIM:
 				creature->MaxTurn = BIG_RAT_SWIM_TURN_RATE_MAX;
 
-				if (!IsRatOnWater(item))
+				if (!RatOnWater(item))
 				{
 					SetAnimation(item, BIG_RAT_ANIM_RUN_FORWARD);
 					break;
@@ -237,7 +237,7 @@ namespace TEN::Entities::Creatures::TR1
 		CreatureJoint(item, 0, head);
 		CreatureAnimation(itemNumber, angle, 0);
 
-		if (IsRatOnWater(item))
+		if (RatOnWater(item))
 		{
 			CreatureUnderwater(item, 0);
 			item->Pose.Position.y = GetWaterHeight(item) - BIG_RAT_WATER_SURFACE_OFFSET;

--- a/TombEngine/Objects/TR1/Entity/tr1_big_rat.cpp
+++ b/TombEngine/Objects/TR1/Entity/tr1_big_rat.cpp
@@ -83,21 +83,24 @@ namespace TEN::Entities::Creatures::TR1
 
 	bool IsRatOnWater(ItemInfo* item)
 	{
-		auto* creature = GetCreatureInfo(item);
-		auto* object = &Objects[item->ObjectNumber];
-
 		int waterDepth = GetWaterSurface(item->Pose.Position.x, item->Pose.Position.y, item->Pose.Position.z, item->RoomNumber);
-		if (waterDepth != NO_HEIGHT)
+		
+		if (item->IsCreature())
 		{
-			creature->LOT.Step = BLOCK(20);
-			creature->LOT.Drop = -BLOCK(20);
-		}
-		else
-		{
-			creature->LOT.Step = CLICK(1);
-			creature->LOT.Drop = -CLICK(1);
-		}
+			auto* creature = GetCreatureInfo(item);
 
+			if (waterDepth != NO_HEIGHT)
+			{
+				creature->LOT.Step = BLOCK(20);
+				creature->LOT.Drop = -BLOCK(20);
+			}
+			else
+			{
+				creature->LOT.Step = CLICK(1);
+				creature->LOT.Drop = -CLICK(1);
+			}
+		}
+		
 		return waterDepth != NO_HEIGHT;
 	}
 


### PR DESCRIPTION
It was happening, that when the Big Rat was killed, like other objects, "CreatureAnimation( )" puts the monster in deactivate state and deletes its item->Data.

But the Control function was trying to access that item->Data after that. In the "IsRatOnWater( )" function, which must be activated after CreatureAnimation( ). Because item->Data didn't exist by then, the game crashes.

This fix what it does is add a check verification to IsRatOnWater in the area that uses creature so if it detects that item->Data is invalid, it ignores those lines.
