### PR TITLE
Fix: Ceiling and Floor trapdoors

### DIFF
--- a/TombEngine/Objects/Generic/generic_objects.cpp
+++ b/TombEngine/Objects/Generic/generic_objects.cpp
@@ -43,7 +43,7 @@ using namespace TEN::Entities::Generic;
 
 static void StartObject(ObjectInfo* object)
 {
-	for (int objectNumber = ID_TRAPDOOR1; objectNumber <= ID_CEILING_TRAPDOOR2; objectNumber++)
+	for (int objectNumber = ID_TRAPDOOR1; objectNumber <= ID_TRAPDOOR3; objectNumber++)
 	{
 		object = &Objects[objectNumber];
 		if (object->loaded)
@@ -58,6 +58,51 @@ static void StartObject(ObjectInfo* object)
 			object->SetupHitEffect(true);
 		}
 	}
+
+	for (int objectNumber = ID_FLOOR_TRAPDOOR1; objectNumber <= ID_FLOOR_TRAPDOOR2; objectNumber++)
+	{
+		object = &Objects[objectNumber];
+		if (object->loaded)
+		{
+			object->initialise = InitialiseTrapDoor;
+			object->collision = FloorTrapDoorCollision;
+			object->control = TrapDoorControl;
+			object->floorBorder = TrapDoorFloorBorder;
+			object->ceilingBorder = TrapDoorCeilingBorder;
+			object->floor = TrapDoorFloor;
+			object->ceiling = TrapDoorCeiling;
+			object->SetupHitEffect(true);
+		}
+	}
+
+	for (int objectNumber = ID_CEILING_TRAPDOOR1; objectNumber <= ID_CEILING_TRAPDOOR2; objectNumber++)
+	{
+		object = &Objects[objectNumber];
+		if (object->loaded)
+		{
+			object->initialise = InitialiseTrapDoor;
+			object->collision = CeilingTrapDoorCollision;
+			object->control = TrapDoorControl;
+			object->floorBorder = TrapDoorFloorBorder;
+			object->ceilingBorder = TrapDoorCeilingBorder;
+			object->floor = TrapDoorFloor;
+			object->ceiling = TrapDoorCeiling;
+			object->SetupHitEffect(true);
+		}
+	}
+
+	/*object = &Objects[ID_SCALING_TRAPDOOR];  //I don't know what this Object purpose.
+	if (object->loaded)
+	{
+		object->initialise = InitialiseTrapDoor;
+		object->collision = TrapDoorCollision;
+		object->control = TrapDoorControl;
+		object->floorBorder = TrapDoorFloorBorder;
+		object->ceilingBorder = TrapDoorCeilingBorder;
+		object->floor = TrapDoorFloor;
+		object->ceiling = TrapDoorCeiling;
+		object->SetupHitEffect(true);
+	}*/
 
 	object = &Objects[ID_BRIDGE_FLAT];
 	if (object->loaded)


### PR DESCRIPTION
Although the trapdoor code were correct, looks like that at some moment, someone merged all the trapdoors to initialize them together with the same values.

But Ceiling and Floor Trapdoors must use Collision functions different than the normal trapdoor. So this fix separate those objects from the generic trapdoors and put their right collision functions.


(P.D, I found an ID_SCALING_TRAPDOOR, I don't know what is that, so I write its initialization block like a normal trapdoor but I commented it, whoever created may know what to do with it.).