### PR TITLE
Tiger polishment adngel

### DIFF
--- a/Documentation/Changes.txt
+++ b/Documentation/Changes.txt
@@ -10,6 +10,7 @@ Version 1.0.7
 	- 1 – Normal mode. Sophia behaves like a regular enemy.
 	- 2 – Tower Mode. Behaviour matched from Tomb Raider III. Invincible unless triggered to be killed.
 	- 6 – Tower Mode with Volumes. Same as Tower Mode but Sophia’s ascent can be controlled using volumes in Tomb Editor.
+* Improve behaviour of Tiger and Lion enemies. 
 
 Version 1.0.6
 =============

--- a/TombEngine/Game/collision/collide_room.cpp
+++ b/TombEngine/Game/collision/collide_room.cpp
@@ -847,19 +847,19 @@ void AlignEntityToSurface(ItemInfo* item, const Vector2& ellipse, float alpha, f
 
 	// Calculate extra rotation required.
 	auto extraRot = EulerAngles(
-		FROM_RAD(atan2f(forwardHeightDif, ellipse.y * 2)),
+		FROM_RAD(atan2(forwardHeightDif, ellipse.y * 2)),
 		0,
-		FROM_RAD(atan2(lateralHeightDif, ellipse.x * 2))
-	) - EulerAngles(item->Pose.Orientation.x, 0, item->Pose.Orientation.z);
+		FROM_RAD(atan2(lateralHeightDif, ellipse.x * 2))) -
+		EulerAngles(item->Pose.Orientation.x, 0, item->Pose.Orientation.z);
 
-	// Rotate X axis if forward height difference is not too significant.
+	// Rotate X axis.
 	if (abs(forwardHeightDif) <= STEPUP_HEIGHT)
 	{
 		if (abs(extraRot.x) <= ANGLE(constraintAngle))
 			item->Pose.Orientation.x += extraRot.x * alpha;
 	}
 
-	// Rotate Z axis if lateral height difference is not too significant.
+	// Rotate Z axis.
 	if (abs(lateralHeightDif) <= STEPUP_HEIGHT)
 	{
 		if (abs(extraRot.z) <= ANGLE(constraintAngle))
@@ -869,7 +869,7 @@ void AlignEntityToSurface(ItemInfo* item, const Vector2& ellipse, float alpha, f
 
 int GetQuadrant(short angle)
 {
-	return (unsigned short)(angle + ANGLE(45.0f)) / ANGLE(90.0f);
+	return (unsigned short(angle + ANGLE(45.0f)) / ANGLE(90.0f));
 }
 
 // Determines vertical surfaces and gets nearest ledge angle.

--- a/TombEngine/Objects/TR3/Entity/tr3_tiger.cpp
+++ b/TombEngine/Objects/TR3/Entity/tr3_tiger.cpp
@@ -187,10 +187,10 @@ namespace TEN::Entities::Creatures::TR3
 				case TIGER_STATE_POUNCE_ATTACK:
 					if (!creature->Flags && item->TouchBits.Test(TigerBiteAttackJoints))
 					{
-						if	(item->Animation.AnimNumber == Objects[ID_TIGER].animIndex + TIGER_ANIM_BITE_ATTACK &&
-							 item->Animation.FrameNumber > g_Level.Anims[item->Animation.AnimNumber].frameBase + 4 ||
-							item->Animation.AnimNumber == Objects[ID_TIGER].animIndex + TIGER_ANIM_POUNCE_ATTACK_START &&
-							 item->Animation.FrameNumber > g_Level.Anims[item->Animation.AnimNumber].frameBase + 12 )
+						if	(item->Animation.AnimNumber == GetAnimNumber(*item, TIGER_ANIM_BITE_ATTACK) &&
+							 item->Animation.FrameNumber > GetFrameNumber(item, 4) ||
+							 item->Animation.AnimNumber == GetAnimNumber(*item, TIGER_ANIM_POUNCE_ATTACK_START) &&
+							 item->Animation.FrameNumber > GetFrameNumber(item, 12))
 						{
 							DoDamage(creature->Enemy, TIGER_BITE_ATTACK_DAMAGE);
 							CreatureEffect(item, TigerBite, DoBloodSplat);
@@ -202,9 +202,9 @@ namespace TEN::Entities::Creatures::TR3
 				case TIGER_STATE_RUN_SWIPE_ATTACK:
 					if (!creature->Flags && item->TouchBits.Test(TigerSwipeAttackJoints))
 					{
-						if (item->Animation.AnimNumber == Objects[ID_TIGER].animIndex + TIGER_ANIM_RUN_SWIPE_ATTACK &&
-							item->Animation.FrameNumber >= g_Level.Anims[item->Animation.AnimNumber].frameBase + 6 &&
-							item->Animation.FrameNumber < g_Level.Anims[item->Animation.AnimNumber].frameBase + 16)
+						if (item->Animation.AnimNumber == GetAnimNumber(*item, TIGER_ANIM_RUN_SWIPE_ATTACK) &&
+							item->Animation.FrameNumber >= GetFrameNumber(item, 6) &&
+							item->Animation.FrameNumber < GetFrameNumber(item, 16))
 						{
 							DoDamage(creature->Enemy, TIGER_SWIPE_ATTACK_DAMAGE);
 							CreatureEffect(item, TigerBite, DoBloodSplat);

--- a/TombEngine/Objects/TR3/Entity/tr3_tiger.cpp
+++ b/TombEngine/Objects/TR3/Entity/tr3_tiger.cpp
@@ -210,10 +210,11 @@ namespace TEN::Entities::Creatures::TR3
 				case TIGER_STATE_POUNCE_ATTACK:
 					if (!creature->Flags && item->TouchBits.Test(TigerBiteAttackJoints))
 					{
-						if	(item->Animation.AnimNumber == GetAnimNumber(*item, TIGER_ANIM_BITE_ATTACK) &&
-							 item->Animation.FrameNumber > GetFrameNumber(item, 4) ||
-							 item->Animation.AnimNumber == GetAnimNumber(*item, TIGER_ANIM_POUNCE_ATTACK_START) &&
-							 item->Animation.FrameNumber > GetFrameNumber(item, 12))
+						if	( (item->Animation.AnimNumber == GetAnimNumber(*item, TIGER_ANIM_BITE_ATTACK) &&
+							   item->Animation.FrameNumber > GetFrameNumber(item,  4) ) ||
+							  (item->Animation.AnimNumber == GetAnimNumber(*item, TIGER_ANIM_POUNCE_ATTACK_START) &&
+							   item->Animation.FrameNumber > GetFrameNumber(item, 12) )
+							)
 						{
 							DoDamage(creature->Enemy, TIGER_BITE_ATTACK_DAMAGE);
 							CreatureEffect(item, TigerBite, DoBloodSplat);

--- a/TombEngine/Objects/TR3/Entity/tr3_tiger.cpp
+++ b/TombEngine/Objects/TR3/Entity/tr3_tiger.cpp
@@ -185,9 +185,9 @@ namespace TEN::Entities::Creatures::TR3
 				case TIGER_STATE_POUNCE_ATTACK:
 					if (!creature->Flags && item->TouchBits.Test(TigerBiteAttackJoints))
 					{
-						if	(item->Animation.ActiveState == TIGER_STATE_BITE_ATTACK &&
+						if	(item->Animation.AnimNumber == Objects[ID_TIGER].animIndex + TIGER_ANIM_BITE_ATTACK &&
 							 item->Animation.FrameNumber > g_Level.Anims[item->Animation.AnimNumber].frameBase + 4 ||
-							 item->Animation.ActiveState == TIGER_STATE_POUNCE_ATTACK &&
+							item->Animation.AnimNumber == Objects[ID_TIGER].animIndex + TIGER_ANIM_POUNCE_ATTACK_START &&
 							 item->Animation.FrameNumber > g_Level.Anims[item->Animation.AnimNumber].frameBase + 12 )
 						{
 							DoDamage(creature->Enemy, TIGER_BITE_ATTACK_DAMAGE);
@@ -200,7 +200,7 @@ namespace TEN::Entities::Creatures::TR3
 				case TIGER_STATE_RUN_SWIPE_ATTACK:
 					if (!creature->Flags && item->TouchBits.Test(TigerSwipeAttackJoints))
 					{
-						if (item->Animation.ActiveState == TIGER_STATE_RUN_SWIPE_ATTACK &&
+						if (item->Animation.AnimNumber == Objects[ID_TIGER].animIndex + TIGER_ANIM_RUN_SWIPE_ATTACK &&
 							item->Animation.FrameNumber >= g_Level.Anims[item->Animation.AnimNumber].frameBase + 6 &&
 							item->Animation.FrameNumber < g_Level.Anims[item->Animation.AnimNumber].frameBase + 16)
 						{

--- a/TombEngine/Objects/TR3/Entity/tr3_tiger.cpp
+++ b/TombEngine/Objects/TR3/Entity/tr3_tiger.cpp
@@ -1,6 +1,7 @@
 #include "framework.h"
 #include "Objects/TR3/Entity/tr3_tiger.h"
 
+#include "Game/collision/collide_room.h"
 #include "Game/control/box.h"
 #include "Game/control/control.h"
 #include "Game/effects/effects.h"
@@ -73,6 +74,7 @@ namespace TEN::Entities::Creatures::TR3
 			return;
 
 		auto* item = &g_Level.Items[itemNumber];
+		auto* object = &Objects[item->ObjectNumber];
 		auto* creature = GetCreatureInfo(item);
 
 		short headingAngle = 0;
@@ -217,5 +219,8 @@ namespace TEN::Entities::Creatures::TR3
 		CreatureTilt(item, tiltAngle);
 		CreatureJoint(item, 0, extraHeadRot.y);
 		CreatureAnimation(itemNumber, headingAngle, tiltAngle);
+
+		auto radius = Vector2(object->radius, object->radius * 1.33f);
+		AlignEntityToSurface(item, radius);
 	}
 }

--- a/TombEngine/Objects/TR4/Entity/tr4_harpy.cpp
+++ b/TombEngine/Objects/TR4/Entity/tr4_harpy.cpp
@@ -446,8 +446,8 @@ namespace TEN::Entities::TR4
 						creature->Enemy != nullptr &&
 						abs(creature->Enemy->Pose.Position.y - item->Pose.Position.y) <= BLOCK(1) &&
 						AI.distance < SQUARE(BLOCK(2)) &&
-						item->Animation.ActiveState == HARPY_STATE_STINGER_ATTACK &&
-						item->Animation.FrameNumber > g_Level.Anims[item->Animation.AnimNumber].frameBase + 17)
+						item->Animation.AnimNumber == GetAnimNumber(*item, HARPY_ANIM_STINGER_ATTACK) &&
+						item->Animation.FrameNumber > GetFrameNumber(item, 17))
 					)
 				{
 					if (creature->Enemy->IsLara())

--- a/TombEngine/Objects/TR5/Entity/tr5_lion.cpp
+++ b/TombEngine/Objects/TR5/Entity/tr5_lion.cpp
@@ -1,6 +1,7 @@
 #include "framework.h"
 #include "Objects/TR5/Entity/tr5_lion.h"
 
+#include "Game/collision/collide_room.h"
 #include "Game/control/box.h"
 #include "Game/control/control.h"
 #include "Game/effects/effects.h"
@@ -77,7 +78,12 @@ namespace TEN::Entities::Creatures::TR5
 
 	void LionControl(short itemNumber)
 	{
+		if (!CreatureActive(itemNumber))
+			return;
+
 		auto* item = &g_Level.Items[itemNumber];
+		auto* object = &Objects[item->ObjectNumber];
+		auto* creature = GetCreatureInfo(item);
 
 		short angle = 0;
 		short tilt = 0;
@@ -85,150 +91,149 @@ namespace TEN::Entities::Creatures::TR5
 		short joint1 = 0;
 		short headingAngle = 0;
 		bool targetAhead = false;
-		
-		if (CreatureActive(itemNumber))
+
+		if (item->HitPoints <= 0)
 		{
-			auto* creature = GetCreatureInfo(item);
+			item->HitPoints = 0;
 
-			if (item->HitPoints <= 0)
-			{
-				item->HitPoints = 0;
+			if (item->Animation.ActiveState != LION_STATE_DEATH)
+				SetAnimation(item, LionDeathAnims[GenerateInt(0, LionDeathAnims.size() - 1)]);
+		}
+		else
+		{
+			AI_INFO AI;
+			CreatureAIInfo(item, &AI);
 
-				if (item->Animation.ActiveState != LION_STATE_DEATH)
-					SetAnimation(item, LionDeathAnims[GenerateInt(0, LionDeathAnims.size() - 1)]);
-			}
-			else
-			{
-				AI_INFO AI;
-				CreatureAIInfo(item, &AI);
+			//Because the lion is quite big, AI.ahead don't get properly the angle from the lion's head. So I'm calculating its own one like tr1_giant_mutant.
 
-				//Because the lion is quite big, AI.ahead don't get properly the angle from the lion's head. So I'm calculating its own one like tr1_giant_mutant.
-
-				Vector3 forwardVector = Vector3(cos(item->Pose.Orientation.x) * sin(item->Pose.Orientation.y), -sin(item->Pose.Orientation.x), cos(item->Pose.Orientation.x) * cos(item->Pose.Orientation.y));
-				forwardVector.Normalize();
-				forwardVector *= LION_HEAD_DISTANCE;
-				headingAngle = (short)phd_atan(	creature->Target.z - item->Pose.Position.z + forwardVector.z,
+			Vector3 forwardVector = Vector3(cos(item->Pose.Orientation.x) * sin(item->Pose.Orientation.y), -sin(item->Pose.Orientation.x), cos(item->Pose.Orientation.x) * cos(item->Pose.Orientation.y));
+			forwardVector.Normalize();
+			forwardVector *= LION_HEAD_DISTANCE;
+			headingAngle = (short)phd_atan(	creature->Target.z - item->Pose.Position.z + forwardVector.z,
 												creature->Target.x - item->Pose.Position.x + forwardVector.x) - item->Pose.Orientation.y;
-				targetAhead = (headingAngle > -FRONT_ARC && headingAngle < FRONT_ARC);
+			targetAhead = (headingAngle > -FRONT_ARC && headingAngle < FRONT_ARC);
 
-				if (targetAhead)
-					joint1 = headingAngle;
+			if (targetAhead)
+				joint1 = headingAngle;
 
-				GetCreatureMood(item, &AI, true);
-				CreatureMood(item, &AI, true);
+			GetCreatureMood(item, &AI, true);
+			CreatureMood(item, &AI, true);
 
-				angle = CreatureTurn(item, creature->MaxTurn);
-				joint0 = angle * -16;
+			angle = CreatureTurn(item, creature->MaxTurn);
+			joint0 = angle * -16;
 
-				switch (item->Animation.ActiveState)
-				{
-					case LION_STATE_IDLE:
-						creature->MaxTurn = 0;
-						creature->Flags = 0;
+			switch (item->Animation.ActiveState)
+			{
+				case LION_STATE_IDLE:
+					creature->MaxTurn = 0;
+					creature->Flags = 0;
 
-						if (item->Animation.RequiredState)
+					if (item->Animation.RequiredState)
+					{
+						item->Animation.TargetState = item->Animation.RequiredState;
+						break;
+					}
+
+					if (creature->Mood == MoodType::Bored)
+					{
+						if (!(GetRandomControl() & 0x3F))
+							item->Animation.TargetState = LION_STATE_WALK_FORWARD;
+
+						break;
+					}
+
+					if (targetAhead && AI.bite)
+					{
+						if (AI.distance >= LION_ATTACK_MIN_RANGE)
 						{
-							item->Animation.TargetState = item->Animation.RequiredState;
-							break;
-						}
-
-						if (creature->Mood == MoodType::Bored)
-						{
-							if (!(GetRandomControl() & 0x3F))
-								item->Animation.TargetState = LION_STATE_WALK_FORWARD;
-
-							break;
-						}
-
-						if (targetAhead && AI.bite)
-						{
-							if (AI.distance >= LION_ATTACK_MIN_RANGE)
+							if (AI.distance <= LION_BITE_ATTACK_RANGE)
 							{
-								if (AI.distance <= LION_BITE_ATTACK_RANGE)
-								{
-									item->Animation.TargetState = LION_STATE_BITE_ATTACK;
-									break;
-								}
-								if (AI.distance < LION_POUNCE_ATTACK_RANGE)
-								{
-									item->Animation.TargetState = LION_STATE_POUNCE_ATTACK;
-									break;
-								}
+								item->Animation.TargetState = LION_STATE_BITE_ATTACK;
+								break;
+							}
+							if (AI.distance < LION_POUNCE_ATTACK_RANGE)
+							{
+								item->Animation.TargetState = LION_STATE_POUNCE_ATTACK;
+								break;
 							}
 						}
+					}
 
-						item->Animation.TargetState = LION_STATE_RUN_FORWARD;
-					break;
+					item->Animation.TargetState = LION_STATE_RUN_FORWARD;
+				break;
 
-					case LION_STATE_WALK_FORWARD:
-						creature->MaxTurn = LION_WALK_TURN_RATE_MAX;
+				case LION_STATE_WALK_FORWARD:
+					creature->MaxTurn = LION_WALK_TURN_RATE_MAX;
 
-						if (creature->Mood == MoodType::Bored)
+					if (creature->Mood == MoodType::Bored)
+					{
+						if (TestProbability(LION_ROAR_CHANCE))
+							item->Animation.TargetState = LION_STATE_ROAR;
+					}
+					else
+						item->Animation.TargetState = LION_STATE_IDLE;
+
+				break;
+
+				case LION_STATE_RUN_FORWARD:
+					creature->MaxTurn = LION_RUN_TURN_RATE_MAX;
+					tilt = angle;
+
+					if (creature->Mood != MoodType::Bored)
+					{
+						if (targetAhead &&
+							AI.bite &&
+							AI.distance < LION_POUNCE_ATTACK_RANGE &&
+							AI.distance >= LION_ATTACK_MIN_RANGE)
+								item->Animation.TargetState = LION_STATE_IDLE;
+						else if (creature->Mood != MoodType::Escape)
 						{
 							if (TestProbability(LION_ROAR_CHANCE))
 								item->Animation.TargetState = LION_STATE_ROAR;
 						}
-						else
-							item->Animation.TargetState = LION_STATE_IDLE;
+					}
+					else
+						item->Animation.TargetState = LION_STATE_IDLE;
 
-					break;
+				break;
 
-					case LION_STATE_RUN_FORWARD:
-						creature->MaxTurn = LION_RUN_TURN_RATE_MAX;
-						tilt = angle;
+				case LION_STATE_POUNCE_ATTACK:
+					creature->MaxTurn = LION_ATTACKS_TURN_RATE_MAX;
 
-						if (creature->Mood != MoodType::Bored)
-						{
-							if (targetAhead &&
-								AI.bite &&
-								AI.distance < LION_POUNCE_ATTACK_RANGE &&
-								AI.distance >= LION_ATTACK_MIN_RANGE)
-									item->Animation.TargetState = LION_STATE_IDLE;
-							else if (creature->Mood != MoodType::Escape)
-							{
-								if (TestProbability(LION_ROAR_CHANCE))
-									item->Animation.TargetState = LION_STATE_ROAR;
-							}
-						}
-						else
-							item->Animation.TargetState = LION_STATE_IDLE;
+					if (!creature->Flags &&
+						item->Animation.AnimNumber == Objects[ID_LION].animIndex + LION_ANIM_POUNCE_ATTACK_END &&
+						item->TouchBits.Test(LionAttackJoints))
+					{
+						DoDamage(creature->Enemy, LION_POUNCE_ATTACK_DAMAGE);
+						CreatureEffect2(item, LionBite1, 10, item->Pose.Orientation.y, DoBloodSplat);
+						creature->Flags = 1;
+					}
 
-					break;
+				break;
 
-					case LION_STATE_POUNCE_ATTACK:
-						creature->MaxTurn = LION_ATTACKS_TURN_RATE_MAX;
+				case LION_STATE_BITE_ATTACK:
+					creature->MaxTurn = LION_ATTACKS_TURN_RATE_MAX;
 
-						if (!creature->Flags &&
-							item->Animation.AnimNumber == Objects[ID_LION].animIndex + LION_ANIM_POUNCE_ATTACK_END &&
-							item->TouchBits.Test(LionAttackJoints))
-						{
-							DoDamage(creature->Enemy, LION_POUNCE_ATTACK_DAMAGE);
-							CreatureEffect2(item, LionBite1, 10, item->Pose.Orientation.y, DoBloodSplat);
-							creature->Flags = 1;
-						}
+					if (!creature->Flags &&
+						item->Animation.AnimNumber == Objects[ID_LION].animIndex + LION_ANIM_BITE_ATTACK &&
+						item->TouchBits.Test(LionAttackJoints))
+					{
+						DoDamage(creature->Enemy, LION_BITE_ATTACK_DAMAGE);
+						CreatureEffect2(item, LionBite2, 10, item->Pose.Orientation.y, DoBloodSplat);
+						creature->Flags = 1;
+					}
 
-					break;
-
-					case LION_STATE_BITE_ATTACK:
-						creature->MaxTurn = LION_ATTACKS_TURN_RATE_MAX;
-
-						if (!creature->Flags &&
-							item->Animation.AnimNumber == Objects[ID_LION].animIndex + LION_ANIM_BITE_ATTACK &&
-							item->TouchBits.Test(LionAttackJoints))
-						{
-							DoDamage(creature->Enemy, LION_BITE_ATTACK_DAMAGE);
-							CreatureEffect2(item, LionBite2, 10, item->Pose.Orientation.y, DoBloodSplat);
-							creature->Flags = 1;
-						}
-
-					break;
-				}
+				break;
 			}
 		}
+
 
 		CreatureTilt(item, tilt);
 		CreatureJoint(item, 0, joint0);
 		CreatureJoint(item, 1, joint1);
 		CreatureAnimation(itemNumber, angle, 0);
+
+		auto radius = Vector2(object->radius, object->radius * 1.33f);
+		AlignEntityToSurface(item, radius);
 	}
 }

--- a/TombEngine/Objects/TR5/Entity/tr5_lion.cpp
+++ b/TombEngine/Objects/TR5/Entity/tr5_lion.cpp
@@ -10,32 +10,33 @@
 #include "Game/items.h"
 #include "Game/Lara/lara.h"
 #include "Game/misc.h"
+#include "Math/Math.h"
 #include "Specific/level.h"
-#include "Math/Random.h"
 #include "Specific/setup.h"
 
-using namespace TEN::Math::Random;
+using namespace TEN::Math;
 
 namespace TEN::Entities::Creatures::TR5
 {
 	constexpr auto LION_POUNCE_ATTACK_DAMAGE = 200;
 	constexpr auto LION_BITE_ATTACK_DAMAGE	 = 60;
 
-	constexpr auto LION_POUNCE_ATTACK_RANGE = SQUARE(SECTOR(1.25f));
-	constexpr auto LION_BITE_ATTACK_RANGE = SQUARE(SECTOR(0.7f));
-	constexpr auto LION_ATTACK_MIN_RANGE = SQUARE(SECTOR(0.4f));
+	constexpr auto LION_POUNCE_ATTACK_RANGE = SQUARE(BLOCK(1.25f));
+	constexpr auto LION_BITE_ATTACK_RANGE	= SQUARE(BLOCK(0.7f));
+	constexpr auto LION_ATTACK_RANGE		= SQUARE(BLOCK(0.4f));
 
-	constexpr auto LION_ROAR_CHANCE = 1.0f / 256;
+	constexpr auto LION_WALK_CHANCE = 63 / 64.0f;
+	constexpr auto LION_ROAR_CHANCE = 1 / 256.0f;
 
 	constexpr auto LION_HEAD_DISTANCE = BLOCK(0.4f);
 
+	constexpr auto LION_WALK_TURN_RATE_MAX	 = ANGLE(2.0f);
+	constexpr auto LION_RUN_TURN_RATE_MAX	 = ANGLE(5.0f);
+	constexpr auto LION_ATTACK_TURN_RATE_MAX = ANGLE(1.0f);
+
 	const auto LionBite1 = BiteInfo(Vector3(2.0f, -10.0f, 250.0f), 21);
 	const auto LionBite2 = BiteInfo(Vector3(-2.0f, -10.0f, 132.0f), 21);
-	const std::vector<unsigned int> LionAttackJoints = { 3, 6, 21 };
-
-	#define LION_WALK_TURN_RATE_MAX				ANGLE(2.0f)
-	#define LION_RUN_TURN_RATE_MAX				ANGLE(5.0f)
-	#define LION_ATTACKS_TURN_RATE_MAX			ANGLE(1.0f)
+	const auto LionAttackJoints = std::vector<unsigned int>{ 3, 6, 21 };
 
 	enum LionState
 	{
@@ -85,150 +86,161 @@ namespace TEN::Entities::Creatures::TR5
 		auto* object = &Objects[item->ObjectNumber];
 		auto* creature = GetCreatureInfo(item);
 
-		short angle = 0;
-		short tilt = 0;
+		short headingAngle = 0;
+		short tiltAngle = 0;
 		short joint0 = 0;
 		short joint1 = 0;
-		short headingAngle = 0;
-		bool targetAhead = false;
+
+		bool isTargetAhead = false;
 
 		if (item->HitPoints <= 0)
 		{
 			item->HitPoints = 0;
 
 			if (item->Animation.ActiveState != LION_STATE_DEATH)
-				SetAnimation(item, LionDeathAnims[GenerateInt(0, LionDeathAnims.size() - 1)]);
+				SetAnimation(item, LionDeathAnims[Random::GenerateInt(0, LionDeathAnims.size() - 1)]);
 		}
 		else
 		{
-			AI_INFO AI;
-			CreatureAIInfo(item, &AI);
+			AI_INFO ai;
+			CreatureAIInfo(item, &ai);
 
-			//Because the lion is quite big, AI.ahead don't get properly the angle from the lion's head. So I'm calculating its own one like tr1_giant_mutant.
+			// NOTE: Because the lion is quite big, AI.ahead doesn't calculate the lion's head angle properly.
+			// Calculate manually like with tr1_giant_mutant.
 
-			Vector3 forwardVector = Vector3(cos(item->Pose.Orientation.x) * sin(item->Pose.Orientation.y), -sin(item->Pose.Orientation.x), cos(item->Pose.Orientation.x) * cos(item->Pose.Orientation.y));
+			auto forwardVector = Vector3(
+				cos(item->Pose.Orientation.x) * sin(item->Pose.Orientation.y),
+				-sin(item->Pose.Orientation.x),
+				cos(item->Pose.Orientation.x) * cos(item->Pose.Orientation.y));
 			forwardVector.Normalize();
 			forwardVector *= LION_HEAD_DISTANCE;
-			headingAngle = (short)phd_atan(	creature->Target.z - item->Pose.Position.z + forwardVector.z,
-												creature->Target.x - item->Pose.Position.x + forwardVector.x) - item->Pose.Orientation.y;
-			targetAhead = (headingAngle > -FRONT_ARC && headingAngle < FRONT_ARC);
 
-			if (targetAhead)
-				joint1 = headingAngle;
+			short headAngle = (short)phd_atan(
+				creature->Target.z - item->Pose.Position.z + forwardVector.z,
+				creature->Target.x - item->Pose.Position.x + forwardVector.x) -
+				item->Pose.Orientation.y;
+			isTargetAhead = (headAngle > -FRONT_ARC && headAngle < FRONT_ARC);
 
-			GetCreatureMood(item, &AI, true);
-			CreatureMood(item, &AI, true);
+			if (isTargetAhead)
+				joint1 = headAngle;
 
-			angle = CreatureTurn(item, creature->MaxTurn);
-			joint0 = angle * -16;
+			GetCreatureMood(item, &ai, true);
+			CreatureMood(item, &ai, true);
+
+			headingAngle = CreatureTurn(item, creature->MaxTurn);
+			joint0 = headingAngle * -16;
 
 			switch (item->Animation.ActiveState)
 			{
-				case LION_STATE_IDLE:
-					creature->MaxTurn = 0;
-					creature->Flags = 0;
+			case LION_STATE_IDLE:
+				creature->MaxTurn = 0;
+				creature->Flags = 0;
 
-					if (item->Animation.RequiredState)
+				if (item->Animation.RequiredState)
+				{
+					item->Animation.TargetState = item->Animation.RequiredState;
+					break;
+				}
+
+				if (creature->Mood == MoodType::Bored)
+				{
+					if (Random::TestProbability(LION_WALK_CHANCE))
+						item->Animation.TargetState = LION_STATE_WALK_FORWARD;
+
+					break;
+				}
+
+				if (isTargetAhead && ai.bite)
+				{
+					if (ai.distance >= LION_ATTACK_RANGE)
 					{
-						item->Animation.TargetState = item->Animation.RequiredState;
-						break;
-					}
-
-					if (creature->Mood == MoodType::Bored)
-					{
-						if (!(GetRandomControl() & 0x3F))
-							item->Animation.TargetState = LION_STATE_WALK_FORWARD;
-
-						break;
-					}
-
-					if (targetAhead && AI.bite)
-					{
-						if (AI.distance >= LION_ATTACK_MIN_RANGE)
+						if (ai.distance <= LION_BITE_ATTACK_RANGE)
 						{
-							if (AI.distance <= LION_BITE_ATTACK_RANGE)
-							{
-								item->Animation.TargetState = LION_STATE_BITE_ATTACK;
-								break;
-							}
-							if (AI.distance < LION_POUNCE_ATTACK_RANGE)
-							{
-								item->Animation.TargetState = LION_STATE_POUNCE_ATTACK;
-								break;
-							}
+							item->Animation.TargetState = LION_STATE_BITE_ATTACK;
+							break;
+						}
+
+						if (ai.distance < LION_POUNCE_ATTACK_RANGE)
+						{
+							item->Animation.TargetState = LION_STATE_POUNCE_ATTACK;
+							break;
 						}
 					}
+				}
 
-					item->Animation.TargetState = LION_STATE_RUN_FORWARD;
+				item->Animation.TargetState = LION_STATE_RUN_FORWARD;
 				break;
 
-				case LION_STATE_WALK_FORWARD:
-					creature->MaxTurn = LION_WALK_TURN_RATE_MAX;
+			case LION_STATE_WALK_FORWARD:
+				creature->MaxTurn = LION_WALK_TURN_RATE_MAX;
 
-					if (creature->Mood == MoodType::Bored && TestProbability(LION_ROAR_CHANCE))
-						item->Animation.TargetState = LION_STATE_ROAR;
-					else
+				if (creature->Mood == MoodType::Bored && Random::TestProbability(LION_ROAR_CHANCE))
+					item->Animation.TargetState = LION_STATE_ROAR;
+				else
+					item->Animation.TargetState = LION_STATE_IDLE;
+
+			break;
+
+			case LION_STATE_RUN_FORWARD:
+				creature->MaxTurn = LION_RUN_TURN_RATE_MAX;
+				tiltAngle = headingAngle;
+
+				if (creature->Mood != MoodType::Bored)
+				{
+					if (isTargetAhead &&
+						ai.bite &&
+						ai.distance < LION_POUNCE_ATTACK_RANGE &&
+						ai.distance >= LION_ATTACK_RANGE)
+					{
 						item->Animation.TargetState = LION_STATE_IDLE;
+					}
+					else if (creature->Mood != MoodType::Escape)
+					{
+						if (Random::TestProbability(LION_ROAR_CHANCE))
+							item->Animation.TargetState = LION_STATE_ROAR;
+					}
+				}
+				else
+				{
+					item->Animation.TargetState = LION_STATE_IDLE;
+				}
+
+			break;
+
+			case LION_STATE_POUNCE_ATTACK:
+				creature->MaxTurn = LION_ATTACK_TURN_RATE_MAX;
+
+				if (!creature->Flags &&
+					item->Animation.AnimNumber == GetAnimNumber(*item, LION_ANIM_POUNCE_ATTACK_END) &&
+					item->TouchBits.Test(LionAttackJoints))
+				{
+					DoDamage(creature->Enemy, LION_POUNCE_ATTACK_DAMAGE);
+					CreatureEffect2(item, LionBite1, 10, item->Pose.Orientation.y, DoBloodSplat);
+					creature->Flags = 1;
+				}
 
 				break;
 
-				case LION_STATE_RUN_FORWARD:
-					creature->MaxTurn = LION_RUN_TURN_RATE_MAX;
-					tilt = angle;
+			case LION_STATE_BITE_ATTACK:
+				creature->MaxTurn = LION_ATTACK_TURN_RATE_MAX;
 
-					if (creature->Mood != MoodType::Bored)
-					{
-						if (targetAhead &&
-							AI.bite &&
-							AI.distance < LION_POUNCE_ATTACK_RANGE &&
-							AI.distance >= LION_ATTACK_MIN_RANGE)
-								item->Animation.TargetState = LION_STATE_IDLE;
-						else if (creature->Mood != MoodType::Escape)
-						{
-							if (TestProbability(LION_ROAR_CHANCE))
-								item->Animation.TargetState = LION_STATE_ROAR;
-						}
-					}
-					else
-						item->Animation.TargetState = LION_STATE_IDLE;
-
-				break;
-
-				case LION_STATE_POUNCE_ATTACK:
-					creature->MaxTurn = LION_ATTACKS_TURN_RATE_MAX;
-
-					if (!creature->Flags &&
-						item->Animation.AnimNumber == GetAnimNumber(*item, LION_ANIM_POUNCE_ATTACK_END) &&
-						item->TouchBits.Test(LionAttackJoints))
-					{
-						DoDamage(creature->Enemy, LION_POUNCE_ATTACK_DAMAGE);
-						CreatureEffect2(item, LionBite1, 10, item->Pose.Orientation.y, DoBloodSplat);
-						creature->Flags = 1;
-					}
-
-				break;
-
-				case LION_STATE_BITE_ATTACK:
-					creature->MaxTurn = LION_ATTACKS_TURN_RATE_MAX;
-
-					if (!creature->Flags &&
-						item->Animation.AnimNumber == GetAnimNumber(*item, LION_ANIM_BITE_ATTACK) &&
-						item->TouchBits.Test(LionAttackJoints))
-					{
-						DoDamage(creature->Enemy, LION_BITE_ATTACK_DAMAGE);
-						CreatureEffect2(item, LionBite2, 10, item->Pose.Orientation.y, DoBloodSplat);
-						creature->Flags = 1;
-					}
+				if (!creature->Flags &&
+					item->Animation.AnimNumber == GetAnimNumber(*item, LION_ANIM_BITE_ATTACK) &&
+					item->TouchBits.Test(LionAttackJoints))
+				{
+					DoDamage(creature->Enemy, LION_BITE_ATTACK_DAMAGE);
+					CreatureEffect2(item, LionBite2, 10, item->Pose.Orientation.y, DoBloodSplat);
+					creature->Flags = 1;
+				}
 
 				break;
 			}
 		}
 
-
-		CreatureTilt(item, tilt);
+		CreatureTilt(item, tiltAngle);
 		CreatureJoint(item, 0, joint0);
 		CreatureJoint(item, 1, joint1);
-		CreatureAnimation(itemNumber, angle, 0);
+		CreatureAnimation(itemNumber, headingAngle, 0);
 
 		auto radius = Vector2(object->radius, object->radius * 1.33f);
 		AlignEntityToSurface(item, radius);

--- a/TombEngine/Objects/TR5/Entity/tr5_lion.cpp
+++ b/TombEngine/Objects/TR5/Entity/tr5_lion.cpp
@@ -165,11 +165,8 @@ namespace TEN::Entities::Creatures::TR5
 				case LION_STATE_WALK_FORWARD:
 					creature->MaxTurn = LION_WALK_TURN_RATE_MAX;
 
-					if (creature->Mood == MoodType::Bored)
-					{
-						if (TestProbability(LION_ROAR_CHANCE))
-							item->Animation.TargetState = LION_STATE_ROAR;
-					}
+					if (creature->Mood == MoodType::Bored && TestProbability(LION_ROAR_CHANCE))
+						item->Animation.TargetState = LION_STATE_ROAR;
 					else
 						item->Animation.TargetState = LION_STATE_IDLE;
 
@@ -201,7 +198,7 @@ namespace TEN::Entities::Creatures::TR5
 					creature->MaxTurn = LION_ATTACKS_TURN_RATE_MAX;
 
 					if (!creature->Flags &&
-						item->Animation.AnimNumber == Objects[ID_LION].animIndex + LION_ANIM_POUNCE_ATTACK_END &&
+						item->Animation.AnimNumber == GetAnimNumber(*item, LION_ANIM_POUNCE_ATTACK_END) &&
 						item->TouchBits.Test(LionAttackJoints))
 					{
 						DoDamage(creature->Enemy, LION_POUNCE_ATTACK_DAMAGE);
@@ -215,7 +212,7 @@ namespace TEN::Entities::Creatures::TR5
 					creature->MaxTurn = LION_ATTACKS_TURN_RATE_MAX;
 
 					if (!creature->Flags &&
-						item->Animation.AnimNumber == Objects[ID_LION].animIndex + LION_ANIM_BITE_ATTACK &&
+						item->Animation.AnimNumber == GetAnimNumber(*item, LION_ANIM_BITE_ATTACK) &&
 						item->TouchBits.Test(LionAttackJoints))
 					{
 						DoDamage(creature->Enemy, LION_BITE_ATTACK_DAMAGE);


### PR DESCRIPTION
This branch make some light changes to Tigers and Lions to improve their behaviour.

## Tiger
- Changed the ranges of the melee attacks, so now it does both bites animation (looks like a combo), although if it gets Lara against a wall, may do only the quick one. Or if lara is a bit far, he may do the jumping one.
- When the tiger is running but Lara is stopped, I added a probability condition, to incentivate the swipe attack over the melee bites.
- If while running, Tiger decides he won't make the melee attack, now there is another condition to check that Lara is ahead before do the swipe attack, (to reduce the number of missdirected attacks), so if lara is not in front, tiger will keep running.
- Separated the melee attacks states from the swipe attack state. (Because some are done with mouth meshes, and the other with leg meshes)
- I added condition check for the animation and frame to avoid hurting Lara while the monster is preparing the attack.
- Added function to align entity to sloped floors.

## Lion
- Added a minimal range condition for the attacks, to reduce the number of times that the Lion attacks forward while Lara is behind Lion's head.
- Added another attack range for the other bite attack.
- Changed the attack collision check condition, for a distance range condition.
- Defined constants for turn values and added turn value to the attacks states to reduced missdirected attacks.
- Replaced AI.ahead for a custom targetAhead that consider the offset for the head. To reduce the times the lion attacks forward while Lara is on the side instead of on the front.
- Added creature->Flags value to control the number of times that DoDamage function happens.
- Added function to align entity to sloped floors.
- Reorganised code to make follow similar patterns that other creatures.


### Video
[![Tiger and Lion test](https://img.youtube.com/vi/oR3-RlqPk5I/0.jpg)](https://www.youtube.com/watch?v=oR3-RlqPk5I)
