### PR TITLE
fixed #995 explodeable headmeshes for TR5 guards

### DIFF
--- a/TombEngine/Objects/TR5/Entity/tr5_guard.cpp
+++ b/TombEngine/Objects/TR5/Entity/tr5_guard.cpp
@@ -1543,13 +1543,13 @@ namespace TEN::Entities::Creatures::TR5
 			{
 				DoBloodSplat(pos->x, pos->y, pos->z, 10, source.Pose.Orientation.y, pos->RoomNumber);
 				DoDamage(&target, INT_MAX);
+
+				return;
 			}
 			else
-			{
 				DoBloodSplat(pos->x, pos->y, pos->z, 10, source.Pose.Orientation.y, pos->RoomNumber);
-				DoItemHit(&target, damage, isExplosive);
-			}
 		}
-	}
 
+		DoItemHit(&target, damage, isExplosive);
+	}
 }

--- a/TombEngine/Objects/TR5/Entity/tr5_guard.cpp
+++ b/TombEngine/Objects/TR5/Entity/tr5_guard.cpp
@@ -32,6 +32,8 @@ namespace TEN::Entities::Creatures::TR5
 	
 	constexpr auto GUARD_NO_WEAPON_ON_HAND_SWAPFLAG = 0x2000;
 
+	constexpr auto GUARD_HEAD_MESH = 14;
+
 	const auto SwatGunBite		  = BiteInfo(Vector3(80.0f, 200.0f, 13.0f), 0);
 	const auto SniperGunBite	  = BiteInfo(Vector3(0.0f, 480.0f, 110.0f), 13);
 	const auto ArmedMafia2GunBite = BiteInfo(Vector3(-50.0f, 220.0f, 60.0f), 13);
@@ -1532,4 +1534,22 @@ namespace TEN::Entities::Creatures::TR5
 			}
 		}
 	}
+
+	void GuardHit(ItemInfo& target, ItemInfo& source, std::optional<GameVector> pos, int damage, bool isExplosive, int jointIndex)
+	{
+		if (pos.has_value())
+		{
+			if (jointIndex == GUARD_HEAD_MESH)
+			{
+				DoBloodSplat(pos->x, pos->y, pos->z, 10, source.Pose.Orientation.y, pos->RoomNumber);
+				DoDamage(&target, INT_MAX);
+			}
+			else
+			{
+				DoBloodSplat(pos->x, pos->y, pos->z, 10, source.Pose.Orientation.y, pos->RoomNumber);
+				DoItemHit(&target, damage, isExplosive);
+			}
+		}
+	}
+
 }

--- a/TombEngine/Objects/TR5/Entity/tr5_guard.h
+++ b/TombEngine/Objects/TR5/Entity/tr5_guard.h
@@ -1,5 +1,8 @@
 #pragma once
 
+class GameVector;
+struct ItemInfo;
+
 namespace TEN::Entities::Creatures::TR5
 {
 	void InitialiseGuard(short itemNumber);
@@ -13,4 +16,6 @@ namespace TEN::Entities::Creatures::TR5
 
 	void InitialiseMafia2(short itemNumber);
 	void Mafia2Control(short itemNumber);
+
+	void GuardHit(ItemInfo& target, ItemInfo& source, std::optional<GameVector> pos, int damage, bool isExplosive, int jointIndex);
 }

--- a/TombEngine/Objects/TR5/tr5_objects.cpp
+++ b/TombEngine/Objects/TR5/tr5_objects.cpp
@@ -118,7 +118,7 @@ static void StartEntity(ObjectInfo *obj)
 		obj->LotType = LotType::HumanPlusJump;
 		obj->SetBoneRotationFlags(6, ROT_X | ROT_Y);
 		obj->SetBoneRotationFlags(13, ROT_X | ROT_Y);
-		obj->SetupHitEffect(true);
+		obj->SetupHitEffect();
 	}
 
 	obj = &Objects[ID_GUARD1];
@@ -138,7 +138,7 @@ static void StartEntity(ObjectInfo *obj)
 		obj->LotType = LotType::HumanPlusJump;
 		obj->SetBoneRotationFlags(6, ROT_X | ROT_Y);
 		obj->SetBoneRotationFlags(13, ROT_X | ROT_Y);
-		obj->SetupHitEffect(true);
+		obj->SetupHitEffect();
 	}
 
 	obj = &Objects[ID_SWAT_PLUS];
@@ -181,7 +181,7 @@ static void StartEntity(ObjectInfo *obj)
 		obj->LotType = LotType::HumanPlusJump;
 		obj->SetBoneRotationFlags(6, ROT_X | ROT_Y);
 		obj->SetBoneRotationFlags(13, ROT_X | ROT_Y);
-		obj->SetupHitEffect(true);
+		obj->SetupHitEffect();
 	}
 
 	obj = &Objects[ID_SCIENTIST];
@@ -202,7 +202,7 @@ static void StartEntity(ObjectInfo *obj)
 		obj->LotType = LotType::HumanPlusJump;
 		obj->SetBoneRotationFlags(6, ROT_X | ROT_Y);
 		obj->SetBoneRotationFlags(13, ROT_X | ROT_Y);
-		obj->SetupHitEffect(true);
+		obj->SetupHitEffect();
 	}
 
 	obj = &Objects[ID_GUARD2];
@@ -224,7 +224,7 @@ static void StartEntity(ObjectInfo *obj)
 		obj->LotType = LotType::Human;
 		obj->SetBoneRotationFlags(6, ROT_X | ROT_Y);
 		obj->SetBoneRotationFlags(13, ROT_X | ROT_Y);
-		obj->SetupHitEffect(true);
+		obj->SetupHitEffect();
 	}
 
 	obj = &Objects[ID_GUARD3];
@@ -246,7 +246,7 @@ static void StartEntity(ObjectInfo *obj)
 		obj->LotType = LotType::Human;
 		obj->SetBoneRotationFlags(6, ROT_X | ROT_Y);
 		obj->SetBoneRotationFlags(13, ROT_X | ROT_Y);
-		obj->SetupHitEffect(true);
+		obj->SetupHitEffect();
 	}
 
 	obj = &Objects[ID_ATTACK_SUB];
@@ -364,7 +364,7 @@ static void StartEntity(ObjectInfo *obj)
 		obj->meshSwapSlot = ID_MESHSWAP_MAFIA2;
 		obj->SetBoneRotationFlags(6, ROT_X | ROT_Y);
 		obj->SetBoneRotationFlags(13, ROT_X | ROT_Y);
-		obj->SetupHitEffect(true);
+		obj->SetupHitEffect();
 	}
 
 	obj = &Objects[ID_PIERRE];
@@ -438,7 +438,7 @@ static void StartEntity(ObjectInfo *obj)
 		obj->intelligent = true;
 		obj->SetBoneRotationFlags(6, ROT_X | ROT_Y);
 		obj->SetBoneRotationFlags(13, ROT_X | ROT_Y);
-		obj->SetupHitEffect(true);
+		obj->SetupHitEffect();
 	}
 
 	obj = &Objects[ID_GUARD_LASER];

--- a/TombEngine/Objects/TR5/tr5_objects.cpp
+++ b/TombEngine/Objects/TR5/tr5_objects.cpp
@@ -198,10 +198,11 @@ static void StartEntity(ObjectInfo *obj)
 		obj->pivotLength = 50;
 		obj->radius = 102;
 		obj->intelligent = true;
+		obj->HitRoutine = GuardHit;
 		obj->LotType = LotType::HumanPlusJump;
 		obj->SetBoneRotationFlags(6, ROT_X | ROT_Y);
 		obj->SetBoneRotationFlags(13, ROT_X | ROT_Y);
-		obj->SetupHitEffect();
+		obj->SetupHitEffect(true);
 	}
 
 	obj = &Objects[ID_GUARD2];

--- a/TombEngine/Objects/TR5/tr5_objects.cpp
+++ b/TombEngine/Objects/TR5/tr5_objects.cpp
@@ -114,11 +114,11 @@ static void StartEntity(ObjectInfo *obj)
 		obj->pivotLength = 50;
 		obj->radius = 102;
 		obj->intelligent = true;
-		obj->explodableMeshbits = 0x4000;
+		obj->HitRoutine = GuardHit;
 		obj->LotType = LotType::HumanPlusJump;
 		obj->SetBoneRotationFlags(6, ROT_X | ROT_Y);
 		obj->SetBoneRotationFlags(13, ROT_X | ROT_Y);
-		obj->SetupHitEffect();
+		obj->SetupHitEffect(true);
 	}
 
 	obj = &Objects[ID_GUARD1];
@@ -133,12 +133,12 @@ static void StartEntity(ObjectInfo *obj)
 		obj->HitPoints = 24;
 		obj->radius = 102;
 		obj->pivotLength = 50;
-		obj->explodableMeshbits = 0x4000;
+		obj->HitRoutine = GuardHit;
 		obj->intelligent = true;
 		obj->LotType = LotType::HumanPlusJump;
 		obj->SetBoneRotationFlags(6, ROT_X | ROT_Y);
 		obj->SetBoneRotationFlags(13, ROT_X | ROT_Y);
-		obj->SetupHitEffect();
+		obj->SetupHitEffect(true);
 	}
 
 	obj = &Objects[ID_SWAT_PLUS];
@@ -176,12 +176,12 @@ static void StartEntity(ObjectInfo *obj)
 		obj->HitPoints = 24;
 		obj->pivotLength = 50;
 		obj->radius = 102;
-		obj->explodableMeshbits = 0x4000;
+		obj->HitRoutine = GuardHit;
 		obj->intelligent = true;
 		obj->LotType = LotType::HumanPlusJump;
 		obj->SetBoneRotationFlags(6, ROT_X | ROT_Y);
 		obj->SetBoneRotationFlags(13, ROT_X | ROT_Y);
-		obj->SetupHitEffect();
+		obj->SetupHitEffect(true);
 	}
 
 	obj = &Objects[ID_SCIENTIST];
@@ -218,12 +218,12 @@ static void StartEntity(ObjectInfo *obj)
 		obj->HitPoints = 24;
 		obj->pivotLength = 50;
 		obj->radius = 102;
-		obj->explodableMeshbits = 0x4000;
+		obj->HitRoutine = GuardHit;
 		obj->intelligent = true;
 		obj->LotType = LotType::Human;
 		obj->SetBoneRotationFlags(6, ROT_X | ROT_Y);
 		obj->SetBoneRotationFlags(13, ROT_X | ROT_Y);
-		obj->SetupHitEffect();
+		obj->SetupHitEffect(true);
 	}
 
 	obj = &Objects[ID_GUARD3];
@@ -240,12 +240,12 @@ static void StartEntity(ObjectInfo *obj)
 		obj->HitPoints = 24;
 		obj->pivotLength = 50;
 		obj->radius = 102;
-		obj->explodableMeshbits = 0x4000;
+		obj->HitRoutine = GuardHit;
 		obj->intelligent = true;
 		obj->LotType = LotType::Human;
 		obj->SetBoneRotationFlags(6, ROT_X | ROT_Y);
 		obj->SetBoneRotationFlags(13, ROT_X | ROT_Y);
-		obj->SetupHitEffect();
+		obj->SetupHitEffect(true);
 	}
 
 	obj = &Objects[ID_ATTACK_SUB];
@@ -357,13 +357,13 @@ static void StartEntity(ObjectInfo *obj)
 		obj->HitPoints = 26;
 		obj->pivotLength = 50;
 		obj->radius = 102;
-		obj->explodableMeshbits = 0x4000;
+		obj->HitRoutine = GuardHit;
 		obj->intelligent = true;
 		obj->LotType = LotType::Human;
 		obj->meshSwapSlot = ID_MESHSWAP_MAFIA2;
 		obj->SetBoneRotationFlags(6, ROT_X | ROT_Y);
 		obj->SetBoneRotationFlags(13, ROT_X | ROT_Y);
-		obj->SetupHitEffect();
+		obj->SetupHitEffect(true);
 	}
 
 	obj = &Objects[ID_PIERRE];
@@ -433,11 +433,11 @@ static void StartEntity(ObjectInfo *obj)
 		obj->HitPoints = 35;
 		obj->pivotLength = 50;
 		obj->radius = 102;
-		obj->explodableMeshbits = 0x4000;
+		obj->HitRoutine = GuardHit;
 		obj->intelligent = true;
 		obj->SetBoneRotationFlags(6, ROT_X | ROT_Y);
 		obj->SetBoneRotationFlags(13, ROT_X | ROT_Y);
-		obj->SetupHitEffect();
+		obj->SetupHitEffect(true);
 	}
 
 	obj = &Objects[ID_GUARD_LASER];


### PR DESCRIPTION
fixed slots: (also added headshot instant death to these objects)
ID_SNIPER
ID_MAFIA
ID_MAFIA2
ID_SWAT
ID_GUARD1
ID_GUARD2
ID_GUARD3