### PR TITLE
Fix direction generation

### DIFF
--- a/TombEngine/Math/Random.cpp
+++ b/TombEngine/Math/Random.cpp
@@ -26,16 +26,21 @@ namespace TEN::Math::Random
 
 	Vector2 GenerateDirection2D()
 	{
-		auto vector = Vector2(GenerateFloat(-1.0f, 1.0f), GenerateFloat(-1.0f, 1.0f));
-		vector.Normalize();
-		return vector;
+		float angle = GenerateFloat(0.0f, 2.0f * PI); // Generate angle in full circle.
+		return Vector2(cos(angle), sin(angle));
 	}
 
 	Vector3 GenerateDirection()
 	{
-		auto vector = Vector3(GenerateFloat(-1.0f, 1.0f), GenerateFloat(-1.0f, 1.0f), GenerateFloat(-1.0f, 1.0f));
-		vector.Normalize();
-		return vector;
+		float theta = GenerateFloat(0.0f, 2.0f * PI); // Generate angle in full circle.
+		float phi = GenerateFloat(0.0f, PI);		  // Generate angle in sphere's upper half.
+
+		auto direction = Vector3(
+			sin(phi) * cos(theta),
+			sin(phi) * sin(theta),
+			cos(phi));
+		direction.Normalize();
+		return direction;
 	}
 
 	Vector3 GenerateDirectionInCone(const Vector3& direction, float semiangleInDeg)
@@ -64,6 +69,21 @@ namespace TEN::Math::Random
 	Vector3 GeneratePointInSphere(const BoundingSphere& sphere)
 	{
 		return (sphere.Center + (GenerateDirection() * GenerateFloat(0.0f, sphere.Radius)));
+	}
+
+	Vector3 GeneratePointOnSphere(const BoundingSphere& sphere)
+	{
+		float u = GenerateFloat(0.0f, 1.0f);
+		float v = GenerateFloat(0.0f, 1.0f);
+
+		float theta = u * PI_MUL_2;
+		float phi = acos((v * 2) - 1.0f);
+
+		auto offset = Vector3(
+			sphere.Radius * (sin(phi) * cos(theta)),
+			sphere.Radius * (sin(phi) * sin(theta)),
+			sphere.Radius * cos(phi));
+		return (sphere.Center + offset);
 	}
 
 	bool TestProbability(float probability)

--- a/TombEngine/Math/Random.cpp
+++ b/TombEngine/Math/Random.cpp
@@ -113,11 +113,11 @@ namespace TEN::Math::Random
 		float theta = u * PI_MUL_2;
 		float phi = acos((v * 2) - 1.0f);
 
-		auto offset = Vector3(
-			sphere.Radius * (sin(phi) * cos(theta)),
-			sphere.Radius * (sin(phi) * sin(theta)),
-			sphere.Radius * cos(phi));
-		return (sphere.Center + offset);
+		auto relPoint = Vector3(
+			sin(phi) * cos(theta),
+			sin(phi) * sin(theta),
+			cos(phi));
+		return (sphere.Center + (relPoint * sphere.Radius));
 	}
 
 	bool TestProbability(float probability)

--- a/TombEngine/Math/Random.cpp
+++ b/TombEngine/Math/Random.cpp
@@ -26,14 +26,14 @@ namespace TEN::Math::Random
 
 	Vector2 GenerateDirection2D()
 	{
-		float angle = GenerateFloat(0.0f, 2.0f * PI); // Generate angle in full circle.
+		float angle = GenerateFloat(0.0f, PI_MUL_2); // Generate angle in full circle.
 		return Vector2(cos(angle), sin(angle));
 	}
 
 	Vector3 GenerateDirection()
 	{
-		float theta = GenerateFloat(0.0f, 2.0f * PI); // Generate angle in full circle.
-		float phi = GenerateFloat(0.0f, PI);		  // Generate angle in sphere's upper half.
+		float theta = GenerateFloat(0.0f, PI_MUL_2); // Generate angle in full circle.
+		float phi = GenerateFloat(0.0f, PI);		 // Generate angle in sphere's upper half.
 
 		auto direction = Vector3(
 			sin(phi) * cos(theta),

--- a/TombEngine/Math/Random.cpp
+++ b/TombEngine/Math/Random.cpp
@@ -30,12 +30,12 @@ namespace TEN::Math::Random
 		return Vector2(cos(angle), sin(angle));
 	}
 
-	Vector2 GeneratePoint2DInSquare(const Vector2& pos2D, short orient2D, float radius)
+	Vector2 GeneratePoint2DInSquare(const Vector2& pos2D, short orient2D, float apothem)
 	{
 		auto rotMatrix = Matrix::CreateRotationZ(orient2D);
 		auto relPoint = Vector2(
-			GenerateFloat(-radius, radius),
-			GenerateFloat(-radius, radius));
+			GenerateFloat(-apothem, apothem),
+			GenerateFloat(-apothem, apothem));
 
 		return (pos2D + Vector2::Transform(relPoint, rotMatrix));
 	}

--- a/TombEngine/Math/Random.cpp
+++ b/TombEngine/Math/Random.cpp
@@ -9,7 +9,7 @@ namespace TEN::Math::Random
 {
 	static std::mt19937 Engine;
 
-	int32_t GenerateInt(int32_t low, int32_t high)
+	int GenerateInt(int low, int high)
 	{
 		return (Engine() / (Engine.max() / (high - low + 1) + 1) + low);
 	}
@@ -28,6 +28,30 @@ namespace TEN::Math::Random
 	{
 		float angle = GenerateFloat(0.0f, PI_MUL_2); // Generate angle in full circle.
 		return Vector2(cos(angle), sin(angle));
+	}
+
+	Vector2 GeneratePoint2DInSquare(const Vector2& pos2D, short orient2D, float radius)
+	{
+		auto rotMatrix = Matrix::CreateRotationZ(orient2D);
+		auto relPoint = Vector2(
+			GenerateFloat(-radius, radius),
+			GenerateFloat(-radius, radius));
+
+		return (pos2D + Vector2::Transform(relPoint, rotMatrix));
+	}
+	
+	Vector2 GeneratePoint2DInCircle(const Vector2& pos2D, float radius)
+	{
+		// Use rejection sampling.
+		auto relPoint = Vector2::Zero;
+		do
+		{
+			relPoint = Vector2(
+				GenerateFloat(-1.0f, 1.0f),
+				GenerateFloat(-1.0f, 1.0f));
+		} while (relPoint.LengthSquared() > 1.0f);
+
+		return (pos2D + (relPoint * radius));
 	}
 
 	Vector3 GenerateDirection()
@@ -68,7 +92,7 @@ namespace TEN::Math::Random
 
 	Vector3 GeneratePointInSphere(const BoundingSphere& sphere)
 	{
-		// Use rejection sampling method.
+		// Use rejection sampling.
 		auto relPoint = Vector3::Zero;
 		do
 		{
@@ -76,8 +100,7 @@ namespace TEN::Math::Random
 				GenerateFloat(-1.0f, 1.0f),
 				GenerateFloat(-1.0f, 1.0f),
 				GenerateFloat(-1.0f, 1.0f));
-		}
-		while (relPoint.LengthSquared() > 1.0f);
+		} while (relPoint.LengthSquared() > 1.0f);
 
 		return (sphere.Center + (relPoint * sphere.Radius));
 	}

--- a/TombEngine/Math/Random.h
+++ b/TombEngine/Math/Random.h
@@ -9,7 +9,7 @@ namespace TEN::Math::Random
 
 	// 2D geometric generation
 	Vector2 GenerateDirection2D();
-	Vector2 GeneratePoint2DInSquare(const Vector2& pos2D, short orient2D, float radius);
+	Vector2 GeneratePoint2DInSquare(const Vector2& pos2D, short orient2D, float apothem);
 	Vector2 GeneratePoint2DInCircle(const Vector2& pos2D, float radius);
 
 	// 3D geometric generation

--- a/TombEngine/Math/Random.h
+++ b/TombEngine/Math/Random.h
@@ -2,11 +2,17 @@
 
 namespace TEN::Math::Random
 {
-	int32_t GenerateInt(int32_t low = 0, int32_t high = SHRT_MAX);
-	float	GenerateFloat(float low = 0.0f, float high = 1.0f);
+	// Value generation
+	int	  GenerateInt(int low = 0, int high = SHRT_MAX);
+	float GenerateFloat(float low = 0.0f, float high = 1.0f);
+	short GenerateAngle(short low = SHRT_MIN, short high = SHRT_MAX);
 
-	short	GenerateAngle(short low = SHRT_MIN, short high = SHRT_MAX);
+	// 2D geometric generation
 	Vector2 GenerateDirection2D();
+	Vector2 GeneratePoint2DInSquare(const Vector2& pos2D, short orient2D, float radius);
+	Vector2 GeneratePoint2DInCircle(const Vector2& pos2D, float radius);
+
+	// 3D geometric generation
 	Vector3 GenerateDirection();
 	Vector3 GenerateDirectionInCone(const Vector3& direction, float semiangleInDeg);
 	Vector3 GeneratePointInBox(const BoundingOrientedBox& box);

--- a/TombEngine/Math/Random.h
+++ b/TombEngine/Math/Random.h
@@ -11,6 +11,7 @@ namespace TEN::Math::Random
 	Vector3 GenerateDirectionInCone(const Vector3& direction, float semiangleInDeg);
 	Vector3 GeneratePointInBox(const BoundingOrientedBox& box);
 	Vector3 GeneratePointInSphere(const BoundingSphere& sphere);
+	Vector3 GeneratePointOnSphere(const BoundingSphere& sphere);
 
 	bool TestProbability(float probability);
 }


### PR DESCRIPTION
- Fix random direction generation function having a bias toward cube corners.
- Fix point in sphere generation function having a bias toward positions closer to the centre of the sphere.
- Add `GeneratePoint2DInSquare()`.
- Add `GeneratePoint2DInCircle()`.
- Add `GeneratePointOnSphere()`.