### PR TITLE
Default input bindings

### DIFF
--- a/Documentation/Changes.txt
+++ b/Documentation/Changes.txt
@@ -25,6 +25,7 @@ Version 1.0.9
 * Add missing gunflash for some entities, also include dynamic light and smoke to all gunflashes.
 * Add log reports if title level or other levels don't exist.
 * Add better error handling for missing font, sprites or shaders.
+* Add "Reset to defaults" entry to controls menu and automatically bind XBOX gamepad profile if connected.
 
 Lua API changes:
 * Add function String::SetTranslated() 

--- a/TombEngine/Game/gui.cpp
+++ b/TombEngine/Game/gui.cpp
@@ -642,14 +642,14 @@ namespace TEN::Gui
 
 			if (GuiIsSelected())
 			{
-                // Defaults.
-                if (SelectedOption == (OptionCount - 2))
-                {
-                    SoundEffect(SFX_TR4_MENU_SELECT, nullptr, SoundEnvironment::Always);
-                    memset(KeyboardLayout[1], 0, KEY_COUNT * sizeof(short));
-                    ApplyDefaultXInputBindings();
-                    return;
-                }
+				// Defaults.
+				if (SelectedOption == (OptionCount - 2))
+				{
+					SoundEffect(SFX_TR4_MENU_SELECT, nullptr, SoundEnvironment::Always);
+					memset(KeyboardLayout[1], 0, KEY_COUNT * sizeof(short));
+					ApplyDefaultXInputBindings();
+					return;
+				}
 
 				// Apply.
 				if (SelectedOption == (OptionCount - 1))

--- a/TombEngine/Game/gui.cpp
+++ b/TombEngine/Game/gui.cpp
@@ -646,8 +646,7 @@ namespace TEN::Gui
 				if (SelectedOption == (OptionCount - 2))
 				{
 					SoundEffect(SFX_TR4_MENU_SELECT, nullptr, SoundEnvironment::Always);
-					memset(KeyboardLayout[1], 0, KEY_COUNT * sizeof(short));
-					ApplyDefaultXInputBindings();
+					ApplyDefaultBindings();
 					return;
 				}
 

--- a/TombEngine/Game/gui.cpp
+++ b/TombEngine/Game/gui.cpp
@@ -547,7 +547,7 @@ namespace TEN::Gui
 
 	void GuiController::HandleControlSettingsInput(ItemInfo* item, bool fromPauseMenu)
 	{
-		static const int numControlSettingsOptions = KEY_COUNT + 1;
+		static const int numControlSettingsOptions = KEY_COUNT + 2;
 
 		OptionCount = numControlSettingsOptions;
 		CurrentSettings.WaitingForKey = false;
@@ -561,7 +561,7 @@ namespace TEN::Gui
 		}
 
 		if (GuiIsSelected() &&
-			SelectedOption <= (numControlSettingsOptions - 2))
+			SelectedOption <= (numControlSettingsOptions - 3))
 		{
 			SoundEffect(SFX_TR4_MENU_SELECT, nullptr, SoundEnvironment::Always);
 			CurrentSettings.WaitingForKey = true;
@@ -642,6 +642,15 @@ namespace TEN::Gui
 
 			if (GuiIsSelected())
 			{
+                // Defaults.
+                if (SelectedOption == (OptionCount - 2))
+                {
+                    SoundEffect(SFX_TR4_MENU_SELECT, nullptr, SoundEnvironment::Always);
+                    memset(KeyboardLayout[1], 0, KEY_COUNT * sizeof(short));
+                    ApplyDefaultXInputBindings();
+                    return;
+                }
+
 				// Apply.
 				if (SelectedOption == (OptionCount - 1))
 				{

--- a/TombEngine/Renderer/Renderer11DrawMenu.cpp
+++ b/TombEngine/Renderer/Renderer11DrawMenu.cpp
@@ -36,11 +36,11 @@ namespace TEN::Renderer
 
 	// Vertical spacing templates
 	constexpr auto MenuVerticalLineSpacing = 30;
-	constexpr auto MenuVerticalNarrowLineSpacing = 25;
+	constexpr auto MenuVerticalNarrowLineSpacing = 24;
 	constexpr auto MenuVerticalBlockSpacing = 50;
 	
 	// Vertical menu positioning templates
-	constexpr auto MenuVerticalTop = 15;
+	constexpr auto MenuVerticalTop = 11;
 	constexpr auto MenuVerticalDisplaySettings = 200;
 	constexpr auto MenuVerticalOtherSettings = 150;
 	constexpr auto MenuVerticalBottomCenter = 400;
@@ -272,12 +272,16 @@ namespace TEN::Renderer
 					GetNextBlockPosition(&y);
 			}
 
+            // Defaults
+            AddString(MenuCenterEntry, y, g_GameFlow->GetString(STRING_CONTROLS_DEFAULTS), PRINTSTRING_COLOR_ORANGE, SF_Center(title_option == 17));
+            GetNextLinePosition(&y);
+
 			// Apply
-			AddString(MenuCenterEntry, y, g_GameFlow->GetString(STRING_APPLY), PRINTSTRING_COLOR_ORANGE, SF_Center(title_option == 17));
+			AddString(MenuCenterEntry, y, g_GameFlow->GetString(STRING_APPLY), PRINTSTRING_COLOR_ORANGE, SF_Center(title_option == 18));
 			GetNextLinePosition(&y);
 
 			// Cancel
-			AddString(MenuCenterEntry, y, g_GameFlow->GetString(STRING_CANCEL), PRINTSTRING_COLOR_ORANGE, SF_Center(title_option == 18));
+			AddString(MenuCenterEntry, y, g_GameFlow->GetString(STRING_CANCEL), PRINTSTRING_COLOR_ORANGE, SF_Center(title_option == 19));
 			break;
 		}
 	}

--- a/TombEngine/Renderer/Renderer11DrawMenu.cpp
+++ b/TombEngine/Renderer/Renderer11DrawMenu.cpp
@@ -272,9 +272,9 @@ namespace TEN::Renderer
 					GetNextBlockPosition(&y);
 			}
 
-            // Defaults
-            AddString(MenuCenterEntry, y, g_GameFlow->GetString(STRING_CONTROLS_DEFAULTS), PRINTSTRING_COLOR_ORANGE, SF_Center(title_option == 17));
-            GetNextLinePosition(&y);
+			// Defaults
+			AddString(MenuCenterEntry, y, g_GameFlow->GetString(STRING_CONTROLS_DEFAULTS), PRINTSTRING_COLOR_ORANGE, SF_Center(title_option == 17));
+			GetNextLinePosition(&y);
 
 			// Apply
 			AddString(MenuCenterEntry, y, g_GameFlow->GetString(STRING_APPLY), PRINTSTRING_COLOR_ORANGE, SF_Center(title_option == 18));

--- a/TombEngine/Scripting/Internal/LanguageScript.h
+++ b/TombEngine/Scripting/Internal/LanguageScript.h
@@ -104,6 +104,7 @@
 #define STRING_CONTROLS_V_SLOW			"controls_slow"
 #define STRING_CONTROLS_V_BRAKE			"controls_brake"
 #define STRING_CONTROLS_V_FIRE			"controls_fire"
+#define STRING_CONTROLS_DEFAULTS        "controls_defaults"
 #define STRING_TITLE_ITEMS				"items"
 #define STRING_TITLE_PUZZLES			"puzzles"
 #define STRING_TITLE_SETTINGS			"settings"

--- a/TombEngine/Specific/Input/Input.cpp
+++ b/TombEngine/Specific/Input/Input.cpp
@@ -14,6 +14,7 @@
 #include "Game/savegame.h"
 #include "Renderer/Renderer11.h"
 #include "Sound/sound.h"
+#include "Specific/trutils.h"
 #include "Specific/winmain.h"
 
 using namespace OIS;
@@ -838,21 +839,24 @@ namespace TEN::Input
 			return false;
 
 		for (int i = 0; i < KEY_COUNT; i++)
+		{
 			if (KeyboardLayout[1][i] != KC_UNASSIGNED && KeyboardLayout[1][i] != KeyboardLayout[0][i])
-			return false;
+				return false;
+		}
 
-		if (OisGamepad->vendor().find("XBOX") != string::npos ||
-			OisGamepad->vendor().find("XBox") != string::npos ||
-			OisGamepad->vendor().find("xbox") != string::npos)
+		auto vendor = TEN::Utils::ToLower(OisGamepad->vendor());
+		if (vendor.find("xbox") != string::npos || vendor.find("xinput") != string::npos)
 		{
 			ApplyBindings(XInputBindings);
+
+			for (int i = 0; i < KEY_COUNT; i++)
+				g_Configuration.KeyboardLayout[i] = KeyboardLayout[1][i];
+
+			return true;
 		}
 		else
+		{
 			return false;
-
-		for (int i = 0; i < KEY_COUNT; i++)
-			g_Configuration.KeyboardLayout[i] = KeyboardLayout[1][i];
-
-		return true;
+		}
 	}
 }

--- a/TombEngine/Specific/Input/Input.cpp
+++ b/TombEngine/Specific/Input/Input.cpp
@@ -91,14 +91,13 @@ namespace TEN::Input
 	auto DefaultBindings = std::vector<int>
 	{
 		KC_UP, KC_DOWN, KC_LEFT, KC_RIGHT, KC_PERIOD, KC_SLASH, KC_RSHIFT, KC_RMENU, KC_RCONTROL, KC_SPACE, KC_COMMA, KC_NUMPAD0, KC_END, KC_ESCAPE, KC_P, KC_PGUP, KC_PGDOWN,
-		/*KC_RCONTROL, KC_DOWN, KC_SLASH, KC_RSHIFT, KC_RMENU, KC_SPACE,*/
+		/*KC_RCONTROL, KC_DOWN, KC_SLASH, KC_RSHIFT, KC_RMENU, KC_SPACE,*/ // TODO: Dedicated vehicle actions.
 		KC_F5, KC_F6, KC_RETURN, KC_ESCAPE, KC_NUMPAD0
 	};
-
 	auto XInputBindings = std::vector<int>
 	{
 		XB_AXIS_X_NEG, XB_AXIS_X_POS, XB_AXIS_Y_NEG, XB_AXIS_Y_POS, XB_AXIS_LTRIGGER_NEG, XB_AXIS_RTRIGGER_NEG, XB_RSHIFT, XB_X, XB_A, XB_Y, XB_DPAD_DOWN, XB_LSHIFT, XB_B, XB_SELECT, XB_START, XB_LSTICK, XB_RSTICK,
-		/*KC_RCONTROL, KC_DOWN, KC_SLASH, KC_RSHIFT, KC_RMENU, KC_SPACE,*/
+		/*KC_RCONTROL, KC_DOWN, KC_SLASH, KC_RSHIFT, KC_RMENU, KC_SPACE,*/ // TODO: Dedicated vehicle actions.
 		KC_F5, KC_F6, KC_RETURN, KC_ESCAPE, KC_NUMPAD0
 	};
 
@@ -108,11 +107,11 @@ namespace TEN::Input
 	{
 		{
 			KC_UP, KC_DOWN, KC_LEFT, KC_RIGHT, KC_PERIOD, KC_SLASH, KC_RSHIFT, KC_RMENU, KC_RCONTROL, KC_SPACE, KC_COMMA, KC_NUMPAD0, KC_END, KC_ESCAPE, KC_P, KC_PGUP, KC_PGDOWN,
-			/*KC_RCONTROL, KC_DOWN, KC_SLASH, KC_RSHIFT, KC_RMENU, KC_SPACE*/
+			/*KC_RCONTROL, KC_DOWN, KC_SLASH, KC_RSHIFT, KC_RMENU, KC_SPACE*/ // TODO: Dedicated vehicle actions.
 		},
 		{
 			KC_UP, KC_DOWN, KC_LEFT, KC_RIGHT, KC_PERIOD, KC_SLASH, KC_RSHIFT, KC_RMENU, KC_RCONTROL, KC_SPACE, KC_COMMA, KC_NUMPAD0, KC_END, KC_ESCAPE, KC_P, KC_PGUP, KC_PGDOWN,
-			/*KC_RCONTROL, KC_DOWN, KC_SLASH, KC_RSHIFT, KC_RMENU, KC_SPACE*/
+			/*KC_RCONTROL, KC_DOWN, KC_SLASH, KC_RSHIFT, KC_RMENU, KC_SPACE*/ // TODO: Dedicated vehicle actions.
 		}
 	};
 
@@ -745,6 +744,44 @@ namespace TEN::Input
 		RumbleInfo = {};
 	}
 
+	static void ApplyBindings(const std::vector<int>& bindings)
+	{
+		for (int i = 0; i < bindings.size(); i++)
+		{
+			if (i >= KEY_COUNT)
+				break;
+
+			KeyboardLayout[1][i] = bindings[i];
+		}
+	}
+
+	bool ApplyDefaultXInputBindings()
+	{
+		if (!OisGamepad)
+			return false;
+
+		for (int i = 0; i < KEY_COUNT; i++)
+		{
+			if (KeyboardLayout[1][i] != KC_UNASSIGNED && KeyboardLayout[1][i] != KeyboardLayout[0][i])
+				return false;
+		}
+
+		auto vendor = TEN::Utils::ToLower(OisGamepad->vendor());
+		if (vendor.find("xbox") != string::npos || vendor.find("xinput") != string::npos)
+		{
+			ApplyBindings(XInputBindings);
+
+			for (int i = 0; i < KEY_COUNT; i++)
+				g_Configuration.KeyboardLayout[i] = KeyboardLayout[1][i];
+
+			return true;
+		}
+		else
+		{
+			return false;
+		}
+	}
+
 	void ClearAction(ActionID actionID)
 	{
 		ActionMap[(int)actionID].Clear();
@@ -820,43 +857,5 @@ namespace TEN::Input
 	bool IsOpticActionHeld()
 	{
 		return (IsDirectionActionHeld() || IsHeld(In::Action) || IsHeld(In::Crouch) || IsHeld(In::Sprint));
-	}
-
-	void ApplyBindings(const std::vector<int> bindings)
-	{
-		for (int i = 0; i < bindings.size(); i++)
-		{
-			if (i >= KEY_COUNT)
-				break;
-	
-			KeyboardLayout[1][i] = bindings[i];
-		}
-	}
-
-	bool ApplyDefaultXInputBindings()
-	{
-		if (!OisGamepad)
-			return false;
-
-		for (int i = 0; i < KEY_COUNT; i++)
-		{
-			if (KeyboardLayout[1][i] != KC_UNASSIGNED && KeyboardLayout[1][i] != KeyboardLayout[0][i])
-				return false;
-		}
-
-		auto vendor = TEN::Utils::ToLower(OisGamepad->vendor());
-		if (vendor.find("xbox") != string::npos || vendor.find("xinput") != string::npos)
-		{
-			ApplyBindings(XInputBindings);
-
-			for (int i = 0; i < KEY_COUNT; i++)
-				g_Configuration.KeyboardLayout[i] = KeyboardLayout[1][i];
-
-			return true;
-		}
-		else
-		{
-			return false;
-		}
 	}
 }

--- a/TombEngine/Specific/Input/Input.cpp
+++ b/TombEngine/Specific/Input/Input.cpp
@@ -94,12 +94,12 @@ namespace TEN::Input
 		KC_F5, KC_F6, KC_RETURN, KC_ESCAPE, KC_NUMPAD0
 	};
 
-    auto XInputBindings = std::vector<int>
-    {
-        XB_AXIS_X_NEG, XB_AXIS_X_POS, XB_AXIS_Y_NEG, XB_AXIS_Y_POS, XB_AXIS_LTRIGGER_NEG, XB_AXIS_RTRIGGER_NEG, XB_RSHIFT, XB_X, XB_A, XB_Y, XB_DPAD_DOWN, XB_LSHIFT, XB_B, XB_SELECT, XB_START, XB_LSTICK, XB_RSTICK,
-        /*KC_RCONTROL, KC_DOWN, KC_SLASH, KC_RSHIFT, KC_RMENU, KC_SPACE,*/
-        KC_F5, KC_F6, KC_RETURN, KC_ESCAPE, KC_NUMPAD0
-    };
+	auto XInputBindings = std::vector<int>
+	{
+		XB_AXIS_X_NEG, XB_AXIS_X_POS, XB_AXIS_Y_NEG, XB_AXIS_Y_POS, XB_AXIS_LTRIGGER_NEG, XB_AXIS_RTRIGGER_NEG, XB_RSHIFT, XB_X, XB_A, XB_Y, XB_DPAD_DOWN, XB_LSHIFT, XB_B, XB_SELECT, XB_START, XB_LSTICK, XB_RSTICK,
+		/*KC_RCONTROL, KC_DOWN, KC_SLASH, KC_RSHIFT, KC_RMENU, KC_SPACE,*/
+		KC_F5, KC_F6, KC_RETURN, KC_ESCAPE, KC_NUMPAD0
+	};
 
 	// Input bindings. These are primitive mappings to actions.
 	bool ConflictingKeys[KEY_COUNT];
@@ -180,10 +180,10 @@ namespace TEN::Input
 					TENLog("Controller supports vibration.", LogLevel::Info);
 					InitializeEffect();
 				}
-                
-                // If controller is XInput and default bindings were successfully assigned, save configuration.
-                if (ApplyDefaultXInputBindings())
-                    SaveConfiguration();
+
+				// If controller is XInput and default bindings were successfully assigned, save configuration.
+				if (ApplyDefaultXInputBindings())
+					SaveConfiguration();
 			}
 			catch (OIS::Exception& ex)
 			{
@@ -821,38 +821,38 @@ namespace TEN::Input
 		return (IsDirectionActionHeld() || IsHeld(In::Action) || IsHeld(In::Crouch) || IsHeld(In::Sprint));
 	}
 
-    void ApplyBindings(const std::vector<int> bindings)
-    {
-        for (int i = 0; i < bindings.size(); i++)
-        {
-            if (i >= KEY_COUNT)
-                break;
+	void ApplyBindings(const std::vector<int> bindings)
+	{
+		for (int i = 0; i < bindings.size(); i++)
+		{
+			if (i >= KEY_COUNT)
+				break;
+	
+			KeyboardLayout[1][i] = bindings[i];
+		}
+	}
 
-            KeyboardLayout[1][i] = bindings[i];
-        }
-    }
+	bool ApplyDefaultXInputBindings()
+	{
+		if (!OisGamepad)
+			return false;
 
-    bool ApplyDefaultXInputBindings()
-    {
-        if (!OisGamepad)
-            return false;
+		for (int i = 0; i < KEY_COUNT; i++)
+			if (KeyboardLayout[1][i] != KC_UNASSIGNED && KeyboardLayout[1][i] != KeyboardLayout[0][i])
+			return false;
 
-        for (int i = 0; i < KEY_COUNT; i++)
-            if (KeyboardLayout[1][i] != KC_UNASSIGNED && KeyboardLayout[1][i] != KeyboardLayout[0][i])
-                return false;
+		if (OisGamepad->vendor().find("XBOX") != string::npos ||
+			OisGamepad->vendor().find("XBox") != string::npos ||
+			OisGamepad->vendor().find("xbox") != string::npos)
+		{
+			ApplyBindings(XInputBindings);
+		}
+		else
+			return false;
 
-        if (OisGamepad->vendor().find("XBOX") != string::npos ||
-            OisGamepad->vendor().find("XBox") != string::npos ||
-            OisGamepad->vendor().find("xbox") != string::npos)
-        {
-            ApplyBindings(XInputBindings);
-        }
-        else
-            return false;
+		for (int i = 0; i < KEY_COUNT; i++)
+			g_Configuration.KeyboardLayout[i] = KeyboardLayout[1][i];
 
-        for (int i = 0; i < KEY_COUNT; i++)
-            g_Configuration.KeyboardLayout[i] = KeyboardLayout[1][i];
-
-        return true;
-    }
+		return true;
+	}
 }

--- a/TombEngine/Specific/Input/Input.cpp
+++ b/TombEngine/Specific/Input/Input.cpp
@@ -182,8 +182,12 @@ namespace TEN::Input
 				}
 
 				// If controller is XInput and default bindings were successfully assigned, save configuration.
-				if (ApplyDefaultXInputBindings())
-					SaveConfiguration();
+                if (ApplyDefaultXInputBindings())
+                {
+                    g_Configuration.EnableRumble = (OisRumble != nullptr);
+                    g_Configuration.EnableThumbstickCameraControl = true;
+                    SaveConfiguration();
+                }
 			}
 			catch (OIS::Exception& ex)
 			{
@@ -754,6 +758,12 @@ namespace TEN::Input
 			KeyboardLayout[1][i] = bindings[i];
 		}
 	}
+
+    void ApplyDefaultBindings()
+    {
+        ApplyBindings(DefaultBindings);
+        ApplyDefaultXInputBindings();
+    }
 
 	bool ApplyDefaultXInputBindings()
 	{

--- a/TombEngine/Specific/Input/Input.h
+++ b/TombEngine/Specific/Input/Input.h
@@ -182,7 +182,8 @@ namespace TEN::Input
 	void ClearAllActions();
 	void Rumble(float power, float delayInSec = 0.3f, RumbleMode mode = RumbleMode::Both);
 	void StopRumble();
-	bool ApplyDefaultXInputBindings();
+    void ApplyDefaultBindings();
+    bool ApplyDefaultXInputBindings();
 
 	// TODO: Later, all these global action accessor functions should be tied to a specific controller/player.
 	// Having them loose like this is very inelegant, but since this is only the first iteration, they will do for now. -- Sezz 2022.10.12

--- a/TombEngine/Specific/Input/Input.h
+++ b/TombEngine/Specific/Input/Input.h
@@ -12,38 +12,38 @@ namespace TEN::Input
 
 	constexpr int MAX_INPUT_SLOTS = MAX_KEYBOARD_KEYS + MAX_GAMEPAD_KEYS + MAX_GAMEPAD_POV_AXES + MAX_GAMEPAD_AXES * 2;
 
-    enum XInputButtons
-    {
-        XB_START = MAX_KEYBOARD_KEYS,
-        XB_SELECT,
-        XB_LSTICK,
-        XB_RSTICK,
-        XB_LSHIFT,
-        XB_RSHIFT,
-        XB_UNUSED1,
-        XB_UNUSED2,
-        XB_A,
-        XB_B,
-        XB_X,
-        XB_Y,
-        XB_LOGO,
-        XB_AXIS_X_POS = MAX_KEYBOARD_KEYS + MAX_GAMEPAD_KEYS,
-        XB_AXIS_X_NEG,
-        XB_AXIS_Y_POS,
-        XB_AXIS_Y_NEG,
-        XB_AXIS_Z_POS,
-        XB_AXIS_Z_NEG,
-        XB_AXIS_W_POS,
-        XB_AXIS_W_NEG,
-        XB_AXIS_LTRIGGER_NEG,
-        XB_AXIS_LTRIGGER_POS,
-        XB_AXIS_RTRIGGER_NEG,
-        XB_AXIS_RTRIGGER_POS,
-        XB_DPAD_UP,
-        XB_DPAD_DOWN,
-        XB_DPAD_LEFT,
-        XB_DPAD_RIGHT
-    };
+	enum XInputButtons
+	{
+		XB_START = MAX_KEYBOARD_KEYS,
+		XB_SELECT,
+		XB_LSTICK,
+		XB_RSTICK,
+		XB_LSHIFT,
+		XB_RSHIFT,
+		XB_UNUSED1,
+		XB_UNUSED2,
+		XB_A,
+		XB_B,
+		XB_X,
+		XB_Y,
+		XB_LOGO,
+		XB_AXIS_X_POS = MAX_KEYBOARD_KEYS + MAX_GAMEPAD_KEYS,
+		XB_AXIS_X_NEG,
+		XB_AXIS_Y_POS,
+		XB_AXIS_Y_NEG,
+		XB_AXIS_Z_POS,
+		XB_AXIS_Z_NEG,
+		XB_AXIS_W_POS,
+		XB_AXIS_W_NEG,
+		XB_AXIS_LTRIGGER_NEG,
+		XB_AXIS_LTRIGGER_POS,
+		XB_AXIS_RTRIGGER_NEG,
+		XB_AXIS_RTRIGGER_POS,
+		XB_DPAD_UP,
+		XB_DPAD_DOWN,
+		XB_DPAD_LEFT,
+		XB_DPAD_RIGHT
+	};
 
 	enum InputKey
 	{
@@ -199,6 +199,6 @@ namespace TEN::Input
 	bool IsWakeActionHeld();
 	bool IsOpticActionHeld();
 
-    void ApplyBindings(const std::vector<int> bindings);
-    bool ApplyDefaultXInputBindings();
+	void ApplyBindings(const std::vector<int> bindings);
+	bool ApplyDefaultXInputBindings();
 }

--- a/TombEngine/Specific/Input/Input.h
+++ b/TombEngine/Specific/Input/Input.h
@@ -12,6 +12,39 @@ namespace TEN::Input
 
 	constexpr int MAX_INPUT_SLOTS = MAX_KEYBOARD_KEYS + MAX_GAMEPAD_KEYS + MAX_GAMEPAD_POV_AXES + MAX_GAMEPAD_AXES * 2;
 
+    enum XInputButtons
+    {
+        XB_START = MAX_KEYBOARD_KEYS,
+        XB_SELECT,
+        XB_LSTICK,
+        XB_RSTICK,
+        XB_LSHIFT,
+        XB_RSHIFT,
+        XB_UNUSED1,
+        XB_UNUSED2,
+        XB_A,
+        XB_B,
+        XB_X,
+        XB_Y,
+        XB_LOGO,
+        XB_AXIS_X_POS = MAX_KEYBOARD_KEYS + MAX_GAMEPAD_KEYS,
+        XB_AXIS_X_NEG,
+        XB_AXIS_Y_POS,
+        XB_AXIS_Y_NEG,
+        XB_AXIS_Z_POS,
+        XB_AXIS_Z_NEG,
+        XB_AXIS_W_POS,
+        XB_AXIS_W_NEG,
+        XB_AXIS_LTRIGGER_NEG,
+        XB_AXIS_LTRIGGER_POS,
+        XB_AXIS_RTRIGGER_NEG,
+        XB_AXIS_RTRIGGER_POS,
+        XB_DPAD_UP,
+        XB_DPAD_DOWN,
+        XB_DPAD_LEFT,
+        XB_DPAD_RIGHT
+    };
+
 	enum InputKey
 	{
 		KEY_FORWARD,
@@ -165,4 +198,7 @@ namespace TEN::Input
 	bool IsDirectionActionHeld();
 	bool IsWakeActionHeld();
 	bool IsOpticActionHeld();
+
+    void ApplyBindings(const std::vector<int> bindings);
+    bool ApplyDefaultXInputBindings();
 }

--- a/TombEngine/Specific/Input/Input.h
+++ b/TombEngine/Specific/Input/Input.h
@@ -168,8 +168,8 @@ namespace TEN::Input
 	extern std::vector<float>		AxisMap;
 
 	// Legacy input bit fields.
-	extern int DbInput; // Debounce: is input clicked?
-	extern int TrInput; // Throttle: is input held?
+	extern int DbInput; // Debounce input.
+	extern int TrInput; // Throttle input.
 
 	extern short KeyboardLayout[2][KEY_COUNT];
 
@@ -182,6 +182,7 @@ namespace TEN::Input
 	void ClearAllActions();
 	void Rumble(float power, float delayInSec = 0.3f, RumbleMode mode = RumbleMode::Both);
 	void StopRumble();
+	bool ApplyDefaultXInputBindings();
 
 	// TODO: Later, all these global action accessor functions should be tied to a specific controller/player.
 	// Having them loose like this is very inelegant, but since this is only the first iteration, they will do for now. -- Sezz 2022.10.12
@@ -198,7 +199,4 @@ namespace TEN::Input
 	bool IsDirectionActionHeld();
 	bool IsWakeActionHeld();
 	bool IsOpticActionHeld();
-
-	void ApplyBindings(const std::vector<int> bindings);
-	bool ApplyDefaultXInputBindings();
 }


### PR DESCRIPTION
Adds "Reset to defaults" menu to control configuration menu.
Additionally, either when resetting to defaults or launching TEN for the first time, automatically binds XBOX mapping instead of keyboard mapping, if XBOX controller is connected. Keyboard mapping remains active in such case too, as it implicitly works as a primary layout.

Things to test:

- Whether key bindings are assigned correctly on first TEN launch (delete `HKCU/Software/TombEngine` in registry to test).
- Whether keyboard layout is correctly reset to defaults.
- Whether XBOX binding is applied when resetting layout to defaults in menu.
- Whether XBOX binding is correct (test with XBOX controller).