### PR TITLE
Use OIS ParamList since default behaviour blocks the WIN key.

### DIFF
--- a/TombEngine/Specific/Input/Input.cpp
+++ b/TombEngine/Specific/Input/Input.cpp
@@ -166,7 +166,15 @@ namespace TEN::Input
 
 		try
 		{
-			OisInputManager = InputManager::createInputSystem((size_t)handle);
+			// Use an OIS ParamList since the default behaviour blocks the WIN key.
+			ParamList pl;
+			std::ostringstream wnd;
+			wnd << (size_t)handle;
+			pl.insert(std::make_pair(std::string("WINDOW"), wnd.str()));
+			pl.insert(std::make_pair(std::string("w32_keyboard"), std::string("DISCL_FOREGROUND")));
+			pl.insert(std::make_pair(std::string("w32_keyboard"), std::string("DISCL_NONEXCLUSIVE")));
+
+			OisInputManager = InputManager::createInputSystem(pl);
 			OisInputManager->enableAddOnFactory(InputManager::AddOn_All);
 
 			if (OisInputManager->getNumberOfDevices(OISKeyboard) == 0)


### PR DESCRIPTION
The default behaviour of the OIS library used here (for some inexplicable reason) blocks standard operation of the Windows key. This restores the regular behaviour, since it is a common combination hotkey to use Win+Shift+Arrow keys to quickly move windows around multi-monitor displays.