### PR TITLE
Adngel crumbling platform

### DIFF
--- a/TombEngine/Objects/Generic/Traps/crumblingPlatform.cpp
+++ b/TombEngine/Objects/Generic/Traps/crumblingPlatform.cpp
@@ -102,17 +102,19 @@ namespace TEN::Entities::Traps
 
 			case CRUMBLING_PLATFORM_STATE_FALL:
 			{
+				short& fallVel = item.ItemFlags[1];
+
 				auto pointColl = GetCollision(item);
 				int relFloorHeight = item.Pose.Position.y - pointColl.Position.Floor;
 
 				// Airborne.
-				if (relFloorHeight < 0)
+				if (relFloorHeight < -fallVel)
 				{
-					item.ItemFlags[1] += CRUMBLING_PLATFORM_FALL_VELOCITY;
-					if (item.ItemFlags[1] > CRUMBLING_PLATFORM_MAX_VELOCITY)
-						item.ItemFlags[1] = CRUMBLING_PLATFORM_MAX_VELOCITY;
+					fallVel += CRUMBLING_PLATFORM_FALL_VELOCITY;
+					if (fallVel > CRUMBLING_PLATFORM_MAX_VELOCITY)
+						fallVel = CRUMBLING_PLATFORM_MAX_VELOCITY;
 
-					item.Pose.Position.y += item.ItemFlags[1];
+					item.Pose.Position.y += fallVel;
 				}
 				// Grounded.
 				else

--- a/TombEngine/Objects/Generic/Traps/crumblingPlatform.cpp
+++ b/TombEngine/Objects/Generic/Traps/crumblingPlatform.cpp
@@ -3,6 +3,8 @@
 
 #include "Game/collision/collide_item.h"
 #include "Game/collision/floordata.h"
+#include "Game/Lara/lara.h"
+#include "Game/Lara/lara_helpers.h"
 #include "Game/setup.h"
 #include "Specific/clock.h"
 #include "Specific/level.h"
@@ -160,6 +162,7 @@ namespace TEN::Entities::Traps
 	void CollideCrumblingPlatform(short itemNumber, ItemInfo* laraItem, CollisionInfo* coll)
 	{
 		auto& item = g_Level.Items[itemNumber];
+		auto& player = *GetLaraInfo(laraItem);
 
 		// OCB >= 0; activate via player collision. OCB < 0 activates via trigger.
 		if (item.TriggerFlags >= 0 && item.Animation.ActiveState == CRUMBLING_PLATFORM_STATE_IDLE)
@@ -167,7 +170,7 @@ namespace TEN::Entities::Traps
 			// Crumble if player is on platform.
 			if (!laraItem->Animation.IsAirborne &&
 				coll->LastBridgeItemNumber == item.Index &&
-				laraItem->Animation.ActiveState != LS_DOZY)
+				player.Control.WaterStatus <= WaterStatus::Wade)
 			{
 				ActivateCrumblingPlatform(itemNumber);
 			}

--- a/TombEngine/Objects/Generic/Traps/crumblingPlatform.cpp
+++ b/TombEngine/Objects/Generic/Traps/crumblingPlatform.cpp
@@ -12,7 +12,7 @@ constexpr auto CRUMBLING_PLATFORM_INITIAL_SPEED = 10;
 constexpr auto CRUMBLING_PLATFORM_MAX_SPEED = 100;
 constexpr auto CRUMBLING_PLATFORM_FALL_VELOCITY = 4;
 
-constexpr auto CRUMBLING_PLATFORM_DELAY = 52;
+constexpr auto CRUMBLING_PLATFORM_DELAY = 35;
 
 //I clamped it to ensure the value is less than half CLICK or it may not update room properly when landing on slopes in 1 click height rooms.
 constexpr auto CRUMBLING_PLATFORM_HEIGHT_TOLERANCE = std::clamp(8, 0, 128);
@@ -45,6 +45,11 @@ void InitializeCrumblingPlatform(short itemNumber)
 	auto bounds = GameBoundingBox(&item);
 	item.ItemFlags[2] = bounds.Y1; //floor
 	item.ItemFlags[3] = bounds.Y2; //ceiling
+
+	//ItemFlags 0 = timer
+	//ItemFlags 1 = gravity velocity
+	//ItemFlags 2 = Top height of bounding box
+	//ItemFlags 3 = Bottom height of bounding box
 }
 
 void CrumblingPlatformCollision(short itemNumber, ItemInfo* laraItem, CollisionInfo* coll)
@@ -131,10 +136,13 @@ void CrumblingPlatformControl(short itemNumber)
 
 		case CRUMBLING_PLATFORM_STATE_LANDING:
 		{
+			//Is hitting the ground.
+			
+			//Align to surface
 			auto radius = Vector2(Objects[item.ObjectNumber].radius);
 			AlignEntityToSurface(&item, radius);
 
-			//Is landing, check if it's the last frame to deactivate the item.
+			//Check if it's the last frame to deactivate the item.
 			int frameEnd = GetAnimData(Objects[item.ObjectNumber], CRUMBLING_PLATFORM_ANIM_LANDING).frameEnd;
 			if (item.Animation.FrameNumber >= frameEnd)
 			{
@@ -162,7 +170,7 @@ void CrumblingPlatformActivate(short itemNumber)
 
 	SetAnimation(&item, CRUMBLING_PLATFORM_ANIM_SHAKING);
 		
-	//item.Flags |= CODE_BITS;
+	item.Flags |= CODE_BITS;
 }
 
 std::optional<int> CrumblingPlatformFloor(short itemNumber, int x, int y, int z)
@@ -170,13 +178,9 @@ std::optional<int> CrumblingPlatformFloor(short itemNumber, int x, int y, int z)
 	ItemInfo& item = g_Level.Items[itemNumber];
 
 	if (item.Animation.ActiveState <= CRUMBLING_PLATFORM_STATE_SHAKING)
-	{
 		return item.Pose.Position.y + item.ItemFlags[2];
-	}
 	else
-	{
 		return std::nullopt;
-	}
 }
 
 std::optional<int> CrumblingPlatformCeiling(short itemNumber, int x, int y, int z)
@@ -184,13 +188,9 @@ std::optional<int> CrumblingPlatformCeiling(short itemNumber, int x, int y, int 
 	ItemInfo& item = g_Level.Items[itemNumber];
 
 	if (item.Animation.ActiveState <= CRUMBLING_PLATFORM_STATE_SHAKING)
-	{
 		return item.Pose.Position.y + item.ItemFlags[3];
-	}
 	else
-	{
 		return std::nullopt;
-	}
 }
 
 int CrumblingPlatformFloorBorder(short itemNumber)

--- a/TombEngine/Objects/Generic/Traps/crumblingPlatform.cpp
+++ b/TombEngine/Objects/Generic/Traps/crumblingPlatform.cpp
@@ -57,7 +57,7 @@ void CrumblingPlatformCollision(short itemNumber, ItemInfo* laraItem, CollisionI
 		//Checks if Lara and Item are in the same XZ sector. And Lara is over the platform.
 		if (!((item.Pose.Position.x ^ laraItem->Pose.Position.x) & 0xFFFFFC00) &&
 			!((laraItem->Pose.Position.z ^ item.Pose.Position.z) & 0xFFFFFC00) &&
-			abs(item.Pose.Position.y - CLICK(2) - laraItem->Pose.Position.y) < CRUMBLING_PLATFORM_HEIGHT_TOLERANCE)
+			abs((item.Pose.Position.y + item.ItemFlags[2]) - laraItem->Pose.Position.y) < CRUMBLING_PLATFORM_HEIGHT_TOLERANCE)
 		{
 			CrumblingPlatformActivate(itemNumber);
 		}
@@ -93,7 +93,6 @@ void CrumblingPlatformControl(short itemNumber)
 
 				auto& collisionResult = GetCollision(item);
 				collisionResult.Block->RemoveBridge(itemNumber);
-				UpdateBridgeItem(itemNumber);
 			}
 		}
 		break;
@@ -168,7 +167,7 @@ std::optional<int> CrumblingPlatformFloor(short itemNumber, int x, int y, int z)
 {
 	ItemInfo& item = g_Level.Items[itemNumber];
 
-	if (item.Animation.ActiveState >= CRUMBLING_PLATFORM_STATE_SHAKING)
+	if (item.Animation.ActiveState <= CRUMBLING_PLATFORM_STATE_SHAKING)
 	{
 		return item.Pose.Position.y + item.ItemFlags[2];
 	}

--- a/TombEngine/Objects/Generic/Traps/crumblingPlatform.cpp
+++ b/TombEngine/Objects/Generic/Traps/crumblingPlatform.cpp
@@ -108,7 +108,7 @@ namespace TEN::Entities::Traps
 				int relFloorHeight = item.Pose.Position.y - pointColl.Position.Floor;
 
 				// Airborne.
-				if (relFloorHeight < -fallVel)
+				if (relFloorHeight <= fallVel)
 				{
 					fallVel += CRUMBLING_PLATFORM_FALL_VELOCITY;
 					if (fallVel > CRUMBLING_PLATFORM_MAX_VELOCITY)

--- a/TombEngine/Objects/Generic/Traps/crumblingPlatform.cpp
+++ b/TombEngine/Objects/Generic/Traps/crumblingPlatform.cpp
@@ -1,0 +1,202 @@
+#include "framework.h"
+#include "Objects/Generic/Traps/crumblingPlatform.h"
+
+#include "Game/collision/collide_item.h"
+#include "Game/collision/floordata.h"
+#include "Game/setup.h"
+#include "Specific/level.h"
+
+using namespace TEN::Collision::Floordata;
+
+constexpr auto CRUMBLING_PLATFORM_INITIAL_SPEED = 10;
+constexpr auto CRUMBLING_PLATFORM_MAX_SPEED = 100;
+constexpr auto CRUMBLING_PLATFORM_FALL_VELOCITY = 4;
+
+constexpr auto CRUMBLING_PLATFORM_DELAY = 52;
+
+//I clamped it to ensure the value is less than half CLICK or it may not update room properly when landing on slopes in 1 click height rooms.
+constexpr auto CRUMBLING_PLATFORM_HEIGHT_TOLERANCE = std::clamp(8, 0, 128);
+
+enum CrumblingPlatformState
+{
+	CRUMBLING_PLATFORM_STATE_IDLE = 0,
+	CRUMBLING_PLATFORM_STATE_SHAKING = 1,
+	CRUMBLING_PLATFORM_STATE_FALLING = 2,
+	CRUMBLING_PLATFORM_STATE_LANDING = 3
+};
+
+enum CrumblingPlatformAnim
+{
+	CRUMBLING_PLATFORM_ANIM_IDLE = 0,
+	CRUMBLING_PLATFORM_ANIM_SHAKING = 1,
+	CRUMBLING_PLATFORM_ANIM_FALLING = 2,
+	CRUMBLING_PLATFORM_ANIM_LANDING = 3
+};
+
+void InitializeCrumblingPlatform(short itemNumber)
+{
+	auto& item = g_Level.Items[itemNumber];
+
+	int timerFrames = (item.TriggerFlags != 0) ? std::abs(item.TriggerFlags) : CRUMBLING_PLATFORM_DELAY;
+	item.ItemFlags[0] = timerFrames;
+	UpdateBridgeItem(itemNumber);
+
+	//Store the bridge collider Ys to override them in the bridge collision (to avoid use the bounding box while is shaking).
+	auto bounds = GameBoundingBox(&item);
+	item.ItemFlags[2] = bounds.Y1; //floor
+	item.ItemFlags[3] = bounds.Y2; //ceiling
+}
+
+void CrumblingPlatformCollision(short itemNumber, ItemInfo* laraItem, CollisionInfo* coll)
+{
+	auto& item = g_Level.Items[itemNumber];
+
+	//If OCB is 0 or higher, activate by Lara's collision. (If OCB < 0, it will activate by trigger).
+	if (item.TriggerFlags >= 0 && item.Animation.ActiveState == CRUMBLING_PLATFORM_STATE_IDLE)
+	{
+		//Checks if Lara and Item are in the same XZ sector. And Lara is over the platform.
+		if (!((item.Pose.Position.x ^ laraItem->Pose.Position.x) & 0xFFFFFC00) &&
+			!((laraItem->Pose.Position.z ^ item.Pose.Position.z) & 0xFFFFFC00) &&
+			abs(item.Pose.Position.y - CLICK(2) - laraItem->Pose.Position.y) < CRUMBLING_PLATFORM_HEIGHT_TOLERANCE)
+		{
+			CrumblingPlatformActivate(itemNumber);
+		}
+	}
+}
+
+void CrumblingPlatformControl(short itemNumber)
+{
+	auto& item = g_Level.Items[itemNumber];
+
+	//It ocb < 0, it must be activated by trigger.
+	if (item.TriggerFlags < 0)
+	{
+		if (TriggerActive(&item))
+			CrumblingPlatformActivate(itemNumber);
+
+		return;
+	}
+
+	switch (item.Animation.ActiveState)
+	{
+		case CRUMBLING_PLATFORM_STATE_SHAKING:
+		{
+			if (item.ItemFlags[0] > 0)
+			{
+				item.ItemFlags[0]--;
+			}
+			else
+			{
+				SetAnimation(&item, CRUMBLING_PLATFORM_ANIM_FALLING);
+
+				item.ItemFlags[1] = CRUMBLING_PLATFORM_INITIAL_SPEED;
+
+				auto& collisionResult = GetCollision(item);
+				collisionResult.Block->RemoveBridge(itemNumber);
+				UpdateBridgeItem(itemNumber);
+			}
+		}
+		break;
+
+		case CRUMBLING_PLATFORM_STATE_FALLING:
+		{
+			auto collisionResult = GetCollision(item);
+			auto height = abs(item.Pose.Position.y - collisionResult.Position.Floor);
+
+			if (height > 0)
+			{//Is falling
+
+				item.ItemFlags[1] += CRUMBLING_PLATFORM_FALL_VELOCITY;
+
+				if (item.ItemFlags[1] > CRUMBLING_PLATFORM_MAX_SPEED)
+					item.ItemFlags[1] = CRUMBLING_PLATFORM_MAX_SPEED;
+
+				item.Pose.Position.y += item.ItemFlags[1];
+			}
+			else
+			{//Has reached the ground
+
+				item.Pose.Position.y = height;
+
+				SetAnimation(&item, CRUMBLING_PLATFORM_ANIM_LANDING);
+			}
+
+			//Update Room Number
+			int probedRoomNumber = collisionResult.RoomNumber;
+			if (item.RoomNumber != probedRoomNumber)
+				ItemNewRoom(itemNumber, probedRoomNumber);
+		}
+		break;
+
+		case CRUMBLING_PLATFORM_STATE_LANDING:
+		{
+			//Is landing, check if it's the last frame to deactivate the item.
+			int frameEnd = GetAnimData(Objects[item.ObjectNumber], CRUMBLING_PLATFORM_ANIM_LANDING).frameEnd;
+			if (item.Animation.FrameNumber >= frameEnd)
+			{
+				RemoveActiveItem(itemNumber);
+				item.Status = ITEM_NOT_ACTIVE;
+			}
+		}
+		break;
+
+		default:
+			TENLog("Error with Crumbling Platform object: " + std::to_string(itemNumber) + ", animation state not recognized.", LogLevel::Error, LogConfig::All, false);
+		break;
+
+	}
+
+	AnimateItem(&item);
+}
+
+void CrumblingPlatformActivate(short itemNumber)
+{
+	auto& item = g_Level.Items[itemNumber];
+	
+	item.Status = ITEM_ACTIVE;
+	AddActiveItem(itemNumber);
+
+	SetAnimation(&item, CRUMBLING_PLATFORM_ANIM_SHAKING);
+		
+	//item.Flags |= CODE_BITS;
+}
+
+std::optional<int> CrumblingPlatformFloor(short itemNumber, int x, int y, int z)
+{
+	ItemInfo& item = g_Level.Items[itemNumber];
+
+	if (item.Animation.ActiveState >= CRUMBLING_PLATFORM_STATE_SHAKING)
+	{
+		return item.Pose.Position.y + item.ItemFlags[2];
+	}
+	else
+	{
+		return std::nullopt;
+	}
+}
+
+std::optional<int> CrumblingPlatformCeiling(short itemNumber, int x, int y, int z)
+{
+	ItemInfo& item = g_Level.Items[itemNumber];
+
+	if (item.Animation.ActiveState <= CRUMBLING_PLATFORM_STATE_SHAKING)
+	{
+		return item.Pose.Position.y + item.ItemFlags[3];
+	}
+	else
+	{
+		return std::nullopt;
+	}
+}
+
+int CrumblingPlatformFloorBorder(short itemNumber)
+{
+	auto& item = g_Level.Items[itemNumber];
+	return item.ItemFlags[2];
+}
+
+int CrumblingPlatformCeilingBorder(short itemNumber)
+{
+	auto& item = g_Level.Items[itemNumber];
+	return item.ItemFlags[3];
+}

--- a/TombEngine/Objects/Generic/Traps/crumblingPlatform.cpp
+++ b/TombEngine/Objects/Generic/Traps/crumblingPlatform.cpp
@@ -1,5 +1,5 @@
 #include "framework.h"
-#include "Objects/Generic/Traps/crumblingPlatform.h"
+#include "Objects/Generic/Traps/CrumblingPlatform.h"
 
 #include "Game/collision/collide_item.h"
 #include "Game/collision/floordata.h"

--- a/TombEngine/Objects/Generic/Traps/crumblingPlatform.cpp
+++ b/TombEngine/Objects/Generic/Traps/crumblingPlatform.cpp
@@ -101,9 +101,9 @@ void CrumblingPlatformControl(short itemNumber)
 		case CRUMBLING_PLATFORM_STATE_FALLING:
 		{
 			auto collisionResult = GetCollision(item);
-			auto height = abs(item.Pose.Position.y - collisionResult.Position.Floor);
+			auto height = item.Pose.Position.y - collisionResult.Position.Floor;
 
-			if (height > 0)
+			if (height < 0)
 			{//Is falling
 
 				item.ItemFlags[1] += CRUMBLING_PLATFORM_FALL_VELOCITY;
@@ -116,7 +116,7 @@ void CrumblingPlatformControl(short itemNumber)
 			else
 			{//Has reached the ground
 
-				item.Pose.Position.y = height;
+				item.Pose.Position.y = collisionResult.Position.Floor;
 
 				SetAnimation(&item, CRUMBLING_PLATFORM_ANIM_LANDING);
 			}
@@ -130,6 +130,9 @@ void CrumblingPlatformControl(short itemNumber)
 
 		case CRUMBLING_PLATFORM_STATE_LANDING:
 		{
+			auto radius = Vector2(Objects[item.ObjectNumber].radius);
+			AlignEntityToSurface(&item, radius);
+
 			//Is landing, check if it's the last frame to deactivate the item.
 			int frameEnd = GetAnimData(Objects[item.ObjectNumber], CRUMBLING_PLATFORM_ANIM_LANDING).frameEnd;
 			if (item.Animation.FrameNumber >= frameEnd)

--- a/TombEngine/Objects/Generic/Traps/crumblingPlatform.cpp
+++ b/TombEngine/Objects/Generic/Traps/crumblingPlatform.cpp
@@ -47,7 +47,7 @@ namespace TEN::Entities::Traps
 		item.ItemFlags[0] = delayInFrameTime;
 		UpdateBridgeItem(itemNumber);
 
-		// Store override bridge collision heights to using bounding box while shaking.
+		// Store override bridge collision heights to avoid using bounding box while shaking.
 		auto bounds = GameBoundingBox(&item);
 		item.ItemFlags[2] = bounds.Y1; // Floor.
 		item.ItemFlags[3] = bounds.Y2; // Ceiling.

--- a/TombEngine/Objects/Generic/Traps/crumblingPlatform.cpp
+++ b/TombEngine/Objects/Generic/Traps/crumblingPlatform.cpp
@@ -68,7 +68,7 @@ namespace TEN::Entities::Traps
 	{
 		auto& item = g_Level.Items[itemNumber];
 
-		// OCD < 0; must be activated by trigger.
+		// OCB < 0; must be activated by trigger.
 		if (item.TriggerFlags < 0)
 		{
 			if (TriggerActive(&item))
@@ -166,7 +166,8 @@ namespace TEN::Entities::Traps
 		{
 			// Crumble if player is on platform.
 			if (!laraItem->Animation.IsAirborne &&
-				coll->LastBridgeItemNumber == item.Index)
+				coll->LastBridgeItemNumber == item.Index &&
+				laraItem->Animation.ActiveState != LS_DOZY)
 			{
 				ActivateCrumblingPlatform(itemNumber);
 			}

--- a/TombEngine/Objects/Generic/Traps/crumblingPlatform.cpp
+++ b/TombEngine/Objects/Generic/Traps/crumblingPlatform.cpp
@@ -148,7 +148,7 @@ namespace TEN::Entities::Traps
 			default:
 				TENLog(
 					"Error with crumbling platform with entity ID" + std::to_string(itemNumber) + ". animation state not recognized.",
-					LogLevel::Error, LogConfig::All, false);
+					LogLevel::Error, LogConfig::All);
 				break;
 		}
 

--- a/TombEngine/Objects/Generic/Traps/crumblingPlatform.cpp
+++ b/TombEngine/Objects/Generic/Traps/crumblingPlatform.cpp
@@ -72,8 +72,10 @@ void CrumblingPlatformControl(short itemNumber)
 	if (item.TriggerFlags < 0)
 	{
 		if (TriggerActive(&item))
+		{
 			CrumblingPlatformActivate(itemNumber);
-
+			item.TriggerFlags = -item.TriggerFlags;
+		}
 		return;
 	}
 

--- a/TombEngine/Objects/Generic/Traps/crumblingPlatform.h
+++ b/TombEngine/Objects/Generic/Traps/crumblingPlatform.h
@@ -6,13 +6,13 @@ struct ItemInfo;
 namespace TEN::Entities::Traps
 {
 	void InitializeCrumblingPlatform(short itemNumber);
-	void CrumblingPlatformCollision(short itemNumber, ItemInfo* laraItem, CollisionInfo* coll);
-	void CrumblingPlatformControl(short itemNumber);
+	void ControlCrumblingPlatform(short itemNumber);
+	void CollideCrumblingPlatform(short itemNumber, ItemInfo* laraItem, CollisionInfo* coll);
 
-	void CrumblingPlatformActivate(short itemNumber);
+	void ActivateCrumblingPlatform(short itemNumber);
 
 	std::optional<int> CrumblingPlatformFloor(short itemNumber, int x, int y, int z);
 	std::optional<int> CrumblingPlatformCeiling(short itemNumber, int x, int y, int z);
-	int CrumblingPlatformFloorBorder(short itemNumber);
-	int CrumblingPlatformCeilingBorder(short itemNumber);
+	int				   CrumblingPlatformFloorBorder(short itemNumber);
+	int				   CrumblingPlatformCeilingBorder(short itemNumber);
 }

--- a/TombEngine/Objects/Generic/Traps/crumblingPlatform.h
+++ b/TombEngine/Objects/Generic/Traps/crumblingPlatform.h
@@ -1,0 +1,15 @@
+#pragma once
+
+struct CollisionInfo;
+struct ItemInfo;
+
+void InitializeCrumblingPlatform(short itemNumber);
+void CrumblingPlatformCollision(short itemNumber, ItemInfo* laraItem, CollisionInfo* coll);
+void CrumblingPlatformControl(short itemNumber);
+
+void CrumblingPlatformActivate(short itemNumber);
+
+std::optional<int> CrumblingPlatformFloor(short itemNumber, int x, int y, int z);
+std::optional<int> CrumblingPlatformCeiling(short itemNumber, int x, int y, int z);
+int CrumblingPlatformFloorBorder(short itemNumber);
+int CrumblingPlatformCeilingBorder(short itemNumber);

--- a/TombEngine/Objects/Generic/Traps/crumblingPlatform.h
+++ b/TombEngine/Objects/Generic/Traps/crumblingPlatform.h
@@ -3,13 +3,16 @@
 struct CollisionInfo;
 struct ItemInfo;
 
-void InitializeCrumblingPlatform(short itemNumber);
-void CrumblingPlatformCollision(short itemNumber, ItemInfo* laraItem, CollisionInfo* coll);
-void CrumblingPlatformControl(short itemNumber);
+namespace TEN::Entities::Traps
+{
+	void InitializeCrumblingPlatform(short itemNumber);
+	void CrumblingPlatformCollision(short itemNumber, ItemInfo* laraItem, CollisionInfo* coll);
+	void CrumblingPlatformControl(short itemNumber);
 
-void CrumblingPlatformActivate(short itemNumber);
+	void CrumblingPlatformActivate(short itemNumber);
 
-std::optional<int> CrumblingPlatformFloor(short itemNumber, int x, int y, int z);
-std::optional<int> CrumblingPlatformCeiling(short itemNumber, int x, int y, int z);
-int CrumblingPlatformFloorBorder(short itemNumber);
-int CrumblingPlatformCeilingBorder(short itemNumber);
+	std::optional<int> CrumblingPlatformFloor(short itemNumber, int x, int y, int z);
+	std::optional<int> CrumblingPlatformCeiling(short itemNumber, int x, int y, int z);
+	int CrumblingPlatformFloorBorder(short itemNumber);
+	int CrumblingPlatformCeilingBorder(short itemNumber);
+}

--- a/TombEngine/Objects/Generic/generic_objects.cpp
+++ b/TombEngine/Objects/Generic/generic_objects.cpp
@@ -40,6 +40,7 @@
 // Traps
 #include "Objects/Generic/Traps/dart_emitter.h"
 #include "Objects/Generic/Traps/falling_block.h"
+#include "Objects/Generic/Traps/crumblingPlatform.h"
 
 using namespace TEN::Entities::Doors;
 using namespace TEN::Entities::Generic;
@@ -444,9 +445,14 @@ void StartTraps(ObjectInfo* object)
 	object = &Objects[ID_CRUMBLING_FLOOR];
 	if (object->loaded)
 	{
-		object->Initialize = InitializeFallingBlock;
-		object->collision = FallingBlockCollision;
-		object->control = FallingBlockControl;
+		object->Initialize = InitializeCrumblingPlatform;
+		object->collision = CrumblingPlatformCollision;
+		object->control = CrumblingPlatformControl;
+
+		object->floor = CrumblingPlatformFloor;
+		object->ceiling = CrumblingPlatformCeiling;
+		object->floorBorder = CrumblingPlatformFloorBorder;
+		object->ceilingBorder = CrumblingPlatformCeilingBorder;
 	}
 
 	object = &Objects[ID_PARALLEL_BARS];

--- a/TombEngine/Objects/Generic/generic_objects.cpp
+++ b/TombEngine/Objects/Generic/generic_objects.cpp
@@ -38,9 +38,9 @@
 #include "Objects/Generic/Doors/underwater_door.h"
 
 // Traps
+#include "Objects/Generic/Traps/CrumblingPlatform.h"
 #include "Objects/Generic/Traps/dart_emitter.h"
 #include "Objects/Generic/Traps/falling_block.h"
-#include "Objects/Generic/Traps/crumblingPlatform.h"
 
 using namespace TEN::Entities::Doors;
 using namespace TEN::Entities::Generic;
@@ -446,8 +446,8 @@ void StartTraps(ObjectInfo* object)
 	if (object->loaded)
 	{
 		object->Initialize = InitializeCrumblingPlatform;
-		object->collision = CrumblingPlatformCollision;
-		object->control = CrumblingPlatformControl;
+		object->control = ControlCrumblingPlatform;
+		object->collision = CollideCrumblingPlatform;
 
 		object->floor = CrumblingPlatformFloor;
 		object->ceiling = CrumblingPlatformCeiling;

--- a/TombEngine/TombEngine.vcxproj
+++ b/TombEngine/TombEngine.vcxproj
@@ -444,7 +444,7 @@ xcopy /Y "$(SolutionDir)Libs\zlib\x64\*.dll" "$(TargetDir)"</Command>
     <ClInclude Include="Objects\Generic\Switches\switch.h" />
     <ClInclude Include="Objects\Generic\Switches\turn_switch.h" />
     <ClInclude Include="Objects\Generic\Switches\underwater_switch.h" />
-    <ClInclude Include="Objects\Generic\Traps\crumblingPlatform.h" />
+    <ClInclude Include="Objects\Generic\Traps\CrumblingPlatform.h" />
     <ClInclude Include="Objects\Generic\Traps\dart_emitter.h" />
     <ClInclude Include="Objects\Generic\Traps\falling_block.h" />
     <ClInclude Include="Objects\Generic\generic_objects.h" />
@@ -899,7 +899,7 @@ xcopy /Y "$(SolutionDir)Libs\zlib\x64\*.dll" "$(TargetDir)"</Command>
     <ClCompile Include="Objects\Generic\Switches\switch.cpp" />
     <ClCompile Include="Objects\Generic\Switches\turn_switch.cpp" />
     <ClCompile Include="Objects\Generic\Switches\underwater_switch.cpp" />
-    <ClCompile Include="Objects\Generic\Traps\crumblingPlatform.cpp" />
+    <ClCompile Include="Objects\Generic\Traps\CrumblingPlatform.cpp" />
     <ClCompile Include="Objects\Generic\Traps\dart_emitter.cpp" />
     <ClCompile Include="Objects\Generic\Traps\falling_block.cpp" />
     <ClCompile Include="Objects\TR1\Entity\Cowboy.cpp" />

--- a/TombEngine/TombEngine.vcxproj
+++ b/TombEngine/TombEngine.vcxproj
@@ -444,6 +444,7 @@ xcopy /Y "$(SolutionDir)Libs\zlib\x64\*.dll" "$(TargetDir)"</Command>
     <ClInclude Include="Objects\Generic\Switches\switch.h" />
     <ClInclude Include="Objects\Generic\Switches\turn_switch.h" />
     <ClInclude Include="Objects\Generic\Switches\underwater_switch.h" />
+    <ClInclude Include="Objects\Generic\Traps\crumblingPlatform.h" />
     <ClInclude Include="Objects\Generic\Traps\dart_emitter.h" />
     <ClInclude Include="Objects\Generic\Traps\falling_block.h" />
     <ClInclude Include="Objects\Generic\generic_objects.h" />
@@ -898,6 +899,7 @@ xcopy /Y "$(SolutionDir)Libs\zlib\x64\*.dll" "$(TargetDir)"</Command>
     <ClCompile Include="Objects\Generic\Switches\switch.cpp" />
     <ClCompile Include="Objects\Generic\Switches\turn_switch.cpp" />
     <ClCompile Include="Objects\Generic\Switches\underwater_switch.cpp" />
+    <ClCompile Include="Objects\Generic\Traps\crumblingPlatform.cpp" />
     <ClCompile Include="Objects\Generic\Traps\dart_emitter.cpp" />
     <ClCompile Include="Objects\Generic\Traps\falling_block.cpp" />
     <ClCompile Include="Objects\TR1\Entity\Cowboy.cpp" />

--- a/TombEngine/TombEngine.vcxproj
+++ b/TombEngine/TombEngine.vcxproj
@@ -444,6 +444,7 @@ xcopy /Y "$(SolutionDir)Libs\zlib\x64\*.dll" "$(TargetDir)"</Command>
     <ClInclude Include="Objects\Generic\Switches\switch.h" />
     <ClInclude Include="Objects\Generic\Switches\turn_switch.h" />
     <ClInclude Include="Objects\Generic\Switches\underwater_switch.h" />
+    <ClInclude Include="Objects\Generic\Traps\CrumblingPlatform.h" />
     <ClInclude Include="Objects\Generic\Traps\dart_emitter.h" />
     <ClInclude Include="Objects\Generic\Traps\falling_block.h" />
     <ClInclude Include="Objects\Generic\generic_objects.h" />
@@ -898,6 +899,7 @@ xcopy /Y "$(SolutionDir)Libs\zlib\x64\*.dll" "$(TargetDir)"</Command>
     <ClCompile Include="Objects\Generic\Switches\switch.cpp" />
     <ClCompile Include="Objects\Generic\Switches\turn_switch.cpp" />
     <ClCompile Include="Objects\Generic\Switches\underwater_switch.cpp" />
+    <ClCompile Include="Objects\Generic\Traps\CrumblingPlatform.cpp" />
     <ClCompile Include="Objects\Generic\Traps\dart_emitter.cpp" />
     <ClCompile Include="Objects\Generic\Traps\falling_block.cpp" />
     <ClCompile Include="Objects\TR1\Entity\Cowboy.cpp" />

--- a/TombEngine/TombEngine.vcxproj
+++ b/TombEngine/TombEngine.vcxproj
@@ -444,7 +444,6 @@ xcopy /Y "$(SolutionDir)Libs\zlib\x64\*.dll" "$(TargetDir)"</Command>
     <ClInclude Include="Objects\Generic\Switches\switch.h" />
     <ClInclude Include="Objects\Generic\Switches\turn_switch.h" />
     <ClInclude Include="Objects\Generic\Switches\underwater_switch.h" />
-    <ClInclude Include="Objects\Generic\Traps\CrumblingPlatform.h" />
     <ClInclude Include="Objects\Generic\Traps\dart_emitter.h" />
     <ClInclude Include="Objects\Generic\Traps\falling_block.h" />
     <ClInclude Include="Objects\Generic\generic_objects.h" />
@@ -899,7 +898,6 @@ xcopy /Y "$(SolutionDir)Libs\zlib\x64\*.dll" "$(TargetDir)"</Command>
     <ClCompile Include="Objects\Generic\Switches\switch.cpp" />
     <ClCompile Include="Objects\Generic\Switches\turn_switch.cpp" />
     <ClCompile Include="Objects\Generic\Switches\underwater_switch.cpp" />
-    <ClCompile Include="Objects\Generic\Traps\CrumblingPlatform.cpp" />
     <ClCompile Include="Objects\Generic\Traps\dart_emitter.cpp" />
     <ClCompile Include="Objects\Generic\Traps\falling_block.cpp" />
     <ClCompile Include="Objects\TR1\Entity\Cowboy.cpp" />


### PR DESCRIPTION
I wrote some code for crumbling platform object.

It has 3 ocb functions.

- OCB == 0: Default behaviour. The platform will start to shake when Lara steps in and will crumble during 35 frames (The animation's leght).
- OCB > 0: The platform will start to shake when Lara steps  and will crumble during the number of frames indicated in the OCB.
- OCB < 0: The platform will need be activated with a trigger, then it will crumble during the number of frames indicated in the OCB.

Right now it needs some changes to the object in the WAD.

- The crumbling animation by default is connecting to the falling animation when it ends, that unables the platform to keep crumbling for more than 35 frames. So this version has changed that to allow the crumbling animation loop.
- The original bounding box doesn't cover the whole sector what interrupts Lara's movements on sector edges, this version has changed the bounding box to cover the 511 units in all the horizontal axis during the Idle and Crumbling animations.
- The original platform, had a height offset of 512 units, the code has been prepared to deal with this case, but still I removed that offset in this version, so now the platform will be on the same click height that indicates Tomb Editor.
- This version has fixed the sounds ID in the falling and landing animations.

Crumbling Platform WAD: https://drive.google.com/file/d/18s56vn45Tn9DYU1S_COViU-031v3uM1Q/view?usp=sharing

Without those changes in the wad, the object still works but with some issues that could affect the gameplay.