### PR TITLE
Knife thrower fix

### DIFF
--- a/Documentation/Changes.txt
+++ b/Documentation/Changes.txt
@@ -8,6 +8,7 @@ Version 1.1.1
  - Reenable look mode while performing up jump, backward jump, or backward crawl.
  - When using binoculars or lasersight, holding Walk allows the player to pan slowly.
 * Fix regression in train death animation.
+* Fix knife thrower AI
 
 Version 1.1.0
 ==============

--- a/TombEngine/Objects/TR2/Entity/tr2_knife_thrower.cpp
+++ b/TombEngine/Objects/TR2/Entity/tr2_knife_thrower.cpp
@@ -95,6 +95,9 @@ namespace TEN::Entities::Creatures::TR2
 
 	void KnifeThrowerControl(short itemNumber)
 	{
+		if (!CreatureActive(itemNumber))
+			return;
+
 		auto* item = &g_Level.Items[itemNumber];
 		auto* creature = GetCreatureInfo(item);
 


### PR DESCRIPTION
Knife thrower never called CreatureActive function, meaning it never got a priority value, meaning it never updated its target position.
Closes #1099