### PR TITLE
Flipmap fixes

### DIFF
--- a/Documentation/Changes.txt
+++ b/Documentation/Changes.txt
@@ -8,6 +8,7 @@ Version 1.1.1
 * Fix TR1 wolf damage value inflicted on a close bite attack.
 * Fix TR1 bear various original AI issues.
 * Fix TR2 knife thrower AI.
+* Fix activation of a flipped room when using SetPos() script command or position change node.
 * Fix volume change in settings not affecting voice track.
 * Overhaul look mode:
  - Allow for consistent and wider viewing angles while crawling, crouching, and hanging.

--- a/TombEngine/Game/Setup.cpp
+++ b/TombEngine/Game/Setup.cpp
@@ -38,10 +38,10 @@ StaticInfo StaticObjects[MAX_STATICS];
 void InitializeGameFlags()
 {
 	ZeroMemory(FlipMap, MAX_FLIPMAP * sizeof(int));
-	ZeroMemory(FlipStats, MAX_FLIPMAP * sizeof(int));
+	ZeroMemory(FlipStats, MAX_FLIPMAP * sizeof(bool));
 
 	FlipEffect = -1;
-	FlipStatus = 0;
+	FlipStatus = false;
 	Camera.underwater = false;
 }
 

--- a/TombEngine/Game/control/box.cpp
+++ b/TombEngine/Game/control/box.cpp
@@ -149,7 +149,7 @@ void CreatureYRot2(Pose* fromPose, short angle, short angleAdd)
 bool SameZone(CreatureInfo* creature, ItemInfo* target)
 {
 	auto& item = g_Level.Items[creature->ItemNumber];
-	auto* zone = g_Level.Zones[(int)creature->LOT.Zone][FlipStatus].data();
+	auto* zone = g_Level.Zones[(int)creature->LOT.Zone][(int)FlipStatus].data();
 
 	auto& roomSource = g_Level.Rooms[item.RoomNumber];
 	auto& boxSource = GetSector(&roomSource, item.Pose.Position.x - roomSource.x, item.Pose.Position.z - roomSource.z)->Box;
@@ -250,7 +250,7 @@ bool CreaturePathfind(ItemInfo* item, Vector3i prevPos, short angle, short tilt)
 
 	auto* creature = GetCreatureInfo(item);
 	auto* LOT = &creature->LOT;
-	int* zone = g_Level.Zones[(int)LOT->Zone][FlipStatus].data();
+	int* zone = g_Level.Zones[(int)LOT->Zone][(int)FlipStatus].data();
 
 	int boxHeight;
 	if (item->BoxNumber != NO_BOX)
@@ -911,7 +911,7 @@ bool ValidBox(ItemInfo* item, short zoneNumber, short boxNumber)
 		return false;
 
 	const auto& creature = *GetCreatureInfo(item);
-	const auto& zone = g_Level.Zones[(int)creature.LOT.Zone][FlipStatus].data();
+	const auto& zone = g_Level.Zones[(int)creature.LOT.Zone][(int)FlipStatus].data();
 
 	if (creature.LOT.Fly == NO_FLYING && zone[boxNumber] != zoneNumber)
 		return false;
@@ -993,7 +993,7 @@ bool UpdateLOT(LOTInfo* LOT, int depth)
 
 bool SearchLOT(LOTInfo* LOT, int depth)
 {
-	auto* zone = g_Level.Zones[(int)LOT->Zone][FlipStatus].data();
+	auto* zone = g_Level.Zones[(int)LOT->Zone][(int)FlipStatus].data();
 	int searchZone = zone[LOT->Head];
 
 	for (int i = 0; i < depth; i++)
@@ -1446,7 +1446,7 @@ void FindAITargetObject(CreatureInfo* creature, int objectNumber, int ocb, bool 
 			aiObject.triggerFlags == ocb &&
 			aiObject.roomNumber != NO_ROOM)
 		{
-			int* zone = g_Level.Zones[(int)creature->LOT.Zone][FlipStatus].data();
+			int* zone = g_Level.Zones[(int)creature->LOT.Zone][(int)FlipStatus].data();
 			auto* room = &g_Level.Rooms[item.RoomNumber];
 
 			item.BoxNumber = GetSector(room, item.Pose.Position.x - room->x, item.Pose.Position.z - room->z)->Box;
@@ -1531,7 +1531,7 @@ void CreatureAIInfo(ItemInfo* item, AI_INFO* AI)
 		creature->Enemy = LaraItem;
 	}
 
-	auto* zone = g_Level.Zones[(int)creature->LOT.Zone][FlipStatus].data();
+	auto* zone = g_Level.Zones[(int)creature->LOT.Zone][(int)FlipStatus].data();
 	auto* room = &g_Level.Rooms[item->RoomNumber];
 
 	item->BoxNumber = GetSector(room, item->Pose.Position.x - room->x, item->Pose.Position.z - room->z)->Box;

--- a/TombEngine/Game/room.cpp
+++ b/TombEngine/Game/room.cpp
@@ -11,9 +11,9 @@
 using namespace TEN::Collision::Floordata;
 using namespace TEN::Renderer;
 
-byte FlipStatus = 0;
-int FlipStats[MAX_FLIPMAP];
-int FlipMap[MAX_FLIPMAP];
+bool FlipStatus = false;
+bool FlipStats[MAX_FLIPMAP];
+int  FlipMap[MAX_FLIPMAP];
 
 std::vector<short> OutsideRoomTable[OUTSIDE_SIZE][OUTSIDE_SIZE];
 
@@ -22,7 +22,13 @@ bool ROOM_INFO::Active()
 	if (flipNumber == NO_ROOM)
 		return true;
 
-	return !(FlipStats[flipNumber] && flippedRoom == NO_ROOM);
+	// Because engine swaps whole room memory block but substitutes flippedRoom,
+	// we have to check both original index and flippedRoom equality, as well as NO_ROOM
+	// in case we are checking non-flipped rooms.
+
+	return (!FlipStats[flipNumber] && flippedRoom != index && flippedRoom != NO_ROOM) ||
+		   ( FlipStats[flipNumber] && flippedRoom == index);
+		   
 }
 
 void DoFlipMap(short group)
@@ -203,8 +209,10 @@ int FindRoomNumber(Vector3i position, int startRoom)
 	{
 		auto& room = g_Level.Rooms[startRoom];
 		for (auto n : room.neighbors)
+		{
 			if (n != startRoom && IsPointInRoom(position, n) && g_Level.Rooms[n].Active())
 				return n;
+		}
 	}
 
 	for (int i = 0; i < g_Level.Rooms.size(); i++)

--- a/TombEngine/Game/room.h
+++ b/TombEngine/Game/room.h
@@ -13,9 +13,9 @@ constexpr auto NO_ROOM		= -1;
 constexpr auto OUTSIDE_Z	= 64;
 constexpr auto OUTSIDE_SIZE = 1024;
 
-extern byte FlipStatus;
-extern int FlipStats[MAX_FLIPMAP];
-extern int FlipMap[MAX_FLIPMAP];
+extern bool FlipStatus;
+extern bool FlipStats[MAX_FLIPMAP];
+extern int  FlipMap[MAX_FLIPMAP];
 
 enum RoomEnvFlags
 {

--- a/TombEngine/Objects/TR4/Entity/Wraith.cpp
+++ b/TombEngine/Objects/TR4/Entity/Wraith.cpp
@@ -412,7 +412,7 @@ namespace TEN::Entities::TR4
 								if (!FlipStats[item.TriggerFlags])
 								{
 									DoFlipMap(item.TriggerFlags);
-									FlipStats[item.TriggerFlags] = 1;
+									FlipStats[item.TriggerFlags] = true;
 								}
 							}
 						}


### PR DESCRIPTION
Fixes an issue with incorrectly switching room while using `SetPos()` script function, if flipped room is available at that position.
Additionally, this PR introduces small flipmap refactor to better reflect used data types.