### PR TITLE
Allow to access node events from scripting

### DIFF
--- a/TombEngine/Game/control/trigger.cpp
+++ b/TombEngine/Game/control/trigger.cpp
@@ -785,20 +785,15 @@ void TestTriggers(int x, int y, int z, FloorInfo* floor, VolumeActivator activat
 				if (!((int)set.Activators & activatorType))
 					continue;
 
-				switch (trigger & TIMER_BITS)
+				int eventType = trigger & TIMER_BITS;
+
+				if (eventType > (int)VolumeEventType::Count)
 				{
-				case 0:
-					HandleEvent(set.OnEnter, activator);
-					break;
-
-				case 1:
-					HandleEvent(set.OnInside, activator);
-					break;
-
-				case 2:
-					HandleEvent(set.OnLeave, activator);
-					break;
+					TENLog("Unknown volume event type encountered for legacy trigger: " + std::to_string(eventType), LogLevel::Warning);
+					continue;
 				}
+
+				HandleEvent(set.Events[eventType], activator);
 			}
 			break;
 

--- a/TombEngine/Game/control/trigger.cpp
+++ b/TombEngine/Game/control/trigger.cpp
@@ -787,7 +787,7 @@ void TestTriggers(int x, int y, int z, FloorInfo* floor, VolumeActivator activat
 
 				int eventType = trigger & TIMER_BITS;
 
-				if (eventType > (int)VolumeEventType::Count)
+				if (eventType >= (int)VolumeEventType::Count)
 				{
 					TENLog("Unknown volume event type encountered for legacy trigger: " + std::to_string(eventType), LogLevel::Warning);
 					continue;

--- a/TombEngine/Game/control/trigger.cpp
+++ b/TombEngine/Game/control/trigger.cpp
@@ -786,10 +786,9 @@ void TestTriggers(int x, int y, int z, FloorInfo* floor, VolumeActivator activat
 					continue;
 
 				int eventType = trigger & TIMER_BITS;
-
 				if (eventType >= (int)VolumeEventType::Count)
 				{
-					TENLog("Unknown volume event type encountered for legacy trigger: " + std::to_string(eventType), LogLevel::Warning);
+					TENLog("Unknown volume event type encountered for legacy trigger " + std::to_string(eventType), LogLevel::Warning);
 					continue;
 				}
 

--- a/TombEngine/Game/control/volume.cpp
+++ b/TombEngine/Game/control/volume.cpp
@@ -66,37 +66,33 @@ namespace TEN::Control::Volumes
 			event.CallCounter--;
 	}
 
-	bool HandleEvent(const std::string& name, VolumeEventType type, VolumeActivator activator)
+	bool HandleEvent(const std::string& name, VolumeEventType eventType, VolumeActivator activator)
 	{
 		// Cache last used event sets so that whole list is not searched every time user calls this.
-		static VolumeEventSet* lastEventSet = nullptr;
+		static VolumeEventSet* lastEventSetPtr = nullptr;
 
-		if (lastEventSet != nullptr && lastEventSet->Name != name)
-		{
-			lastEventSet = nullptr;
-		}
+		if (lastEventSetPtr != nullptr && lastEventSetPtr->Name != name)
+			lastEventSetPtr = nullptr;
 
-		if (lastEventSet == nullptr)
+		if (lastEventSetPtr == nullptr)
 		{
 			for (auto& eventSet : g_Level.EventSets)
 			{
 				if (eventSet.Name == name)
 				{
-					lastEventSet = &eventSet;
+					lastEventSetPtr = &eventSet;
 					break;
 				}
 			}
 		}
 
-		if (lastEventSet != nullptr)
+		if (lastEventSetPtr != nullptr)
 		{
-			HandleEvent(lastEventSet->Events[(int)type], activator);
+			HandleEvent(lastEventSetPtr->Events[(int)eventType], activator);
 			return true;
 		}
-		else
-		{
-			return false;
-		}
+	
+		return false;
 	}
 
 	void TestVolumes(short roomNumber, const BoundingOrientedBox& box, VolumeActivatorFlags activatorFlag, VolumeActivator activator)

--- a/TombEngine/Game/control/volume.h
+++ b/TombEngine/Game/control/volume.h
@@ -44,7 +44,7 @@ namespace TEN::Control::Volumes
 	void TestVolumes(CAMERA_INFO* camera);
 
 	void HandleEvent(VolumeEvent& event, VolumeActivator& activator);
-	bool HandleEvent(const std::string& name, VolumeEventType type, VolumeActivator activator);
+	bool HandleEvent(const std::string& name, VolumeEventType eventType, VolumeActivator activator);
 	void InitializeNodeScripts();
 }
 

--- a/TombEngine/Game/control/volume.h
+++ b/TombEngine/Game/control/volume.h
@@ -44,6 +44,7 @@ namespace TEN::Control::Volumes
 	void TestVolumes(CAMERA_INFO* camera);
 
 	void HandleEvent(VolumeEvent& event, VolumeActivator& activator);
+	bool HandleEvent(const std::string& name, VolumeEventType type, VolumeActivator activator);
 	void InitializeNodeScripts();
 }
 

--- a/TombEngine/Game/control/volumeactivator.h
+++ b/TombEngine/Game/control/volumeactivator.h
@@ -25,6 +25,7 @@ namespace TEN::Control::Volumes
 		Enter,
 		Inside,
 		Leave,
+
 		Count
 	};
 

--- a/TombEngine/Game/control/volumeactivator.h
+++ b/TombEngine/Game/control/volumeactivator.h
@@ -20,6 +20,14 @@ namespace TEN::Control::Volumes
 		Nodes
 	};
 
+	enum class VolumeEventType
+	{
+		Enter,
+		Inside,
+		Leave,
+		Count
+	};
+
 	enum class VolumeActivatorFlags
 	{
 		None		   = (0 << 0),
@@ -42,11 +50,8 @@ namespace TEN::Control::Volumes
 
 	struct VolumeEventSet
 	{
-		std::string			 Name		= {};
+		std::string	Name = {};
 		VolumeActivatorFlags Activators = VolumeActivatorFlags::None;
-
-		VolumeEvent OnEnter	 = {};
-		VolumeEvent OnLeave	 = {};
-		VolumeEvent OnInside = {};
+		std::array<VolumeEvent, int(VolumeEventType::Count)> Events = {};
 	};
 };

--- a/TombEngine/Game/savegame.cpp
+++ b/TombEngine/Game/savegame.cpp
@@ -805,9 +805,9 @@ bool SaveGame::Save(int slot)
 	{
 		Save::EventSetCallCountersBuilder serializedEventSetCallCounter{ fbb };
 
-		serializedEventSetCallCounter.add_on_enter(set.OnEnter.CallCounter);
-		serializedEventSetCallCounter.add_on_inside(set.OnInside.CallCounter);
-		serializedEventSetCallCounter.add_on_leave(set.OnLeave.CallCounter);
+		serializedEventSetCallCounter.add_on_enter(set.Events[(int)VolumeEventType::Enter].CallCounter);
+		serializedEventSetCallCounter.add_on_inside(set.Events[(int)VolumeEventType::Inside].CallCounter);
+		serializedEventSetCallCounter.add_on_leave(set.Events[(int)VolumeEventType::Leave].CallCounter);
 
 		auto serializedEventSetCallCounterOffset = serializedEventSetCallCounter.Finish();
 		serializedEventSetCallCounters.push_back(serializedEventSetCallCounterOffset);
@@ -1868,9 +1868,9 @@ bool SaveGame::Load(int slot)
 		{
 			auto cc_saved = s->call_counters()->Get(i);
 
-			g_Level.EventSets[i].OnEnter.CallCounter = cc_saved->on_enter();
-			g_Level.EventSets[i].OnInside.CallCounter = cc_saved->on_inside();
-			g_Level.EventSets[i].OnLeave.CallCounter = cc_saved->on_leave();
+			g_Level.EventSets[i].Events[(int)VolumeEventType::Enter].CallCounter = cc_saved->on_enter();
+			g_Level.EventSets[i].Events[(int)VolumeEventType::Inside].CallCounter = cc_saved->on_inside();
+			g_Level.EventSets[i].Events[(int)VolumeEventType::Leave].CallCounter = cc_saved->on_leave();
 		}
 	}
 

--- a/TombEngine/Scripting/Internal/ReservedScriptNames.h
+++ b/TombEngine/Scripting/Internal/ReservedScriptNames.h
@@ -51,6 +51,11 @@ static constexpr char ScriptReserved_PostLoad[]			= "POSTLOAD";
 static constexpr char ScriptReserved_PreControlPhase[]	= "PRECONTROLPHASE";
 static constexpr char ScriptReserved_PostControlPhase[] = "POSTCONTROLPHASE";
 
+// Event types
+static constexpr char ScriptReserved_OnEnter[]	= "ENTER";
+static constexpr char ScriptReserved_OnInside[] = "INSIDE";
+static constexpr char ScriptReserved_OnLeave[]	= "LEAVE";
+
 // Member functions
 static constexpr char ScriptReserved_New[]					= "New";
 static constexpr char ScriptReserved_Init[]					= "Init";
@@ -230,6 +235,7 @@ static constexpr char ScriptReserved_HasLineOfSight[]				= "HasLineOfSight";
 
 static constexpr char ScriptReserved_AddCallback[]					= "AddCallback";
 static constexpr char ScriptReserved_RemoveCallback[]				= "RemoveCallback";
+static constexpr char ScriptReserved_HandleEvent[]					= "HandleEvent";
 
 static constexpr char ScriptReserved_EmitParticle[]					= "EmitParticle";
 static constexpr char ScriptReserved_EmitLightningArc[]				= "EmitLightningArc";
@@ -280,6 +286,7 @@ static constexpr char ScriptReserved_RoomReverb[]				= "RoomReverb";
 static constexpr char ScriptReserved_DisplayStringOption[]		= "DisplayStringOption";
 static constexpr char ScriptReserved_CallbackPoint[]			= "CallbackPoint";
 static constexpr char ScriptReserved_EndReason[]				= "EndReason";
+static constexpr char ScriptReserved_EventType[]				= "EventType";
 
 static constexpr char ScriptReserved_LevelVars[]	= "LevelVars";
 static constexpr char ScriptReserved_GameVars[]		= "GameVars";

--- a/TombEngine/Scripting/Internal/TEN/Logic/LogicHandler.cpp
+++ b/TombEngine/Scripting/Internal/TEN/Logic/LogicHandler.cpp
@@ -277,20 +277,11 @@ void LogicHandler::RemoveCallback(CallbackPoint point, const LevelFunc& levelFun
 @tparam type EventType Event to execute.
 @tparam activator Moveable Optional activator. If not provided, player object will be automatically provided as activator.
 */
-void LogicHandler::HandleEvent(const std::string& name, VolumeEventType type, TypeOrNil<Moveable>& activator)
+void LogicHandler::HandleEvent(const std::string& name, VolumeEventType type, sol::optional<Moveable&> activator)
 {
-	bool result = false;
-
-	if (std::holds_alternative<Moveable>(activator))
-	{
-		result = TEN::Control::Volumes::HandleEvent(name, type, std::get<Moveable>(activator).GetIndex());
-	}
-	else
-	{
-		result = TEN::Control::Volumes::HandleEvent(name, type, nullptr);
-	}
-
-	if (!result)
+	bool success = TEN::Control::Volumes::HandleEvent(name, type, activator.has_value() ? 
+					(VolumeActivator)activator.value().GetIndex() : nullptr);
+	if (!success)
 	{
 		TENLog("Error: event " + name + " could not be executed. Check if event with such name exists in project.",
 			   LogLevel::Error, LogConfig::All, false);

--- a/TombEngine/Scripting/Internal/TEN/Logic/LogicHandler.cpp
+++ b/TombEngine/Scripting/Internal/TEN/Logic/LogicHandler.cpp
@@ -3,18 +3,18 @@
 
 #include <filesystem>
 
-#include "Game/savegame.h"
 #include "Game/control/volume.h"
 #include "Game/effects/Electricity.h"
+#include "Game/savegame.h"
 #include "Scripting/Internal/ReservedScriptNames.h"
 #include "Scripting/Internal/ScriptAssert.h"
 #include "Scripting/Internal/ScriptUtil.h"
-#include "Scripting/Internal/TEN/Objects/Moveable/MoveableObject.h"
-#include "Scripting/Internal/TEN/Vec2/Vec2.h"
-#include "Scripting/Internal/TEN/Vec3/Vec3.h"
-#include "Scripting/Internal/TEN/Rotation/Rotation.h"
 #include "Scripting/Internal/TEN/Color/Color.h"
 #include "Scripting/Internal/TEN/Logic/LevelFunc.h"
+#include "Scripting/Internal/TEN/Objects/Moveable/MoveableObject.h"
+#include "Scripting/Internal/TEN/Rotation/Rotation.h"
+#include "Scripting/Internal/TEN/Vec2/Vec2.h"
+#include "Scripting/Internal/TEN/Vec3/Vec3.h"
 
 using namespace TEN::Effects::Electricity;
 
@@ -38,7 +38,7 @@ enum class CallbackPoint
 	PostEnd
 };
 
-static const std::unordered_map<std::string, CallbackPoint> kCallbackPoints
+static const std::unordered_map<std::string, CallbackPoint> CALLBACK_POINTS
 {
 	{ ScriptReserved_PreStart, CallbackPoint::PreStart },
 	{ ScriptReserved_PostStart, CallbackPoint::PostStart },
@@ -52,7 +52,7 @@ static const std::unordered_map<std::string, CallbackPoint> kCallbackPoints
 	{ ScriptReserved_PostEnd, CallbackPoint::PostEnd }
 };
 
-static const std::unordered_map<std::string, VolumeEventType> kEventTypes
+static const std::unordered_map<std::string, VolumeEventType> EVENT_TYPES
 {
 	{ ScriptReserved_OnEnter, VolumeEventType::Enter },
 	{ ScriptReserved_OnInside, VolumeEventType::Inside },
@@ -68,7 +68,7 @@ enum class LevelEndReason
 	Other
 };
 
-static const std::unordered_map<std::string, LevelEndReason> kLevelEndReasons
+static const std::unordered_map<std::string, LevelEndReason> LEVEL_END_REASONS
 {
 	{ ScriptReserved_EndReasonLevelComplete, LevelEndReason::LevelComplete },
 	{ ScriptReserved_EndReasonLoadGame, LevelEndReason::LoadGame },
@@ -164,9 +164,9 @@ LogicHandler::LogicHandler(sol::state* lua, sol::table & parent) : m_handler{ lu
 	tableLogic.set_function(ScriptReserved_RemoveCallback, &LogicHandler::RemoveCallback, this);
 	tableLogic.set_function(ScriptReserved_HandleEvent, &LogicHandler::HandleEvent, this);
 
-	m_handler.MakeReadOnlyTable(tableLogic, ScriptReserved_EndReason, kLevelEndReasons);
-	m_handler.MakeReadOnlyTable(tableLogic, ScriptReserved_CallbackPoint, kCallbackPoints);
-	m_handler.MakeReadOnlyTable(tableLogic, ScriptReserved_EventType, kEventTypes);
+	m_handler.MakeReadOnlyTable(tableLogic, ScriptReserved_EndReason, LEVEL_END_REASONS);
+	m_handler.MakeReadOnlyTable(tableLogic, ScriptReserved_CallbackPoint, CALLBACK_POINTS);
+	m_handler.MakeReadOnlyTable(tableLogic, ScriptReserved_EventType, EVENT_TYPES);
 
 	m_callbacks.insert(std::make_pair(CallbackPoint::PreStart, &m_callbacksPreStart));
 	m_callbacks.insert(std::make_pair(CallbackPoint::PostStart, &m_callbacksPostStart));
@@ -275,7 +275,7 @@ void LogicHandler::RemoveCallback(CallbackPoint point, const LevelFunc& levelFun
 @function HandleEvent
 @tparam name string Name of the event set to find.
 @tparam type EventType Event to execute.
-@tparam activator Moveable Optional activator. If not provided, player object will be automatically provided as activator.
+@tparam activator Moveable Optional activator. Default is the player object.
 */
 void LogicHandler::HandleEvent(const std::string& name, VolumeEventType type, sol::optional<Moveable&> activator)
 {

--- a/TombEngine/Scripting/Internal/TEN/Logic/LogicHandler.h
+++ b/TombEngine/Scripting/Internal/TEN/Logic/LogicHandler.h
@@ -4,6 +4,8 @@
 #include "Game/items.h"
 #include "Scripting/Include/ScriptInterfaceGame.h"
 #include "Scripting/Internal/LuaHandler.h"
+#include "Scripting/Internal/ScriptUtil.h"
+#include "Scripting/Internal/TEN/Objects/Moveable/MoveableObject.h"
 
 enum class CallbackPoint;
 class LevelFunc;
@@ -121,6 +123,7 @@ public:
 
 	void AddCallback(CallbackPoint point, const LevelFunc& levelFunc);
 	void RemoveCallback(CallbackPoint point, const LevelFunc& levelFunc);
+	void HandleEvent(const std::string& name, VolumeEventType type, TypeOrNil<Moveable>& activator);
 
 	void ResetScripts(bool clearGameVars) override;
 	void ShortenTENCalls() override;

--- a/TombEngine/Scripting/Internal/TEN/Logic/LogicHandler.h
+++ b/TombEngine/Scripting/Internal/TEN/Logic/LogicHandler.h
@@ -123,7 +123,7 @@ public:
 
 	void AddCallback(CallbackPoint point, const LevelFunc& levelFunc);
 	void RemoveCallback(CallbackPoint point, const LevelFunc& levelFunc);
-	void HandleEvent(const std::string& name, VolumeEventType type, TypeOrNil<Moveable>& activator);
+	void HandleEvent(const std::string& name, VolumeEventType type, sol::optional<Moveable&> activator);
 
 	void ResetScripts(bool clearGameVars) override;
 	void ShortenTENCalls() override;

--- a/TombEngine/Specific/level.cpp
+++ b/TombEngine/Specific/level.cpp
@@ -1001,9 +1001,9 @@ void LoadEventSets()
 		eventSet.Name = ReadString();
 		eventSet.Activators = (VolumeActivatorFlags)ReadInt32();
 
-		LoadEvent(eventSet.OnEnter);
-		LoadEvent(eventSet.OnInside);
-		LoadEvent(eventSet.OnLeave);
+		LoadEvent(eventSet.Events[(int)VolumeEventType::Enter]);
+		LoadEvent(eventSet.Events[(int)VolumeEventType::Inside]);
+		LoadEvent(eventSet.Events[(int)VolumeEventType::Leave]);
 
 		g_Level.EventSets.push_back(eventSet);
 	}

--- a/TombEngine/Specific/level.cpp
+++ b/TombEngine/Specific/level.cpp
@@ -1001,9 +1001,8 @@ void LoadEventSets()
 		eventSet.Name = ReadString();
 		eventSet.Activators = (VolumeActivatorFlags)ReadInt32();
 
-		LoadEvent(eventSet.Events[(int)VolumeEventType::Enter]);
-		LoadEvent(eventSet.Events[(int)VolumeEventType::Inside]);
-		LoadEvent(eventSet.Events[(int)VolumeEventType::Leave]);
+		for (int e = 0; e < (int)VolumeEventType::Count; e++)
+			LoadEvent(eventSet.Events[e]);
 
 		g_Level.EventSets.push_back(eventSet);
 	}

--- a/TombEngine/Specific/level.cpp
+++ b/TombEngine/Specific/level.cpp
@@ -1001,8 +1001,8 @@ void LoadEventSets()
 		eventSet.Name = ReadString();
 		eventSet.Activators = (VolumeActivatorFlags)ReadInt32();
 
-		for (int e = 0; e < (int)VolumeEventType::Count; e++)
-			LoadEvent(eventSet.Events[e]);
+		for (int eventType = 0; eventType < (int)VolumeEventType::Count; eventType++)
+			LoadEvent(eventSet.Events[eventType]);
 
 		g_Level.EventSets.push_back(eventSet);
 	}


### PR DESCRIPTION
This PR introduces a way to access node events compiled into level file from lua API. It is done by searching whole node event array by the name and finding a node event with same name. Eventually, this PR also allows to access node events from another node events, therefore allowing to do nested calls and for loops via nodes.

To test:

 - Calling node events from lua by name
 - Check if existing volumes work correctly (because the way event is accessed was changed too)