### PR TITLE
Delete SetTitleScreenImagePath references

### DIFF
--- a/Scripts/Gameflow.lua
+++ b/Scripts/Gameflow.lua
@@ -6,11 +6,6 @@
 
 Flow.SetIntroImagePath("Screens\\main.jpg")
 
--- This image should be used for static title screen background (as in TR1-TR3).
--- For now it is not implemented.
-
-Flow.SetTitleScreenImagePath("Screens\\main.jpg")
-
 -- Set overall amount of secrets in game.
 -- If set to 0, secrets won't be displayed in statistics.
 

--- a/TombEngine/Scripting/Internal/ReservedScriptNames.h
+++ b/TombEngine/Scripting/Internal/ReservedScriptNames.h
@@ -190,7 +190,6 @@ static constexpr char ScriptReserved_AddLevel[]					= "AddLevel";
 static constexpr char ScriptReserved_GetLevel[]					= "GetLevel";
 static constexpr char ScriptReserved_GetCurrentLevel[]			= "GetCurrentLevel";
 static constexpr char ScriptReserved_SetIntroImagePath[]		= "SetIntroImagePath";
-static constexpr char ScriptReserved_SetTitleScreenImagePath[]	= "SetTitleScreenImagePath";
 static constexpr char ScriptReserved_SetFarView[]				= "SetFarView";
 static constexpr char ScriptReserved_SetSettings[]				= "SetSettings";
 static constexpr char ScriptReserved_SetAnimations[]			= "SetAnimations";

--- a/TombEngine/Scripting/Internal/TEN/Flow/FlowHandler.cpp
+++ b/TombEngine/Scripting/Internal/TEN/Flow/FlowHandler.cpp
@@ -59,14 +59,6 @@ Must be a .jpg or .png image.
 */
 	tableFlow.set_function(ScriptReserved_SetIntroImagePath, &FlowHandler::SetIntroImagePath, this);
 
-/*** Image to show in the background of the title screen.
-Must be a .jpg or .png image.
-__(not yet implemented)__
-@function SetTitleScreenImagePath
-@tparam string path the path to the image, relative to the TombEngine exe
-*/
-	tableFlow.set_function(ScriptReserved_SetTitleScreenImagePath, &FlowHandler::SetTitleScreenImagePath, this);
-
 /*** Enable or disable Lara drawing in title flyby.
 Must be true or false
 @function EnableLaraInTitle
@@ -313,11 +305,6 @@ void FlowHandler::AddLevel(Level const& level)
 void FlowHandler::SetIntroImagePath(const std::string& path)
 {
 	IntroImagePath = path;
-}
-
-void FlowHandler::SetTitleScreenImagePath(const std::string& path)
-{
-	TitleScreenImagePath = path;
 }
 
 void FlowHandler::SetTotalSecretCount(int secretsNumber)


### PR DESCRIPTION
Aim of the pr is to napalm SetTitleScreenImagePath  references throughout the code because:

A) It won't be implemented anytime soon
B) you draw a 1920x1080 (up to 2048x2048) sprite which can fill the whole screen space area for title
   - Also means users won't be doing the usual "delete files" procedures as they do with exes etc, providing better security.