### PR TITLE
Room fixes

### DIFF
--- a/TombEngine/Game/Lara/lara.cpp
+++ b/TombEngine/Game/Lara/lara.cpp
@@ -45,6 +45,9 @@ void LaraControl(ItemInfo* item, CollisionInfo* coll)
 {
 	auto& player = GetLaraInfo(*item);
 
+	for (int r : g_Level.Rooms[item->RoomNumber].neighbors)
+		g_Renderer.PrintDebugMessage("%d", r);
+
 	// Alert nearby creatures.
 	if (player.Control.Weapon.HasFired)
 	{

--- a/TombEngine/Game/Lara/lara.cpp
+++ b/TombEngine/Game/Lara/lara.cpp
@@ -45,9 +45,6 @@ void LaraControl(ItemInfo* item, CollisionInfo* coll)
 {
 	auto& player = GetLaraInfo(*item);
 
-	for (int r : g_Level.Rooms[item->RoomNumber].neighbors)
-		g_Renderer.PrintDebugMessage("%d", r);
-
 	// Alert nearby creatures.
 	if (player.Control.Weapon.HasFired)
 	{

--- a/TombEngine/Game/room.cpp
+++ b/TombEngine/Game/room.cpp
@@ -6,10 +6,13 @@
 #include "Game/control/lot.h"
 #include "Game/control/volume.h"
 #include "Game/items.h"
+#include "Objects/game_object_ids.h"
 #include "Renderer/Renderer11.h"
+#include "Specific/trutils.h"
 
 using namespace TEN::Collision::Floordata;
 using namespace TEN::Renderer;
+using namespace TEN::Utils;
 
 bool FlipStatus = false;
 bool FlipStats[MAX_FLIPMAP];
@@ -17,106 +20,109 @@ int  FlipMap[MAX_FLIPMAP];
 
 std::vector<short> OutsideRoomTable[OUTSIDE_SIZE][OUTSIDE_SIZE];
 
-bool ROOM_INFO::Active()
+bool ROOM_INFO::Active() const
 {
 	if (flipNumber == NO_ROOM)
 		return true;
 
-	// Because engine swaps whole room memory block but substitutes flippedRoom,
-	// we have to check both original index and flippedRoom equality, as well as NO_ROOM
-	// in case we are checking non-flipped rooms.
-
+	// Since engine swaps whole room memory block but substitutes flippedRoom,
+	// must check both original room number and flippedRoom equality,
+	// as well as NO_ROOM if checking non-flipped rooms.
 	return (!FlipStats[flipNumber] && flippedRoom != index && flippedRoom != NO_ROOM) ||
 		   ( FlipStats[flipNumber] && flippedRoom == index);
-		   
 }
 
-void DoFlipMap(short group)
+void DoFlipMap(int group)
 {
-	for (int i = 0; i < g_Level.Rooms.size(); i++)
+	// Run through rooms.
+	for (int roomNumber = 0; roomNumber < g_Level.Rooms.size(); roomNumber++)
 	{
-		auto* room = &g_Level.Rooms[i];
+		auto& room = g_Level.Rooms[roomNumber];
 
-		if (room->flippedRoom >= 0 && room->flipNumber == group)
+		// Handle flipmap.
+		if (room.flippedRoom >= 0 && room.flipNumber == group)
 		{
-			RemoveRoomFlipItems(room);
+			RemoveRoomFlipItems(&room);
 
-			auto* flipped = &g_Level.Rooms[room->flippedRoom];
+			auto& flippedRoom = g_Level.Rooms[room.flippedRoom];
 
-			auto temp = *room;
-			*room = *flipped;
-			*flipped = temp;
+			std::swap(room, flippedRoom);
 
-			room->flippedRoom = flipped->flippedRoom;
-			flipped->flippedRoom = NO_ROOM;
+			room.flippedRoom = flippedRoom.flippedRoom;
+			flippedRoom.flippedRoom = NO_ROOM;
 
-			room->itemNumber = flipped->itemNumber;
-			room->fxNumber = flipped->fxNumber;
+			room.itemNumber = flippedRoom.itemNumber;
+			room.fxNumber = flippedRoom.fxNumber;
 
-			AddRoomFlipItems(room);
+			AddRoomFlipItems(&room);
 
-			g_Renderer.FlipRooms(i, room->flippedRoom);
+			g_Renderer.FlipRooms(roomNumber, room.flippedRoom);
 
-			for (auto& fd : room->floor)
-				fd.Room = i;
+			for (auto& sector : room.floor)
+				sector.Room = roomNumber;
 
-			for (auto& fd : flipped->floor)
-				fd.Room = room->flippedRoom;
+			for (auto& sector : flippedRoom.floor)
+				sector.Room = room.flippedRoom;
 		}
 	}
 
-	FlipStatus = FlipStats[group] = !FlipStats[group];
+	FlipStatus =
+	FlipStats[group] = !FlipStats[group];
 
-	for (auto& currentCreature : ActiveCreatures)
-		currentCreature->LOT.TargetBox = NO_BOX;
+	for (auto& creature : ActiveCreatures)
+		creature->LOT.TargetBox = NO_BOX;
 }
 
 void AddRoomFlipItems(ROOM_INFO* room)
 {
-	for (short linkNumber = room->itemNumber; linkNumber != NO_ITEM; linkNumber = g_Level.Items[linkNumber].NextItem)
+	// Run through linked items.
+	for (int itemNumber = room->itemNumber; itemNumber != NO_ITEM; itemNumber = g_Level.Items[itemNumber].NextItem)
 	{
-		const auto& item = g_Level.Items[linkNumber];
+		const auto& item = g_Level.Items[itemNumber];
+		const auto& object = Objects[item.ObjectNumber];
 
-		if (Objects[item.ObjectNumber].GetFloorHeight != nullptr)
+		// Item is bridge; update relevant sectors.
+		if (object.GetFloorHeight != nullptr)
 			UpdateBridgeItem(item);
 	}
 }
 
 void RemoveRoomFlipItems(ROOM_INFO* room)
 {
-	for (short linkNumber = room->itemNumber; linkNumber != NO_ITEM; linkNumber = g_Level.Items[linkNumber].NextItem)
+	// Run through linked items.
+	for (int itemNumber = room->itemNumber; itemNumber != NO_ITEM; itemNumber = g_Level.Items[itemNumber].NextItem)
 	{
-		auto* item = &g_Level.Items[linkNumber];
+		const auto& item = g_Level.Items[itemNumber];
+		const auto& object = Objects[item.ObjectNumber];
 
-		if (item->Flags & ONESHOT &&
-			Objects[item->ObjectNumber].intelligent &&
-			item->HitPoints <= 0 &&
-			item->HitPoints != NOT_TARGETABLE)
+		if (item.Flags & ONESHOT &&
+			item.HitPoints != NOT_TARGETABLE &&
+			item.HitPoints <= 0 &&
+			object.intelligent)
 		{
-			KillItem(linkNumber);
+			KillItem(itemNumber);
 		}
 
-		if (Objects[item->ObjectNumber].GetFloorHeight != nullptr)
-			UpdateBridgeItem(*item, true);
+		// Item is bridge; update relevant sectors.
+		if (Objects[item.ObjectNumber].GetFloorHeight != nullptr)
+			UpdateBridgeItem(item, true);
 	}
 }
 
-bool IsObjectInRoom(short roomNumber, short objectNumber)
+bool IsObjectInRoom(int roomNumber, GAME_OBJECT_ID objectID)
 {
-	short itemNumber = g_Level.Rooms[roomNumber].itemNumber;
-
+	int itemNumber = g_Level.Rooms[roomNumber].itemNumber;
 	if (itemNumber == NO_ITEM)
 		return false;
 
 	while (true)
 	{
-		auto* item = &g_Level.Items[itemNumber];
+		const auto& item = g_Level.Items[itemNumber];
 
-		if (item->ObjectNumber == objectNumber)
+		if (item.ObjectNumber == objectID)
 			break;
 
-		itemNumber = item->NextItem;
-
+		itemNumber = item.NextItem;
 		if (itemNumber == NO_ITEM)
 			return false;
 	}
@@ -137,25 +143,25 @@ int IsRoomOutside(int x, int y, int z)
 
 	for (int i = 0; i < OutsideRoomTable[xTable][zTable].size(); i++)
 	{
-		short roomNumber = OutsideRoomTable[xTable][zTable][i];
-		auto* room = &g_Level.Rooms[roomNumber];
+		int roomNumber = OutsideRoomTable[xTable][zTable][i];
+		const auto& room = g_Level.Rooms[roomNumber];
 
-		if ((y > room->maxceiling && y < room->minfloor) &&
-			(z > (room->z + BLOCK(1)) && z < (room->z + (room->zSize - 1) * BLOCK(1))) &&
-			(x > (room->x + BLOCK(1)) && x < (room->x + (room->xSize - 1) * BLOCK(1))))
+		if ((x > (room.x + BLOCK(1)) && x < (room.x + (room.xSize - 1) * BLOCK(1))) &&
+			(y > room.maxceiling && y < room.minfloor) &&
+			(z > (room.z + BLOCK(1)) && z < (room.z + (room.zSize - 1) * BLOCK(1))))
 		{
-			auto probe = GetCollision(x, y, z, roomNumber);
+			auto pointColl = GetCollision(x, y, z, roomNumber);
 
-			if (probe.Position.Floor == NO_HEIGHT || y > probe.Position.Floor)
+			if (pointColl.Position.Floor == NO_HEIGHT || y > pointColl.Position.Floor)
 				return NO_ROOM;
 
-			if (y < probe.Position.Ceiling)
+			if (y < pointColl.Position.Ceiling)
 				return NO_ROOM;
 
-			if (TestEnvironmentFlags(ENV_FLAG_WATER, room->flags) ||
-				TestEnvironmentFlags(ENV_FLAG_WIND, room->flags))
+			if (TestEnvironmentFlags(ENV_FLAG_WATER, room.flags) ||
+				TestEnvironmentFlags(ENV_FLAG_WIND, room.flags))
 			{
-				return probe.RoomNumber;
+				return pointColl.RoomNumber;
 			}
 
 			return NO_ROOM;
@@ -165,37 +171,42 @@ int IsRoomOutside(int x, int y, int z)
 	return NO_ROOM;
 }
 
+// TODO: Can use floordata's GetRoomGridCoord()?
 FloorInfo* GetSector(ROOM_INFO* room, int x, int z) 
 {
 	int sectorX = std::clamp(x / BLOCK(1), 0, room->xSize - 1);
 	int sectorZ = std::clamp(z / BLOCK(1), 0, room->zSize - 1);
 
-	int index = sectorZ + sectorX * room->zSize;
-	if (index > room->floor.size()) 
+	int sectorID = sectorZ + (sectorX * room->zSize);
+	if (sectorID > room->floor.size()) 
 		return nullptr;
 	
-	return &room->floor[index];
+	return &room->floor[sectorID];
 }
 
-GameBoundingBox& GetBoundsAccurate(const MESH_INFO& mesh, bool visibility)
+GameBoundingBox& GetBoundsAccurate(const MESH_INFO& mesh, bool getVisibilityBox)
 {
-	static GameBoundingBox result;
+	static auto bounds = GameBoundingBox();
 
-	if (visibility)
-		result = StaticObjects[mesh.staticNumber].visibilityBox * mesh.scale;
+	if (getVisibilityBox)
+	{
+		bounds = StaticObjects[mesh.staticNumber].visibilityBox * mesh.scale;
+	}
 	else
-		result = StaticObjects[mesh.staticNumber].collisionBox * mesh.scale;
+	{
+		bounds = StaticObjects[mesh.staticNumber].collisionBox * mesh.scale;
+	}
 
-	return result;
+	return bounds;
 }
 
-bool IsPointInRoom(Vector3i pos, int roomNumber)
+bool IsPointInRoom(const Vector3i& pos, int roomNumber)
 {
-	auto* room = &g_Level.Rooms[roomNumber];
+	const auto& room = g_Level.Rooms[roomNumber];
 
-	if (pos.z >= (room->z + BLOCK(1)) && pos.z <= (room->z + ((room->zSize - 1) * BLOCK(1))) &&
-		pos.x >= (room->x + BLOCK(1)) && pos.x <= (room->x + ((room->xSize - 1) * BLOCK(1))) &&
-		pos.y <= room->minfloor && pos.y > room->maxceiling) // Up is -Y, hence Y should be "less" than floor.
+	if (pos.z >= (room.z + BLOCK(1)) && pos.z <= (room.z + ((room.zSize - 1) * BLOCK(1))) &&
+		pos.x >= (room.x + BLOCK(1)) && pos.x <= (room.x + ((room.xSize - 1) * BLOCK(1))) &&
+		pos.y <= room.minfloor && pos.y > room.maxceiling) // NOTE: Up is -Y, hence Y should be "less" than floor.
 	{
 		return true;
 	}
@@ -203,91 +214,101 @@ bool IsPointInRoom(Vector3i pos, int roomNumber)
 	return false;
 }
 
-int FindRoomNumber(Vector3i position, int startRoom)
+int FindRoomNumber(const Vector3i& pos, int startRoomNumber)
 {
-	if (startRoom != NO_ROOM && startRoom < g_Level.Rooms.size())
+	if (startRoomNumber != NO_ROOM && startRoomNumber < g_Level.Rooms.size())
 	{
-		auto& room = g_Level.Rooms[startRoom];
-		for (auto n : room.neighbors)
+		const auto& room = g_Level.Rooms[startRoomNumber];
+		for (int neighborRoomNumber : room.neighbors)
 		{
-			if (n != startRoom && IsPointInRoom(position, n) && g_Level.Rooms[n].Active())
-				return n;
+			const auto& neighborRoom = g_Level.Rooms[neighborRoomNumber];
+			if (neighborRoomNumber != startRoomNumber && neighborRoom.Active() &&
+				IsPointInRoom(pos, neighborRoomNumber))
+			{
+				return neighborRoomNumber;
+			}
 		}
 	}
 
-	for (int i = 0; i < g_Level.Rooms.size(); i++)
-		if (IsPointInRoom(position, i) && g_Level.Rooms[i].Active())
-			return i;
+	for (int roomNumber = 0; roomNumber < g_Level.Rooms.size(); roomNumber++)
+	{
+		if (IsPointInRoom(pos, roomNumber) && g_Level.Rooms[roomNumber].Active())
+			return roomNumber;
+	}
 
-	return (startRoom != NO_ROOM) ? startRoom : 0;
+	return (startRoomNumber != NO_ROOM) ? startRoomNumber : 0;
 }
 
 Vector3i GetRoomCenter(int roomNumber)
 {
-	auto* room = &g_Level.Rooms[roomNumber];
+	const auto& room = g_Level.Rooms[roomNumber];
 
-	auto halfLength = BLOCK(room->xSize) / 2;
-	auto halfDepth = BLOCK(room->zSize) / 2;
-	auto halfHeight = (room->maxceiling - room->minfloor) / 2;
+	int halfLength = BLOCK(room.xSize) / 2;
+	int halfDepth = BLOCK(room.zSize) / 2;
+	int halfHeight = (room.maxceiling - room.minfloor) / 2;
 
-	auto center = Vector3i(
-		room->x + halfLength,
-		room->minfloor + halfHeight,
-		room->z + halfDepth);
-	return center;
+	// Calculate and return center.
+	return Vector3i(
+		room.x + halfLength,
+		room.minfloor + halfHeight,
+		room.z + halfDepth);
 }
 
-std::set<int> GetRoomList(int roomNumber)
+static std::set<int> GetNeighborRoomNumbers(int roomNumber, unsigned int searchDepth, std::set<int>& visitedRoomNumbers = std::set<int>{})
 {
-	auto roomNumberList = std::set<int>{};
-
+	// No rooms exist; return empty set.
 	if (g_Level.Rooms.size() <= roomNumber)
-		return roomNumberList;
+		return {};
 
-	roomNumberList.insert(roomNumber);
+	// Collect current room number as neighbor of itself.
+	auto neighborRoomNumbers = std::set<int>{};
+	visitedRoomNumbers.insert(roomNumber);
 
-	auto* roomPtr = &g_Level.Rooms[roomNumber];
-	for (size_t i = 0; i < roomPtr->doors.size(); i++)
-		roomNumberList.insert(roomPtr->doors[i].room);
+	// Search depth limit reached; return empty set.
+	if (searchDepth == 0)
+		return neighborRoomNumbers;
 
-	for (int roomNumber : roomNumberList)
+	// Recursively collect neighbors of current neighbor.
+	const auto& room = g_Level.Rooms[roomNumber];
+	for (int doorID = 0; doorID < room.doors.size(); doorID++) 
 	{
-		roomPtr = &g_Level.Rooms[roomNumber];
-		for (size_t j = 0; j < roomPtr->doors.size(); j++)
-			roomNumberList.insert(roomPtr->doors[j].room);
+		int neighborRoomNumber = room.doors[doorID].room;
+		neighborRoomNumbers.insert(neighborRoomNumber);
+
+		auto recNeighborRoomNumbers = GetNeighborRoomNumbers(neighborRoomNumber, searchDepth - 1, visitedRoomNumbers);
+		neighborRoomNumbers.insert(recNeighborRoomNumbers.begin(), recNeighborRoomNumbers.end());
 	}
 
-	return roomNumberList;
+	return neighborRoomNumbers;
 }
 
 void InitializeNeighborRoomList()
 {
-	for (int i = 0; i < g_Level.Rooms.size(); i++)
-	{
-		auto& room = g_Level.Rooms[i];
+	constexpr auto NEIGHBOR_ROOM_SEARCH_DEPTH = 2;
 
+	for (int roomNumber = 0; roomNumber < g_Level.Rooms.size(); roomNumber++)
+	{
+		auto& room = g_Level.Rooms[roomNumber];
+		
 		room.neighbors.clear();
 
-		auto roomNumberList = GetRoomList(i);
-		for (int roomNumber : roomNumberList)
-			room.neighbors.push_back(roomNumber);
+		auto neighborRoomNumbers = GetNeighborRoomNumbers(roomNumber, NEIGHBOR_ROOM_SEARCH_DEPTH);
+		for (int neighborRoomNumber : neighborRoomNumbers)
+			room.neighbors.push_back(neighborRoomNumber);
 	}
 
 	// Add flipped variations of itself.
-	for (int i = 0; i < g_Level.Rooms.size(); i++)
+	for (int roomNumber = 0; roomNumber < g_Level.Rooms.size(); roomNumber++)
 	{
-		auto& room = g_Level.Rooms[i];
+		auto& room = g_Level.Rooms[roomNumber];
 		if (room.flippedRoom == NO_ROOM)
 			continue;
 
-		auto it = std::find(room.neighbors.begin(), room.neighbors.end(), room.flippedRoom);
-		if (it == room.neighbors.end())
+		if (!Contains(room.neighbors, room.flippedRoom))
 			room.neighbors.push_back(room.flippedRoom);
 
 		auto& flippedRoom = g_Level.Rooms[room.flippedRoom];
-		auto it2 = std::find(flippedRoom.neighbors.begin(), flippedRoom.neighbors.end(), i);
-
-		if (it2 == flippedRoom.neighbors.end())
-			flippedRoom.neighbors.push_back(i);
+		if (!Contains(flippedRoom.neighbors, roomNumber))
+			flippedRoom.neighbors.push_back(roomNumber);
 	}
 }

--- a/TombEngine/Game/room.cpp
+++ b/TombEngine/Game/room.cpp
@@ -6,10 +6,12 @@
 #include "Game/control/lot.h"
 #include "Game/control/volume.h"
 #include "Game/items.h"
+#include "Math/Math.h"
 #include "Objects/game_object_ids.h"
 #include "Renderer/Renderer11.h"
 #include "Specific/trutils.h"
 
+using namespace TEN::Math;
 using namespace TEN::Collision::Floordata;
 using namespace TEN::Renderer;
 using namespace TEN::Utils;
@@ -204,9 +206,9 @@ bool IsPointInRoom(const Vector3i& pos, int roomNumber)
 {
 	const auto& room = g_Level.Rooms[roomNumber];
 
-	if (pos.z >= (room.z + BLOCK(1)) && pos.z <= (room.z + ((room.zSize - 1) * BLOCK(1))) &&
-		pos.x >= (room.x + BLOCK(1)) && pos.x <= (room.x + ((room.xSize - 1) * BLOCK(1))) &&
-		pos.y <= room.minfloor && pos.y > room.maxceiling) // NOTE: Up is -Y, hence Y should be "less" than floor.
+	if (pos.z >= (room.z + BLOCK(1)) && pos.z <= (room.z + BLOCK(room.zSize - 1)) &&
+		pos.y <= room.minfloor && pos.y > room.maxceiling &&
+		pos.x >= (room.x + BLOCK(1)) && pos.x <= (room.x + BLOCK(room.xSize - 1)))
 	{
 		return true;
 	}
@@ -256,14 +258,14 @@ Vector3i GetRoomCenter(int roomNumber)
 
 static std::vector<int> GetNeighborRoomNumbers(int roomNumber, unsigned int searchDepth, std::vector<int>& visitedRoomNumbers = std::vector<int>{})
 {
-	// No rooms exist; return empty set.
+	// No rooms exist; return empty vector.
 	if (g_Level.Rooms.size() <= roomNumber)
 		return {};
 
 	// Collect current room number as neighbor of itself.
 	visitedRoomNumbers.push_back(roomNumber);
 
-	// Search depth limit reached; return empty set.
+	// Search depth limit reached; return empty vector.
 	if (searchDepth == 0)
 		return {};
 

--- a/TombEngine/Game/room.cpp
+++ b/TombEngine/Game/room.cpp
@@ -294,8 +294,6 @@ void InitializeNeighborRoomList()
 	for (int roomNumber = 0; roomNumber < g_Level.Rooms.size(); roomNumber++)
 	{
 		auto& room = g_Level.Rooms[roomNumber];
-		
-		room.neighbors.clear();
 		room.neighbors = GetNeighborRoomNumbers(roomNumber, NEIGHBOR_ROOM_SEARCH_DEPTH);
 	}
 

--- a/TombEngine/Game/room.h
+++ b/TombEngine/Game/room.h
@@ -1,11 +1,13 @@
 #pragma once
-#include "framework.h"
-#include "Game/collision/floordata.h"
 #include "Math/Math.h"
-#include "Specific/newtypes.h"
+
+using namespace TEN::Math;
 
 enum GAME_OBJECT_ID : short;
 enum class ReverbType;
+class FloorInfo;
+class GameBoundingBox;
+struct BUCKET;
 struct TriggerVolume;
 
 constexpr auto MAX_FLIPMAP	= 256;

--- a/TombEngine/Game/room.h
+++ b/TombEngine/Game/room.h
@@ -4,6 +4,7 @@
 #include "Math/Math.h"
 #include "Specific/newtypes.h"
 
+enum GAME_OBJECT_ID : short;
 enum class ReverbType;
 struct TriggerVolume;
 
@@ -140,19 +141,18 @@ struct ROOM_INFO
 
 	std::vector<int> neighbors = {};
 
-	bool Active();
+	bool Active() const;
 };
 
-void DoFlipMap(short group);
+void DoFlipMap(int group);
 void AddRoomFlipItems(ROOM_INFO* room);
 void RemoveRoomFlipItems(ROOM_INFO* room);
-bool IsObjectInRoom(short roomNumber, short objectNumber);
-bool IsPointInRoom(Vector3i pos, int roomNumber);
-int FindRoomNumber(Vector3i pos, int startRoom = NO_ROOM);
+bool IsObjectInRoom(int roomNumber, GAME_OBJECT_ID objectID);
+bool IsPointInRoom(const Vector3i& pos, int roomNumber);
+int FindRoomNumber(const Vector3i& pos, int startRoomNumber = NO_ROOM);
 Vector3i GetRoomCenter(int roomNumber);
 int IsRoomOutside(int x, int y, int z);
-std::set<int> GetRoomList(int roomNumber);
 void InitializeNeighborRoomList();
 
-GameBoundingBox& GetBoundsAccurate(const MESH_INFO& mesh, bool visibility);
+GameBoundingBox& GetBoundsAccurate(const MESH_INFO& mesh, bool getVisibilityBox);
 FloorInfo* GetSector(ROOM_INFO* room, int x, int z);


### PR DESCRIPTION
- Fix room number neighbor getter wrongly returning neighbors beyond the appropriate search depth.
- Use `std::swap()` when flipping rooms instead of making temp copies.
- Add comments, streamline code.