### PR TITLE
keyholes: keep or loose key from inventory with ocb

### DIFF
--- a/TombEngine/Objects/Generic/puzzles_keys.cpp
+++ b/TombEngine/Objects/Generic/puzzles_keys.cpp
@@ -445,6 +445,7 @@ void KeyHoleCollision(short itemNumber, ItemInfo* laraItem, CollisionInfo* coll)
 	if (triggerIndexPtr == nullptr)
 		return;
 
+	int animation;
 	short triggerType = (*(triggerIndexPtr++) >> 8) & TRIGGER_BITS;
 
 	bool isActionReady = (IsHeld(In::Action) || g_Gui.GetInventoryItemChosen() != NO_ITEM);
@@ -483,14 +484,21 @@ void KeyHoleCollision(short itemNumber, ItemInfo* laraItem, CollisionInfo* coll)
 
 			if (MoveLaraPosition(KeyHolePosition, keyHoleItem, laraItem))
 			{
-				if (triggerType != TRIGGER_TYPES::SWITCH)
+				if (triggerType = TRIGGER_TYPES::SWITCH )
 				{
+					keyHoleItem->ItemFlags[1] = true;
+				}
+
+				if (keyHoleItem->TriggerFlags < 0)
+				{
+					animation = abs(keyHoleItem->TriggerFlags);
 					RemoveObjectFromInventory(GAME_OBJECT_ID(keyHoleItem->ObjectNumber - (ID_KEY_HOLE1 - ID_KEY_ITEM1)), 1);
 				}
 				else
 				{
-					keyHoleItem->ItemFlags[1] = true;
+					animation = keyHoleItem->TriggerFlags;
 				}
+
 
 				if (keyHoleItem->TriggerFlags == 0)
 				{
@@ -498,7 +506,7 @@ void KeyHoleCollision(short itemNumber, ItemInfo* laraItem, CollisionInfo* coll)
 				}
 				else
 				{
-					laraItem->Animation.AnimNumber = keyHoleItem->TriggerFlags;
+					laraItem->Animation.AnimNumber = animation;
 				}
 				
 				laraItem->Animation.ActiveState = LS_INSERT_KEY;


### PR DESCRIPTION
I have included a new system for Keyholes. Now you can have one shot keyholes with a key trigger and multiple use keyholes with a switch trigger. But if you put a negative animnumber in the ocb of the keyhole you will loose the key from inventory and if you insert a positive animnumber into the ocb Lara will keep the key in the inventory.

One time keyhole with a key trigger: 
positive OCB -> play anim number and keep key in inventory.
negative OCB -> play anim number and loose key from inventory.

multiple keyhole with switch trigger: 
positive OCB -> play anim number and keep key in inventory.
negative OCB -> play anim number and loose key from inventory.

both: 
OCB = 0 play anim number 131 (LA_USE_KEY) and keeps the key in inventory