### PR TITLE
Lara start position handling

### DIFF
--- a/Documentation/Changes.txt
+++ b/Documentation/Changes.txt
@@ -16,6 +16,7 @@ Version 1.3
 * Fix several issues with limited pistol ammo.
 * Fix Lara not being able to crawl if two-handed weapon is currently equipped.
 * Fix playback issues with audio tracks placed in subfolders.
+* Fix legacy trigger leveljumps ignoring provided level index.
 * Separate underwater wall and ceiling switch objects into two slots each.
 * Improve fly cheat collision.
 * Add global events.

--- a/Documentation/Changes.txt
+++ b/Documentation/Changes.txt
@@ -19,6 +19,7 @@ Version 1.3
 * Separate underwater wall and ceiling switch objects into two slots each.
 * Improve fly cheat collision.
 * Add global events.
+* Add previously missing Lara start position object functionality.
 * Add fast speed for fly cheat by holding Sprint input action.
 * Allow walking on slopes when wading in water (similar to quicksand).
 * Allow player to pull certain levers with both hands when holding a flare.

--- a/TombEngine/Game/Lara/lara_initialise.cpp
+++ b/TombEngine/Game/Lara/lara_initialise.cpp
@@ -171,7 +171,7 @@ void InitializeLaraStartPosition(ItemInfo* item)
 		if (it.ObjectNumber != GAME_OBJECT_ID::ID_LARA_START_POS)
 			continue;
 
-		if (it.TriggerFlags != RequiredStartPos)
+		if (!it.TriggerFlags || it.TriggerFlags != RequiredStartPos)
 			continue;
 
 		item->Pose = it.Pose;

--- a/TombEngine/Game/Lara/lara_initialise.cpp
+++ b/TombEngine/Game/Lara/lara_initialise.cpp
@@ -59,7 +59,7 @@ void InitializeLara(bool restore)
 
 	if (restore)
 	{
-		InitializeLaraLevelJump(LaraItem->Index, &lBackup);
+		InitializeLaraLevelJump(LaraItem, &lBackup);
 		LaraItem->HitPoints = lHitPoints;
 	}
 	else
@@ -71,6 +71,7 @@ void InitializeLara(bool restore)
 	InitializePlayerStateMachine();
 	InitializeLaraMeshes(LaraItem);
 	InitializeLaraAnims(LaraItem);
+	InitializeLaraStartPosition(LaraItem);
 
 	g_Hud.StatusBars.Initialize(*LaraItem);
 }
@@ -163,9 +164,26 @@ void InitializeLaraLoad(short itemNumber)
 	LaraItem = &g_Level.Items[itemNumber];
 }
 
-void InitializeLaraLevelJump(short itemNum, LaraInfo* lBackup)
+void InitializeLaraStartPosition(ItemInfo* item)
 {
-	auto* item = &g_Level.Items[itemNum];
+	for (auto& it : g_Level.Items)
+	{
+		if (it.ObjectNumber != GAME_OBJECT_ID::ID_LARA_START_POS)
+			continue;
+
+		if (it.TriggerFlags != RequiredStartPos)
+			continue;
+
+		item->Pose = it.Pose;
+		item->RoomNumber = it.RoomNumber;
+
+		TENLog("Player start position has been set according to object " + std::to_string(it.Index) + " with OCB " + std::to_string(it.TriggerFlags), LogLevel::Info);
+		break;
+	}
+}
+
+void InitializeLaraLevelJump(ItemInfo* item, LaraInfo* lBackup)
+{
 	auto* lara = GetLaraInfo(item);
 
 	// Restore inventory.

--- a/TombEngine/Game/Lara/lara_initialise.cpp
+++ b/TombEngine/Game/Lara/lara_initialise.cpp
@@ -177,7 +177,7 @@ void InitializeLaraStartPosition(ItemInfo* item)
 		item->Pose = it.Pose;
 		item->RoomNumber = it.RoomNumber;
 
-		TENLog("Player start position has been set according to object " + std::to_string(it.Index) + " with OCB " + std::to_string(it.TriggerFlags), LogLevel::Info);
+		TENLog("Player start position has been set according to start position object with index " + std::to_string(it.TriggerFlags), LogLevel::Info);
 		break;
 	}
 }

--- a/TombEngine/Game/Lara/lara_initialise.h
+++ b/TombEngine/Game/Lara/lara_initialise.h
@@ -3,8 +3,9 @@
 
 void BackupLara();
 void InitializeLara(bool restore);
+void InitializeLaraLoad(short itemNumber);
 void InitializeLaraMeshes(ItemInfo* item);
 void InitializeLaraAnims(ItemInfo* item);
-void InitializeLaraLoad(short itemNumber);
-void InitializeLaraLevelJump(short itemNum, LaraInfo* lBackup);
+void InitializeLaraStartPosition(ItemInfo* item);
+void InitializeLaraLevelJump(ItemInfo* item, LaraInfo* lBackup);
 void InitializeLaraDefaultInventory();

--- a/TombEngine/Game/control/control.cpp
+++ b/TombEngine/Game/control/control.cpp
@@ -492,8 +492,6 @@ void DeInitializeScripting(int levelIndex, GameStatus reason)
 
 void InitializeOrLoadGame(bool loadGame)
 {
-	RequiredStartPos = false;
-
 	g_Gui.SetInventoryItemChosen(NO_ITEM);
 	g_Gui.SetEnterInventory(NO_ITEM);
 

--- a/TombEngine/Game/control/flipeffect.cpp
+++ b/TombEngine/Game/control/flipeffect.cpp
@@ -332,6 +332,7 @@ void Turn180(ItemInfo* item)
 void FinishLevel(ItemInfo* item)
 {
 	NextLevel = CurrentLevel + 1;
+	RequiredStartPos = TriggerTimer;
 }
 
 void VoidEffect(ItemInfo* item)

--- a/TombEngine/Game/control/trigger.cpp
+++ b/TombEngine/Game/control/trigger.cpp
@@ -750,8 +750,8 @@ void TestTriggers(int x, int y, int z, FloorInfo* floor, Activator activator, bo
 			break;
 
 		case TO_FINISH:
-			RequiredStartPos = false;
-			NextLevel = CurrentLevel + 1;
+			NextLevel = value ? value : CurrentLevel + 1;
+			RequiredStartPos = timer;
 			break;
 
 		case TO_CD:

--- a/TombEngine/Scripting/Internal/TEN/Flow/FlowHandler.cpp
+++ b/TombEngine/Scripting/Internal/TEN/Flow/FlowHandler.cpp
@@ -124,11 +124,13 @@ have an ID of 0, the second an ID of 1, and so on.
 	tableFlow.set_function(ScriptReserved_GetCurrentLevel, &FlowHandler::GetCurrentLevel, this);
 
 /***
-Finishes the current level, with optional level index provided. If level index
-is not provided or is zero, jumps to next level. If level index is more than
-level count, jumps to title.
+Finishes the current level, with optional level index and start position index provided.
+If level index is not provided or is zero, jumps to next level. If level index is more than
+level count, jumps to title. If LARA_START_POS objects are present in level, player will be
+teleported to such object with OCB similar to provided second argument.
 @function EndLevel
 @int[opt] index level index (default 0)
+@int[opt] startPos player start position (default 0)
 */
 	tableFlow.set_function(ScriptReserved_EndLevel, &FlowHandler::EndLevel, this);
 
@@ -430,10 +432,11 @@ int FlowHandler::GetLevelNumber(const std::string& fileName)
 	return -1;
 }
 
-void FlowHandler::EndLevel(std::optional<int> nextLevel)
+void FlowHandler::EndLevel(std::optional<int> nextLevel, std::optional<int> startPosIndex)
 {
 	int index = (nextLevel.has_value() && nextLevel.value() != 0) ? nextLevel.value() : CurrentLevel + 1;
 	NextLevel = index;
+	RequiredStartPos = startPosIndex.has_value() ? startPosIndex.value() : 0;
 }
 
 GameStatus FlowHandler::GetGameStatus()
@@ -649,6 +652,7 @@ bool FlowHandler::DoFlow()
 
 		case GameStatus::NewGame:
 			CurrentLevel = (SelectedLevelForNewGame != 0 ? SelectedLevelForNewGame : 1);
+			RequiredStartPos = 0;
 			SelectedLevelForNewGame = 0;
 			InitializeGame = true;
 			break;

--- a/TombEngine/Scripting/Internal/TEN/Flow/FlowHandler.h
+++ b/TombEngine/Scripting/Internal/TEN/Flow/FlowHandler.h
@@ -59,7 +59,7 @@ public:
 	Level*		GetCurrentLevel();
 	int			GetLevelNumber(const std::string& flieName);
 	int			GetNumLevels() const;
-	void		EndLevel(std::optional<int> nextLevel);
+	void		EndLevel(std::optional<int> nextLevel, std::optional<int> startPosIndex);
 	GameStatus	GetGameStatus();
 	void		FlipMap(int flipmap);
 	void		SaveGame(int slot);


### PR DESCRIPTION
Implements missing functionality for LARA_START_POS object.

Now, if there are any LARA_START_POS objects in newly loaded level, engine will search for such object with OCB similar to optionally provided start position index either in timer field for legacy triggers, or in additional argument for lua script function.

Additionally, this PR fixes issue with legacy leveljump trigger which ignored both provided level index and timer value for start position index.