### PR TITLE
Load spot cameras properly

### DIFF
--- a/TombEngine/Game/spotcam.h
+++ b/TombEngine/Game/spotcam.h
@@ -10,21 +10,19 @@ constexpr auto MAX_SPOTCAMS = 256;
 constexpr auto SPOTCAM_CINEMATIC_BARS_HEIGHT = 1.0f / 16;
 constexpr auto SPOTCAM_CINEMATIC_BARS_SPEED = 1.0f / FPS;
 
-// TODO: Game loads spot cameras in chunks, therefore member ordering and size must remain the same.
 struct SPOTCAM
 {
 	Vector3i Position		= Vector3i::Zero;
 	Vector3i PositionTarget = Vector3i::Zero;
 	
-	unsigned char sequence;
-	unsigned char camera;
+	int roomNumber;
+	int sequence;
+	int camera;
 	short fov;
 	short roll;
-	short timer;
-	short speed;
-	short flags;
-	short roomNumber;
-	short pad;
+	int timer;
+	int speed;
+	int flags;
 };
 
 enum SPOTCAM_FLAGS

--- a/TombEngine/Game/spotcam.h
+++ b/TombEngine/Game/spotcam.h
@@ -27,22 +27,22 @@ struct SPOTCAM
 
 enum SPOTCAM_FLAGS
 {
-	SCF_CUT_PAN					= (1 << 0),	 // Cut without panning smoothly.
-	SCF_OVERLAY					= (1 << 1),  // TODO: Add vignette.
-	SCF_LOOP_SEQUENCE			= (1 << 2),
-	SCF_TRACKING_CAM			= (1 << 3),
-	SCF_HIDE_LARA				= (1 << 4),
-	SCF_FOCUS_LARA_HEAD			= (1 << 5),
-	SCF_CUT_TO_LARA_CAM			= (1 << 6),
-	SCF_CUT_TO_CAM				= (1 << 7),
-	SCF_STOP_MOVEMENT			= (1 << 8),  // Stop movement for a given time (cf. `Timer` field).
-	SCF_DISABLE_BREAKOUT		= (1 << 9),  // Disable breaking out from cutscene using LOOK key.
-	SCF_DISABLE_LARA_CONTROLS	= (1 << 10), // Also add widescreen bars.
-	SCF_REENABLE_LARA_CONTROLS	= (1 << 11), // Used with 0x0400, keeps widescreen bars.
-	SCF_SCREEN_FADE_IN			= (1 << 12),
-	SCF_SCREEN_FADE_OUT			= (1 << 13),
-	SCF_ACTIVATE_HEAVY_TRIGGERS = (1 << 14), // When camera is moving above heavy trigger sector, it will be activated.
-	SCF_CAMERA_ONE_SHOT			= (1 << 15),
+	SCF_CUT_PAN					= 1 << 0,  // Cut without panning smoothly.
+	SCF_OVERLAY					= 1 << 1,  // TODO: Add vignette.
+	SCF_LOOP_SEQUENCE			= 1 << 2,
+	SCF_TRACKING_CAM			= 1 << 3,
+	SCF_HIDE_LARA				= 1 << 4,
+	SCF_FOCUS_LARA_HEAD			= 1 << 5,
+	SCF_CUT_TO_LARA_CAM			= 1 << 6,
+	SCF_CUT_TO_CAM				= 1 << 7,
+	SCF_STOP_MOVEMENT			= 1 << 8,  // Stop movement for a given time (cf. `Timer` field).
+	SCF_DISABLE_BREAKOUT		= 1 << 9,  // Disable breaking out from cutscene using LOOK key.
+	SCF_DISABLE_LARA_CONTROLS	= 1 << 10, // Also add widescreen bars.
+	SCF_REENABLE_LARA_CONTROLS	= 1 << 11, // Used with 0x0400, keeps widescreen bars.
+	SCF_SCREEN_FADE_IN			= 1 << 12,
+	SCF_SCREEN_FADE_OUT			= 1 << 13,
+	SCF_ACTIVATE_HEAVY_TRIGGERS = 1 << 14, // When camera is moving above heavy trigger sector, it will be activated.
+	SCF_CAMERA_ONE_SHOT			= 1 << 15,
 };
 
 extern SPOTCAM SpotCam[MAX_SPOTCAMS];

--- a/TombEngine/Specific/level.cpp
+++ b/TombEngine/Specific/level.cpp
@@ -527,9 +527,6 @@ void LoadCameras()
 		ReadInt16();
 	}
 
-	//if (NumberSpotcams != 0)
-	//	ReadBytes(SpotCam, NumberSpotcams * sizeof(SPOTCAM));
-
 	int numSinks = ReadInt32();
 	TENLog("Num sinks: " + std::to_string(numSinks), LogLevel::Info);
 


### PR DESCRIPTION
Minor revision to avoid loading spot cameras as a chunk. Otherwise, modifying the `SPOTCAM` struct in any way would break everything.

To test, ensure spot cameras still work as before.