### PR TITLE
Fixed TombEngine "Resource.rc" - "PRODUCTVERSION 1,7,1,0" to reflect …

### DIFF
--- a/TombEngine/Resources.rc
+++ b/TombEngine/Resources.rc
@@ -3,19 +3,8 @@
 #pragma code_page(65001)
 
 #include "resource.h"
-
-#define APSTUDIO_READONLY_SYMBOLS
 /////////////////////////////////////////////////////////////////////////////
-//
-// Generated from the TEXTINCLUDE 2 resource.
-//
-#include "winres.h"
-
-/////////////////////////////////////////////////////////////////////////////
-#undef APSTUDIO_READONLY_SYMBOLS
-
-/////////////////////////////////////////////////////////////////////////////
-// English resources
+// angličtina (neutrální) resources
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
 LANGUAGE LANG_ENGLISH, SUBLANG_NEUTRAL
@@ -27,7 +16,7 @@ LANGUAGE LANG_ENGLISH, SUBLANG_NEUTRAL
 
 VS_VERSION_INFO VERSIONINFO
  FILEVERSION 1,3,0,0
- PRODUCTVERSION 1,7,0,0
+ PRODUCTVERSION 1,7,1,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -48,7 +37,7 @@ BEGIN
             VALUE "LegalCopyright", "Copyright (c) 2024"
             VALUE "OriginalFilename", "TombEngine.exe"
             VALUE "ProductName", "Tomb Engine"
-            VALUE "ProductVersion", "1.7.0.0"
+            VALUE "ProductVersion", "1.7.1.0"
         END
     END
     BLOCK "VarFileInfo"
@@ -56,6 +45,7 @@ BEGIN
         VALUE "Translation", 0x9, 1200
     END
 END
+
 
 /////////////////////////////////////////////////////////////////////////////
 //
@@ -126,8 +116,43 @@ BEGIN
     0
 END
 
-#endif    // English resources
+#endif    // angličtina (neutrální) resources
 /////////////////////////////////////////////////////////////////////////////
+
+
+/////////////////////////////////////////////////////////////////////////////
+// Angličtina (Spojené státy) resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
+LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+1 TEXTINCLUDE 
+BEGIN
+    "resource.h\0"
+END
+
+2 TEXTINCLUDE 
+BEGIN
+    "\0"
+END
+
+3 TEXTINCLUDE 
+BEGIN
+    "\r\n"
+    "\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
+#endif    // Angličtina (Spojené státy) resources
+/////////////////////////////////////////////////////////////////////////////
+
 
 
 #ifndef APSTUDIO_INVOKED


### PR DESCRIPTION
…current Tomb Editor. Fixes TombEngine log error:

"[warning] Level version is different from TEN version" for Tomb Engine 1.7.1.0.