### PR TITLE
Static object refactor

### DIFF
--- a/Documentation/doc/2 classes/Objects.Static.html
+++ b/Documentation/doc/2 classes/Objects.Static.html
@@ -422,7 +422,7 @@
     <h3>Parameters:</h3>
     <ul>
         <li><span class="parameter">slot</span>
-            <span class="types"><span class="type">int</span></span>
+            <span class="types"><a class="type" href="../4 enums/Objects.ObjID.html#">ObjID</a></span>
          New slot ID.
         </li>
     </ul>

--- a/Documentation/doc/2 classes/Objects.Static.html
+++ b/Documentation/doc/2 classes/Objects.Static.html
@@ -100,7 +100,7 @@
 <div id="content">
 
 <h1>Class <code>Objects.Static</code></h1>
-<p>Statics</p>
+<p>Static object.</p>
 <p>
 
 </p>
@@ -109,87 +109,84 @@
 <h2><a href="#Functions">Functions</a></h2>
 <table class="function_list">
 	<tr>
-	<td class="name" ><a href="#Static:Enable">Static:Enable()</a></td>
-	<td class="summary">Enable the static, for cases when it was shattered or manually disabled before.</td>
-	</tr>
-	<tr>
-	<td class="name" ><a href="#Static:Disable">Static:Disable()</a></td>
-	<td class="summary">Disable the static</td>
-	</tr>
-	<tr>
-	<td class="name" ><a href="#Static:GetActive">Static:GetActive()</a></td>
-	<td class="summary">Get static mesh visibility</td>
-	</tr>
-	<tr>
-	<td class="name" ><a href="#Static:GetSolid">Static:GetSolid()</a></td>
-	<td class="summary">Get static mesh solid collision state</td>
-	</tr>
-	<tr>
-	<td class="name" ><a href="#Static:SetSolid">Static:SetSolid(solidState)</a></td>
-	<td class="summary">Set static mesh solid collision state</td>
-	</tr>
-	<tr>
-	<td class="name" ><a href="#Static:GetPosition">Static:GetPosition()</a></td>
-	<td class="summary">Get the static's position</td>
-	</tr>
-	<tr>
-	<td class="name" ><a href="#Static:SetPosition">Static:SetPosition(position)</a></td>
-	<td class="summary">Set the static's position</td>
-	</tr>
-	<tr>
-	<td class="name" ><a href="#Static:GetRotation">Static:GetRotation()</a></td>
-	<td class="summary">Get the static's rotation</td>
-	</tr>
-	<tr>
-	<td class="name" ><a href="#Static:SetRotation">Static:SetRotation(rotation)</a></td>
-	<td class="summary">Set the static's rotation</td>
-	</tr>
-	<tr>
-	<td class="name" ><a href="#Static:GetScale">Static:GetScale()</a></td>
-	<td class="summary">Get the static's scale</td>
-	</tr>
-	<tr>
-	<td class="name" ><a href="#Static:SetScale">Static:SetScale(scale)</a></td>
-	<td class="summary">Set the static's scale</td>
-	</tr>
-	<tr>
-	<td class="name" ><a href="#Static:GetHP">Static:GetHP()</a></td>
-	<td class="summary">Get current HP (hit points/health points)
- Used only with shatterable static meshes.</td>
-	</tr>
-	<tr>
-	<td class="name" ><a href="#Static:SetHP">Static:SetHP(HP)</a></td>
-	<td class="summary">Set current HP (hit points/health points)
- Used only with shatterable static meshes.</td>
-	</tr>
-	<tr>
 	<td class="name" ><a href="#Static:GetName">Static:GetName()</a></td>
-	<td class="summary">Get the static's unique string identifier</td>
-	</tr>
-	<tr>
-	<td class="name" ><a href="#Static:SetName">Static:SetName(name)</a></td>
-	<td class="summary">Set the static's name (its unique string identifier)
- e.g.</td>
+	<td class="summary">Get this static's unique string identifier.</td>
 	</tr>
 	<tr>
 	<td class="name" ><a href="#Static:GetSlot">Static:GetSlot()</a></td>
-	<td class="summary">Get the static's slot number (as listed in Tomb Editor and WadTool)</td>
+	<td class="summary">Get this static's slot ID.</td>
 	</tr>
 	<tr>
-	<td class="name" ><a href="#Static:SetSlot">Static:SetSlot(slot)</a></td>
-	<td class="summary">Set the static's slot number (as listed in Tomb Editor and WadTool)</td>
+	<td class="name" ><a href="#Static:GetPosition">Static:GetPosition()</a></td>
+	<td class="summary">Get this static's position.</td>
+	</tr>
+	<tr>
+	<td class="name" ><a href="#Static:GetRotation">Static:GetRotation()</a></td>
+	<td class="summary">Get this static's rotation.</td>
+	</tr>
+	<tr>
+	<td class="name" ><a href="#Static:GetScale">Static:GetScale()</a></td>
+	<td class="summary">Get this static's scale.</td>
 	</tr>
 	<tr>
 	<td class="name" ><a href="#Static:GetColor">Static:GetColor()</a></td>
-	<td class="summary">Get the static's color</td>
+	<td class="summary">Get this static's color.</td>
+	</tr>
+	<tr>
+	<td class="name" ><a href="#Static:GetHP">Static:GetHP()</a></td>
+	<td class="summary">Get this static's hit points.</td>
+	</tr>
+	<tr>
+	<td class="name" ><a href="#Static:GetSolid">Static:GetSolid()</a></td>
+	<td class="summary">Get this static's solid collision status.</td>
+	</tr>
+	<tr>
+	<td class="name" ><a href="#Static:GetActive">Static:GetActive()</a></td>
+	<td class="summary">Get this static's visibility status.</td>
+	</tr>
+	<tr>
+	<td class="name" ><a href="#Static:SetName">Static:SetName(name)</a></td>
+	<td class="summary">Set this static's unique string identifier.</td>
+	</tr>
+	<tr>
+	<td class="name" ><a href="#Static:SetSlot">Static:SetSlot(slot)</a></td>
+	<td class="summary">Set this static's slot ID.</td>
+	</tr>
+	<tr>
+	<td class="name" ><a href="#Static:SetPosition">Static:SetPosition(pos)</a></td>
+	<td class="summary">Set this static's position.</td>
+	</tr>
+	<tr>
+	<td class="name" ><a href="#Static:SetRotation">Static:SetRotation(rot)</a></td>
+	<td class="summary">Set this static's rotation.</td>
+	</tr>
+	<tr>
+	<td class="name" ><a href="#Static:SetScale">Static:SetScale(scale)</a></td>
+	<td class="summary">Set this static's scale.</td>
 	</tr>
 	<tr>
 	<td class="name" ><a href="#Static:SetColor">Static:SetColor(color)</a></td>
-	<td class="summary">Set the static's color</td>
+	<td class="summary">Set this static's color.</td>
+	</tr>
+	<tr>
+	<td class="name" ><a href="#Static:SetHP">Static:SetHP(hisPoints)</a></td>
+	<td class="summary">Set this static's hit points.</td>
+	</tr>
+	<tr>
+	<td class="name" ><a href="#Static:SetSolid">Static:SetSolid(isSolid)</a></td>
+	<td class="summary">Set this static's solid collision status.</td>
+	</tr>
+	<tr>
+	<td class="name" ><a href="#Static:Enable">Static:Enable()</a></td>
+	<td class="summary">Enable this static.</td>
+	</tr>
+	<tr>
+	<td class="name" ><a href="#Static:Disable">Static:Disable()</a></td>
+	<td class="summary">Disable this static.</td>
 	</tr>
 	<tr>
 	<td class="name" ><a href="#Static:Shatter">Static:Shatter()</a></td>
-	<td class="summary">Shatter static mesh</td>
+	<td class="summary">Shatter this static.</td>
 	</tr>
 </table>
 
@@ -201,11 +198,378 @@
 
     <dl class="function">
     <dt>
+    <a name = "Static:GetName"></a>
+    <strong>Static:GetName()</strong>
+    </dt>
+    <dd>
+    Get this static's unique string identifier. ()
+
+
+
+
+    <h3>Returns:</h3>
+    <ol>
+
+           <span class="types"><a class="type" href="https://www.lua.org/manual/5.4/manual.html#6.4">string</a></span>
+        Name.
+    </ol>
+
+
+
+
+</dd>
+    <dt>
+    <a name = "Static:GetSlot"></a>
+    <strong>Static:GetSlot()</strong>
+    </dt>
+    <dd>
+    Get this static's slot ID. ()
+
+
+
+
+    <h3>Returns:</h3>
+    <ol>
+
+           <span class="types"><a class="type" href="https://www.lua.org/manual/5.4/manual.html#6.4">string</a></span>
+        Slot ID.
+    </ol>
+
+
+
+
+</dd>
+    <dt>
+    <a name = "Static:GetPosition"></a>
+    <strong>Static:GetPosition()</strong>
+    </dt>
+    <dd>
+    Get this static's position. ()
+
+
+
+
+    <h3>Returns:</h3>
+    <ol>
+
+           <span class="types"><a class="type" href="../3 primitive classes/Vec3.html#">Vec3</a></span>
+        Position.
+    </ol>
+
+
+
+
+</dd>
+    <dt>
+    <a name = "Static:GetRotation"></a>
+    <strong>Static:GetRotation()</strong>
+    </dt>
+    <dd>
+    Get this static's rotation. ()
+
+
+
+
+    <h3>Returns:</h3>
+    <ol>
+
+           <span class="types"><a class="type" href="../3 primitive classes/Rotation.html#">Rotation</a></span>
+         Rotation.
+ Doesn't guarantee the returned value will be identical to a value set via SetRotation(),
+ only that the angle measures will be mathematically equal. E.g. 90 degrees = -270 degrees = 450 degrees.
+    </ol>
+
+
+
+
+</dd>
+    <dt>
+    <a name = "Static:GetScale"></a>
+    <strong>Static:GetScale()</strong>
+    </dt>
+    <dd>
+    Get this static's scale. ()
+
+
+
+
+    <h3>Returns:</h3>
+    <ol>
+
+           <span class="types"><span class="type">float</span></span>
+        Scale.
+    </ol>
+
+
+
+
+</dd>
+    <dt>
+    <a name = "Static:GetColor"></a>
+    <strong>Static:GetColor()</strong>
+    </dt>
+    <dd>
+    Get this static's color. ()
+
+
+
+
+    <h3>Returns:</h3>
+    <ol>
+
+           <span class="types"><a class="type" href="../3 primitive classes/Color.html#">Color</a></span>
+        Color.
+    </ol>
+
+
+
+
+</dd>
+    <dt>
+    <a name = "Static:GetHP"></a>
+    <strong>Static:GetHP()</strong>
+    </dt>
+    <dd>
+    Get this static's hit points.  Used only with shatterable statics.()
+
+
+
+
+    <h3>Returns:</h3>
+    <ol>
+
+           <span class="types"><span class="type">int</span></span>
+        Hit points.
+    </ol>
+
+
+
+
+</dd>
+    <dt>
+    <a name = "Static:GetSolid"></a>
+    <strong>Static:GetSolid()</strong>
+    </dt>
+    <dd>
+    Get this static's solid collision status. ()
+
+
+
+
+    <h3>Returns:</h3>
+    <ol>
+
+           <span class="types"><span class="type">bool</span></span>
+        Solid collision status.
+    </ol>
+
+
+
+
+</dd>
+    <dt>
+    <a name = "Static:GetActive"></a>
+    <strong>Static:GetActive()</strong>
+    </dt>
+    <dd>
+    Get this static's visibility status. ()
+
+
+
+
+    <h3>Returns:</h3>
+    <ol>
+
+           <span class="types"><span class="type">bool</span></span>
+        Visibility status.
+    </ol>
+
+
+
+
+</dd>
+    <dt>
+    <a name = "Static:SetName"></a>
+    <strong>Static:SetName(name)</strong>
+    </dt>
+    <dd>
+    Set this static's unique string identifier. ()
+
+
+
+    <h3>Parameters:</h3>
+    <ul>
+        <li><span class="parameter">name</span>
+            <span class="types"><a class="type" href="https://www.lua.org/manual/5.4/manual.html#6.4">string</a></span>
+         New name.
+        </li>
+    </ul>
+
+
+
+
+
+</dd>
+    <dt>
+    <a name = "Static:SetSlot"></a>
+    <strong>Static:SetSlot(slot)</strong>
+    </dt>
+    <dd>
+    Set this static's slot ID. ()
+
+
+
+    <h3>Parameters:</h3>
+    <ul>
+        <li><span class="parameter">slot</span>
+            <span class="types"><span class="type">int</span></span>
+         New slot ID.
+        </li>
+    </ul>
+
+
+
+
+
+</dd>
+    <dt>
+    <a name = "Static:SetPosition"></a>
+    <strong>Static:SetPosition(pos)</strong>
+    </dt>
+    <dd>
+    Set this static's position. ()
+
+
+
+    <h3>Parameters:</h3>
+    <ul>
+        <li><span class="parameter">pos</span>
+            <span class="types"><a class="type" href="../3 primitive classes/Vec3.html#">Vec3</a></span>
+         New position.
+        </li>
+    </ul>
+
+
+
+
+
+</dd>
+    <dt>
+    <a name = "Static:SetRotation"></a>
+    <strong>Static:SetRotation(rot)</strong>
+    </dt>
+    <dd>
+    Set this static's rotation. ()
+
+
+
+    <h3>Parameters:</h3>
+    <ul>
+        <li><span class="parameter">rot</span>
+            <span class="types"><a class="type" href="../3 primitive classes/Rotation.html#">Rotation</a></span>
+         New rotation.
+        </li>
+    </ul>
+
+
+
+
+
+</dd>
+    <dt>
+    <a name = "Static:SetScale"></a>
+    <strong>Static:SetScale(scale)</strong>
+    </dt>
+    <dd>
+    Set this static's scale. ()
+
+
+
+    <h3>Parameters:</h3>
+    <ul>
+        <li><span class="parameter">scale</span>
+            <span class="types"><span class="type">Scale</span></span>
+         New scale.
+        </li>
+    </ul>
+
+
+
+
+
+</dd>
+    <dt>
+    <a name = "Static:SetColor"></a>
+    <strong>Static:SetColor(color)</strong>
+    </dt>
+    <dd>
+    Set this static's color. ()
+
+
+
+    <h3>Parameters:</h3>
+    <ul>
+        <li><span class="parameter">color</span>
+            <span class="types"><a class="type" href="../3 primitive classes/Color.html#">Color</a></span>
+         New color.
+        </li>
+    </ul>
+
+
+
+
+
+</dd>
+    <dt>
+    <a name = "Static:SetHP"></a>
+    <strong>Static:SetHP(hisPoints)</strong>
+    </dt>
+    <dd>
+    Set this static's hit points.  Used only with shatterable statics.()
+
+
+
+    <h3>Parameters:</h3>
+    <ul>
+        <li><span class="parameter">hisPoints</span>
+            <span class="types"><span class="type">int</span></span>
+         New hit points.
+        </li>
+    </ul>
+
+
+
+
+
+</dd>
+    <dt>
+    <a name = "Static:SetSolid"></a>
+    <strong>Static:SetSolid(isSolid)</strong>
+    </dt>
+    <dd>
+    Set this static's solid collision status. ()
+
+
+
+    <h3>Parameters:</h3>
+    <ul>
+        <li><span class="parameter">isSolid</span>
+            <span class="types"><span class="type">bool</span></span>
+         Solid collision status.
+        </li>
+    </ul>
+
+
+
+
+
+</dd>
+    <dt>
     <a name = "Static:Enable"></a>
     <strong>Static:Enable()</strong>
     </dt>
     <dd>
-    Enable the static, for cases when it was shattered or manually disabled before.
+    Enable this static.  used in cases where it was previously shattered or manually disabled.()
 
 
 
@@ -220,378 +584,10 @@
     <strong>Static:Disable()</strong>
     </dt>
     <dd>
-    Disable the static
+    Disable this static. ()
 
 
 
-
-
-
-
-
-</dd>
-    <dt>
-    <a name = "Static:GetActive"></a>
-    <strong>Static:GetActive()</strong>
-    </dt>
-    <dd>
-    Get static mesh visibility
-
-
-
-
-    <h3>Returns:</h3>
-    <ol>
-
-           <span class="types"><span class="type">bool</span></span>
-        visibility state
-    </ol>
-
-
-
-
-</dd>
-    <dt>
-    <a name = "Static:GetSolid"></a>
-    <strong>Static:GetSolid()</strong>
-    </dt>
-    <dd>
-    Get static mesh solid collision state
-
-
-
-
-    <h3>Returns:</h3>
-    <ol>
-
-           <span class="types"><span class="type">bool</span></span>
-        solid collision state (true if solid, false if soft)
-    </ol>
-
-
-
-
-</dd>
-    <dt>
-    <a name = "Static:SetSolid"></a>
-    <strong>Static:SetSolid(solidState)</strong>
-    </dt>
-    <dd>
-    Set static mesh solid collision state
-
-
-
-    <h3>Parameters:</h3>
-    <ul>
-        <li><span class="parameter">solidState</span>
-            <span class="types"><span class="type">bool</span></span>
-         if set, collision will be solid, if not, will be soft
-        </li>
-    </ul>
-
-
-
-
-
-</dd>
-    <dt>
-    <a name = "Static:GetPosition"></a>
-    <strong>Static:GetPosition()</strong>
-    </dt>
-    <dd>
-    Get the static's position
-
-
-
-
-    <h3>Returns:</h3>
-    <ol>
-
-           <span class="types"><a class="type" href="../3 primitive classes/Vec3.html#">Vec3</a></span>
-        a copy of the static's position
-    </ol>
-
-
-
-
-</dd>
-    <dt>
-    <a name = "Static:SetPosition"></a>
-    <strong>Static:SetPosition(position)</strong>
-    </dt>
-    <dd>
-    Set the static's position
-
-
-
-    <h3>Parameters:</h3>
-    <ul>
-        <li><span class="parameter">position</span>
-            <span class="types"><a class="type" href="../3 primitive classes/Vec3.html#">Vec3</a></span>
-         the new position of the static
-        </li>
-    </ul>
-
-
-
-
-
-</dd>
-    <dt>
-    <a name = "Static:GetRotation"></a>
-    <strong>Static:GetRotation()</strong>
-    </dt>
-    <dd>
-    Get the static's rotation
-
-
-
-
-    <h3>Returns:</h3>
-    <ol>
-
-           <span class="types"><a class="type" href="../3 primitive classes/Rotation.html#">Rotation</a></span>
-        a copy of the static's rotation
-    </ol>
-
-
-
-
-</dd>
-    <dt>
-    <a name = "Static:SetRotation"></a>
-    <strong>Static:SetRotation(rotation)</strong>
-    </dt>
-    <dd>
-    Set the static's rotation
-
-
-
-    <h3>Parameters:</h3>
-    <ul>
-        <li><span class="parameter">rotation</span>
-            <span class="types"><a class="type" href="../3 primitive classes/Rotation.html#">Rotation</a></span>
-         the static's new rotation
-        </li>
-    </ul>
-
-
-
-
-
-</dd>
-    <dt>
-    <a name = "Static:GetScale"></a>
-    <strong>Static:GetScale()</strong>
-    </dt>
-    <dd>
-    Get the static's scale
-
-
-
-
-    <h3>Returns:</h3>
-    <ol>
-
-           <span class="types"><span class="type">float</span></span>
-        current static scale
-    </ol>
-
-
-
-
-</dd>
-    <dt>
-    <a name = "Static:SetScale"></a>
-    <strong>Static:SetScale(scale)</strong>
-    </dt>
-    <dd>
-    Set the static's scale
-
-
-
-    <h3>Parameters:</h3>
-    <ul>
-        <li><span class="parameter">scale</span>
-            <span class="types"><span class="type">Scale</span></span>
-         the static's new scale
-        </li>
-    </ul>
-
-
-
-
-
-</dd>
-    <dt>
-    <a name = "Static:GetHP"></a>
-    <strong>Static:GetHP()</strong>
-    </dt>
-    <dd>
-    Get current HP (hit points/health points)
- Used only with shatterable static meshes.
-
-
-
-
-    <h3>Returns:</h3>
-    <ol>
-
-           <span class="types"><span class="type">int</span></span>
-        the amount of HP the static currently has
-    </ol>
-
-
-
-
-</dd>
-    <dt>
-    <a name = "Static:SetHP"></a>
-    <strong>Static:SetHP(HP)</strong>
-    </dt>
-    <dd>
-    Set current HP (hit points/health points)
- Used only with shatterable static meshes.
-
-
-
-    <h3>Parameters:</h3>
-    <ul>
-        <li><span class="parameter">HP</span>
-            <span class="types"><span class="type">int</span></span>
-         the amount of HP to give the static
-        </li>
-    </ul>
-
-
-
-
-
-</dd>
-    <dt>
-    <a name = "Static:GetName"></a>
-    <strong>Static:GetName()</strong>
-    </dt>
-    <dd>
-    Get the static's unique string identifier
-
-
-
-
-    <h3>Returns:</h3>
-    <ol>
-
-           <span class="types"><a class="type" href="https://www.lua.org/manual/5.4/manual.html#6.4">string</a></span>
-        the static's name
-    </ol>
-
-
-
-
-</dd>
-    <dt>
-    <a name = "Static:SetName"></a>
-    <strong>Static:SetName(name)</strong>
-    </dt>
-    <dd>
-    Set the static's name (its unique string identifier)
- e.g.  "my_vase" or "oldrubble"
-
-
-
-    <h3>Parameters:</h3>
-    <ul>
-        <li><span class="parameter">name</span>
-            <span class="types"><a class="type" href="https://www.lua.org/manual/5.4/manual.html#6.4">string</a></span>
-         The static's new name
-        </li>
-    </ul>
-
-
-
-
-
-</dd>
-    <dt>
-    <a name = "Static:GetSlot"></a>
-    <strong>Static:GetSlot()</strong>
-    </dt>
-    <dd>
-    Get the static's slot number (as listed in Tomb Editor and WadTool)
-
-
-
-
-    <h3>Returns:</h3>
-    <ol>
-
-           <span class="types"><a class="type" href="https://www.lua.org/manual/5.4/manual.html#6.4">string</a></span>
-        the static's slot number
-    </ol>
-
-
-
-
-</dd>
-    <dt>
-    <a name = "Static:SetSlot"></a>
-    <strong>Static:SetSlot(slot)</strong>
-    </dt>
-    <dd>
-    Set the static's slot number (as listed in Tomb Editor and WadTool)
-
-
-
-    <h3>Parameters:</h3>
-    <ul>
-        <li><span class="parameter">slot</span>
-            <span class="types"><span class="type">int</span></span>
-         The static's slot number
-        </li>
-    </ul>
-
-
-
-
-
-</dd>
-    <dt>
-    <a name = "Static:GetColor"></a>
-    <strong>Static:GetColor()</strong>
-    </dt>
-    <dd>
-    Get the static's color
-
-
-
-
-    <h3>Returns:</h3>
-    <ol>
-
-           <span class="types"><a class="type" href="../3 primitive classes/Color.html#">Color</a></span>
-        a copy of the static's color
-    </ol>
-
-
-
-
-</dd>
-    <dt>
-    <a name = "Static:SetColor"></a>
-    <strong>Static:SetColor(color)</strong>
-    </dt>
-    <dd>
-    Set the static's color
-
-
-
-    <h3>Parameters:</h3>
-    <ul>
-        <li><span class="parameter">color</span>
-            <span class="types"><a class="type" href="../3 primitive classes/Color.html#">Color</a></span>
-         the new color of the static
-        </li>
-    </ul>
 
 
 
@@ -603,7 +599,7 @@
     <strong>Static:Shatter()</strong>
     </dt>
     <dd>
-    Shatter static mesh
+    Shatter this static. ()
 
 
 

--- a/Documentation/doc/index.html
+++ b/Documentation/doc/index.html
@@ -229,7 +229,7 @@ local door = GetMoveableByName("door_type4_14")
 	</tr>
 	<tr>
 		<td class="name"  ><a href="2 classes/Objects.Static.html">Objects.Static</a></td>
-		<td class="summary">Statics</td>
+		<td class="summary">Static object.</td>
 	</tr>
 	<tr>
 		<td class="name"  ><a href="2 classes/Objects.Volume.html">Objects.Volume</a></td>

--- a/Documentation/output.xml
+++ b/Documentation/output.xml
@@ -3473,26 +3473,99 @@ most can just be ignored (see usage).</description>
 <function>
 	<module>Objects.Static</module>
 	<caller>Static</caller>
-	<name>Enable</name>
-	<summary>Enable the static, for cases when it was shattered or manually disabled before.</summary>
-</function>
-
-<function>
-	<module>Objects.Static</module>
-	<caller>Static</caller>
-	<name>Disable</name>
-	<summary>Disable the static</summary>
-</function>
-
-<function>
-	<module>Objects.Static</module>
-	<caller>Static</caller>
-	<name>GetActive</name>
-	<summary>Get static mesh visibility</summary>
+	<name>GetName</name>
+	<summary>Get this static's unique string identifier.</summary>
+	<description>()</description>
 	<returns>
 		<return>
-			<type>bool</type>
-			<description>visibility state</description>
+			<type>string</type>
+			<description>Name.</description>
+		</return>
+	</returns>
+</function>
+
+<function>
+	<module>Objects.Static</module>
+	<caller>Static</caller>
+	<name>GetSlot</name>
+	<summary>Get this static's slot ID.</summary>
+	<description>()</description>
+	<returns>
+		<return>
+			<type>string</type>
+			<description>Slot ID.</description>
+		</return>
+	</returns>
+</function>
+
+<function>
+	<module>Objects.Static</module>
+	<caller>Static</caller>
+	<name>GetPosition</name>
+	<summary>Get this static's position.</summary>
+	<description>()</description>
+	<returns>
+		<return>
+			<type>Vec3</type>
+			<description>Position.</description>
+		</return>
+	</returns>
+</function>
+
+<function>
+	<module>Objects.Static</module>
+	<caller>Static</caller>
+	<name>GetRotation</name>
+	<summary>Get this static's rotation.</summary>
+	<description>()</description>
+	<returns>
+		<return>
+			<type>Rotation</type>
+			<description> Rotation.
+ Doesn't guarantee the returned value will be identical to a value set via SetRotation(),
+ only that the angle measures will be mathematically equal. E.g. 90 degrees = -270 degrees = 450 degrees.</description>
+		</return>
+	</returns>
+</function>
+
+<function>
+	<module>Objects.Static</module>
+	<caller>Static</caller>
+	<name>GetScale</name>
+	<summary>Get this static's scale.</summary>
+	<description>()</description>
+	<returns>
+		<return>
+			<type>float</type>
+			<description>Scale.</description>
+		</return>
+	</returns>
+</function>
+
+<function>
+	<module>Objects.Static</module>
+	<caller>Static</caller>
+	<name>GetColor</name>
+	<summary>Get this static's color.</summary>
+	<description>()</description>
+	<returns>
+		<return>
+			<type>Color</type>
+			<description>Color.</description>
+		</return>
+	</returns>
+</function>
+
+<function>
+	<module>Objects.Static</module>
+	<caller>Static</caller>
+	<name>GetHP</name>
+	<summary>Get this static's hit points.</summary>
+	<description>Used only with shatterable statics.()</description>
+	<returns>
+		<return>
+			<type>int</type>
+			<description>Hit points.</description>
 		</return>
 	</returns>
 </function>
@@ -3501,11 +3574,12 @@ most can just be ignored (see usage).</description>
 	<module>Objects.Static</module>
 	<caller>Static</caller>
 	<name>GetSolid</name>
-	<summary>Get static mesh solid collision state</summary>
+	<summary>Get this static's solid collision status.</summary>
+	<description>()</description>
 	<returns>
 		<return>
 			<type>bool</type>
-			<description>solid collision state (true if solid, false if soft)</description>
+			<description>Solid collision status.</description>
 		</return>
 	</returns>
 </function>
@@ -3513,136 +3587,13 @@ most can just be ignored (see usage).</description>
 <function>
 	<module>Objects.Static</module>
 	<caller>Static</caller>
-	<name>SetSolid</name>
-	<summary>Set static mesh solid collision state</summary>
-	<parameters>
-		<parameter>
-			<name>solidState</name>
+	<name>GetActive</name>
+	<summary>Get this static's visibility status.</summary>
+	<description>()</description>
+	<returns>
+		<return>
 			<type>bool</type>
-			<description>if set, collision will be solid, if not, will be soft</description>
-		</parameter>
-	</parameters>
-</function>
-
-<function>
-	<module>Objects.Static</module>
-	<caller>Static</caller>
-	<name>GetPosition</name>
-	<summary>Get the static's position</summary>
-	<returns>
-		<return>
-			<type>Vec3</type>
-			<description>a copy of the static's position</description>
-		</return>
-	</returns>
-</function>
-
-<function>
-	<module>Objects.Static</module>
-	<caller>Static</caller>
-	<name>SetPosition</name>
-	<summary>Set the static's position</summary>
-	<parameters>
-		<parameter>
-			<name>position</name>
-			<type>Vec3</type>
-			<description>the new position of the static</description>
-		</parameter>
-	</parameters>
-</function>
-
-<function>
-	<module>Objects.Static</module>
-	<caller>Static</caller>
-	<name>GetRotation</name>
-	<summary>Get the static's rotation</summary>
-	<returns>
-		<return>
-			<type>Rotation</type>
-			<description>a copy of the static's rotation</description>
-		</return>
-	</returns>
-</function>
-
-<function>
-	<module>Objects.Static</module>
-	<caller>Static</caller>
-	<name>SetRotation</name>
-	<summary>Set the static's rotation</summary>
-	<parameters>
-		<parameter>
-			<name>rotation</name>
-			<type>Rotation</type>
-			<description>the static's new rotation</description>
-		</parameter>
-	</parameters>
-</function>
-
-<function>
-	<module>Objects.Static</module>
-	<caller>Static</caller>
-	<name>GetScale</name>
-	<summary>Get the static's scale</summary>
-	<returns>
-		<return>
-			<type>float</type>
-			<description>current static scale</description>
-		</return>
-	</returns>
-</function>
-
-<function>
-	<module>Objects.Static</module>
-	<caller>Static</caller>
-	<name>SetScale</name>
-	<summary>Set the static's scale</summary>
-	<parameters>
-		<parameter>
-			<name>scale</name>
-			<type>Scale</type>
-			<description>the static's new scale</description>
-		</parameter>
-	</parameters>
-</function>
-
-<function>
-	<module>Objects.Static</module>
-	<caller>Static</caller>
-	<name>GetHP</name>
-	<summary>Get current HP (hit points/health points)
- Used only with shatterable static meshes.</summary>
-	<returns>
-		<return>
-			<type>int</type>
-			<description>the amount of HP the static currently has</description>
-		</return>
-	</returns>
-</function>
-
-<function>
-	<module>Objects.Static</module>
-	<caller>Static</caller>
-	<name>SetHP</name>
-	<summary>Set current HP (hit points/health points)
- Used only with shatterable static meshes.</summary>
-	<parameters>
-		<parameter>
-			<name>HP</name>
-			<type>int</type>
-			<description>the amount of HP to give the static</description>
-		</parameter>
-	</parameters>
-</function>
-
-<function>
-	<module>Objects.Static</module>
-	<caller>Static</caller>
-	<name>GetName</name>
-	<summary>Get the static's unique string identifier</summary>
-	<returns>
-		<return>
-			<type>string</type>
-			<description>the static's name</description>
+			<description>Visibility status.</description>
 		</return>
 	</returns>
 </function>
@@ -3651,41 +3602,28 @@ most can just be ignored (see usage).</description>
 	<module>Objects.Static</module>
 	<caller>Static</caller>
 	<name>SetName</name>
-	<summary>Set the static's name (its unique string identifier)
- e.g.</summary>
-	<description>"my\_vase" or "oldrubble"</description>
+	<summary>Set this static's unique string identifier.</summary>
+	<description>()</description>
 	<parameters>
 		<parameter>
 			<name>name</name>
 			<type>string</type>
-			<description>The static's new name</description>
+			<description>New name.</description>
 		</parameter>
 	</parameters>
-</function>
-
-<function>
-	<module>Objects.Static</module>
-	<caller>Static</caller>
-	<name>GetSlot</name>
-	<summary>Get the static's slot number (as listed in Tomb Editor and WadTool)</summary>
-	<returns>
-		<return>
-			<type>string</type>
-			<description>the static's slot number</description>
-		</return>
-	</returns>
 </function>
 
 <function>
 	<module>Objects.Static</module>
 	<caller>Static</caller>
 	<name>SetSlot</name>
-	<summary>Set the static's slot number (as listed in Tomb Editor and WadTool)</summary>
+	<summary>Set this static's slot ID.</summary>
+	<description>()</description>
 	<parameters>
 		<parameter>
 			<name>slot</name>
 			<type>int</type>
-			<description>The static's slot number</description>
+			<description>New slot ID.</description>
 		</parameter>
 	</parameters>
 </function>
@@ -3693,26 +3631,59 @@ most can just be ignored (see usage).</description>
 <function>
 	<module>Objects.Static</module>
 	<caller>Static</caller>
-	<name>GetColor</name>
-	<summary>Get the static's color</summary>
-	<returns>
-		<return>
-			<type>Color</type>
-			<description>a copy of the static's color</description>
-		</return>
-	</returns>
+	<name>SetPosition</name>
+	<summary>Set this static's position.</summary>
+	<description>()</description>
+	<parameters>
+		<parameter>
+			<name>pos</name>
+			<type>Vec3</type>
+			<description>New position.</description>
+		</parameter>
+	</parameters>
+</function>
+
+<function>
+	<module>Objects.Static</module>
+	<caller>Static</caller>
+	<name>SetRotation</name>
+	<summary>Set this static's rotation.</summary>
+	<description>()</description>
+	<parameters>
+		<parameter>
+			<name>rot</name>
+			<type>Rotation</type>
+			<description>New rotation.</description>
+		</parameter>
+	</parameters>
+</function>
+
+<function>
+	<module>Objects.Static</module>
+	<caller>Static</caller>
+	<name>SetScale</name>
+	<summary>Set this static's scale.</summary>
+	<description>()</description>
+	<parameters>
+		<parameter>
+			<name>scale</name>
+			<type>Scale</type>
+			<description>New scale.</description>
+		</parameter>
+	</parameters>
 </function>
 
 <function>
 	<module>Objects.Static</module>
 	<caller>Static</caller>
 	<name>SetColor</name>
-	<summary>Set the static's color</summary>
+	<summary>Set this static's color.</summary>
+	<description>()</description>
 	<parameters>
 		<parameter>
 			<name>color</name>
 			<type>Color</type>
-			<description>the new color of the static</description>
+			<description>New color.</description>
 		</parameter>
 	</parameters>
 </function>
@@ -3720,8 +3691,55 @@ most can just be ignored (see usage).</description>
 <function>
 	<module>Objects.Static</module>
 	<caller>Static</caller>
+	<name>SetHP</name>
+	<summary>Set this static's hit points.</summary>
+	<description>Used only with shatterable statics.()</description>
+	<parameters>
+		<parameter>
+			<name>hisPoints</name>
+			<type>int</type>
+			<description>New hit points.</description>
+		</parameter>
+	</parameters>
+</function>
+
+<function>
+	<module>Objects.Static</module>
+	<caller>Static</caller>
+	<name>SetSolid</name>
+	<summary>Set this static's solid collision status.</summary>
+	<description>()</description>
+	<parameters>
+		<parameter>
+			<name>isSolid</name>
+			<type>bool</type>
+			<description>Solid collision status.</description>
+		</parameter>
+	</parameters>
+</function>
+
+<function>
+	<module>Objects.Static</module>
+	<caller>Static</caller>
+	<name>Enable</name>
+	<summary>Enable this static.</summary>
+	<description>used in cases where it was previously shattered or manually disabled.()</description>
+</function>
+
+<function>
+	<module>Objects.Static</module>
+	<caller>Static</caller>
+	<name>Disable</name>
+	<summary>Disable this static.</summary>
+	<description>()</description>
+</function>
+
+<function>
+	<module>Objects.Static</module>
+	<caller>Static</caller>
 	<name>Shatter</name>
-	<summary>Shatter static mesh</summary>
+	<summary>Shatter this static.</summary>
+	<description>()</description>
 </function>
 
 <function>

--- a/Documentation/output.xml
+++ b/Documentation/output.xml
@@ -3622,7 +3622,7 @@ most can just be ignored (see usage).</description>
 	<parameters>
 		<parameter>
 			<name>slot</name>
-			<type>int</type>
+			<type>Objects.ObjID</type>
 			<description>New slot ID.</description>
 		</parameter>
 	</parameters>

--- a/TombEngine/Game/Lara/lara_one_gun.cpp
+++ b/TombEngine/Game/Lara/lara_one_gun.cpp
@@ -1564,7 +1564,7 @@ void HandleProjectile(ItemInfo& projectile, ItemInfo& emitter, const Vector3i& p
 			hasHit = hasHitNotByEmitter = doShatter = true;
 			doExplosion = isExplosive;
 
-			if (StaticObjects[staticPtr->staticNumber].shatterType == ShatterType::None)
+			if (staticPtr->AssetPtr->shatterType == ShatterType::None)
 				continue;
 
 			staticPtr->HitPoints -= damage;
@@ -1574,8 +1574,8 @@ void HandleProjectile(ItemInfo& projectile, ItemInfo& emitter, const Vector3i& p
 			if (!isExplosive)
 				continue;
 
-			TriggerExplosionSparks(staticPtr->pos.Position.x, staticPtr->pos.Position.y, staticPtr->pos.Position.z, 3, -2, 0, projectile.RoomNumber);
-			auto pose = Pose(staticPtr->pos.Position.x, staticPtr->pos.Position.y - 128, staticPtr->pos.Position.z, 0, staticPtr->pos.Orientation.y, 0);
+			TriggerExplosionSparks(staticPtr->Pose.Position.x, staticPtr->Pose.Position.y, staticPtr->Pose.Position.z, 3, -2, 0, projectile.RoomNumber);
+			auto pose = Pose(staticPtr->Pose.Position.x, staticPtr->Pose.Position.y - 128, staticPtr->Pose.Position.z, 0, staticPtr->Pose.Orientation.y, 0);
 			TriggerShockwave(&pose, 40, 176, 64, 0, 96, 128, 16, EulerAngles::Identity, 0, true, false, false, (int)ShockwaveStyle::Normal);
 		}
 

--- a/TombEngine/Game/Setup.cpp
+++ b/TombEngine/Game/Setup.cpp
@@ -33,7 +33,6 @@ using namespace TEN::Entities;
 using namespace TEN::Entities::Switches;
 
 ObjectHandler Objects;
-StaticAsset	  StaticAssets[STATIC_COUNT_MAX];
 
 void ObjectHandler::Initialize() 
 { 
@@ -216,13 +215,12 @@ void InitializeObjects()
 	SequenceUsed[5] = 0;
 }
 
-StaticAsset& GetStaticAsset(int id)
+StaticAsset& GetStaticAsset(GAME_OBJECT_ID id)
 {
-	if (id < 0 || id > STATIC_COUNT_MAX)
-	{
-		TENLog("GetStaticAsset(): ID " + std::to_string(id) + " out of range.");
-		return StaticAssets[0];
-	}
+	auto it = g_Level.StaticAssets.find(id);
+	if (it != g_Level.StaticAssets.end())
+		return it->second;
 
-	return StaticAssets[id];
+	TENLog("GetStaticAsset(): ID " + std::to_string(id) + " out of range. Returning static asset 0.");
+	return g_Level.StaticAssets[(GAME_OBJECT_ID)0];
 }

--- a/TombEngine/Game/Setup.cpp
+++ b/TombEngine/Game/Setup.cpp
@@ -33,7 +33,7 @@ using namespace TEN::Entities;
 using namespace TEN::Entities::Switches;
 
 ObjectHandler Objects;
-StaticInfo StaticObjects[MAX_STATICS];
+StaticAsset	  StaticAssets[STATIC_COUNT_MAX];
 
 void ObjectHandler::Initialize() 
 { 
@@ -47,7 +47,7 @@ bool ObjectHandler::CheckID(GAME_OBJECT_ID objectID, bool isSilent)
 		if (!isSilent)
 		{
 			TENLog(
-				"Attempted to access unavailable slot ID (" + std::to_string(objectID) + "). " +
+				"Attempted to access unavailable slot ID " + std::to_string(objectID) + ". " +
 				"Check if last accessed item exists in level.", LogLevel::Warning, LogConfig::Debug);
 		}
 
@@ -157,11 +157,6 @@ void InitializeSpecialEffects()
 	TEN::Entities::Creatures::TR3::ClearFishSwarm();
 }
 
-void CustomObjects()
-{
-	
-}
-
 void InitializeObjects()
 {
 	AllocTR4Objects();
@@ -202,9 +197,6 @@ void InitializeObjects()
 	InitializeTR3Objects(); // Standard TR3 objects
 	InitializeTR4Objects(); // Standard TR4 objects
 
-	// User defined objects
-	CustomObjects();
-
 	HairEffect.Initialize();
 	InitializeSpecialEffects();
 
@@ -222,4 +214,15 @@ void InitializeObjects()
 	SequenceUsed[3] = 0;
 	SequenceUsed[4] = 0;
 	SequenceUsed[5] = 0;
+}
+
+StaticAsset& GetStaticAsset(int id)
+{
+	if (id < 0 || id > STATIC_COUNT_MAX)
+	{
+		TENLog("GetStaticAsset(): ID " + std::to_string(id) + " out of range.");
+		return StaticAssets[0];
+	}
+
+	return StaticAssets[id];
 }

--- a/TombEngine/Game/Setup.cpp
+++ b/TombEngine/Game/Setup.cpp
@@ -215,7 +215,7 @@ void InitializeObjects()
 	SequenceUsed[5] = 0;
 }
 
-StaticAsset& GetStaticAsset(GAME_OBJECT_ID id)
+const StaticAsset& GetStaticAsset(GAME_OBJECT_ID id)
 {
 	auto it = g_Level.StaticAssets.find(id);
 	if (it != g_Level.StaticAssets.end())

--- a/TombEngine/Game/Setup.h
+++ b/TombEngine/Game/Setup.h
@@ -12,8 +12,6 @@ constexpr auto DEFAULT_RADIUS = 10;
 constexpr auto GRAVITY		  = 6.0f;
 constexpr auto SWAMP_GRAVITY  = GRAVITY / 3.0f;
 
-constexpr auto STATIC_COUNT_MAX = 1000;
-
 enum JointRotationFlags
 {
 	ROT_X = (1 << 2),
@@ -141,10 +139,9 @@ private:
 };
 
 extern ObjectHandler Objects;
-extern StaticAsset	 StaticAssets[STATIC_COUNT_MAX];
 
 void InitializeGameFlags();
 void InitializeSpecialEffects();
 void InitializeObjects();
 
-StaticAsset& GetStaticAsset(int id);
+StaticAsset& GetStaticAsset(GAME_OBJECT_ID id);

--- a/TombEngine/Game/Setup.h
+++ b/TombEngine/Game/Setup.h
@@ -144,4 +144,4 @@ void InitializeGameFlags();
 void InitializeSpecialEffects();
 void InitializeObjects();
 
-StaticAsset& GetStaticAsset(GAME_OBJECT_ID id);
+const StaticAsset& GetStaticAsset(GAME_OBJECT_ID id);

--- a/TombEngine/Game/Setup.h
+++ b/TombEngine/Game/Setup.h
@@ -12,7 +12,7 @@ constexpr auto DEFAULT_RADIUS = 10;
 constexpr auto GRAVITY		  = 6.0f;
 constexpr auto SWAMP_GRAVITY  = GRAVITY / 3.0f;
 
-constexpr auto MAX_STATICS = 1000;
+constexpr auto STATIC_COUNT_MAX = 1000;
 
 enum JointRotationFlags
 {
@@ -47,10 +47,10 @@ enum class LotType
 
 enum class HitEffect
 {
-    None,
-    Blood,
-    Smoke,
-    Richochet,
+	None,
+	Blood,
+	Smoke,
+	Richochet,
 	NonExplosive,
 	Special
 };
@@ -69,6 +69,7 @@ enum class ShatterType
 	Explode
 };
 
+// MoveableAsset
 struct ObjectInfo
 {
 	bool loaded = false; // IsLoaded
@@ -110,6 +111,20 @@ struct ObjectInfo
 	void SetHitEffect(bool isSolid = false, bool isAlive = false);
 };
 
+struct StaticAsset
+{
+	int ID = 0;
+	int meshNumber = 0; // g_Level.meshes index. TODO: Contain here.
+
+	GameBoundingBox visibilityBox = {};
+	GameBoundingBox collisionBox  = {};
+
+	ShatterType shatterType	 = ShatterType::None;
+	int			shatterSound = 0;
+
+	int flags = 0;
+};
+
 class ObjectHandler
 {
 private:
@@ -125,19 +140,11 @@ private:
 	ObjectInfo& GetFirstAvailableObject();
 };
 
-struct StaticInfo
-{
-	int meshNumber;
-	int flags;
-	GameBoundingBox visibilityBox;
-	GameBoundingBox collisionBox;
-	ShatterType shatterType;
-	int shatterSound;
-};
-
 extern ObjectHandler Objects;
-extern StaticInfo StaticObjects[MAX_STATICS];
+extern StaticAsset	 StaticAssets[STATIC_COUNT_MAX];
 
 void InitializeGameFlags();
 void InitializeSpecialEffects();
 void InitializeObjects();
+
+StaticAsset& GetStaticAsset(int id);

--- a/TombEngine/Game/StaticObject.cpp
+++ b/TombEngine/Game/StaticObject.cpp
@@ -1,0 +1,3 @@
+#include "framework.h"
+
+#include "Game/Setup.h"

--- a/TombEngine/Game/StaticObject.h
+++ b/TombEngine/Game/StaticObject.h
@@ -8,8 +8,8 @@ struct StaticAsset;
 class StaticObject
 {
 public:
-	std::string		  Name	   = {};
-	int				  ID	   = 0;
+	std::string		   Name		= {};
+	int				   ID		= 0;
 	const StaticAsset* AssetPtr = nullptr;
 
 	Pose  Pose		 = Pose::Zero;

--- a/TombEngine/Game/StaticObject.h
+++ b/TombEngine/Game/StaticObject.h
@@ -1,0 +1,23 @@
+#pragma once
+#include "Math/Math.h"
+
+using namespace TEN::Math;
+
+struct StaticAsset;
+
+class StaticObject
+{
+public:
+	std::string		  Name	   = {};
+	int				  ID	   = 0;
+	const StaticAsset* AssetPtr = nullptr;
+
+	Pose  Pose		 = Pose::Zero;
+	int	  RoomNumber = 0;
+	float Scale		 = 0.0f;
+	Color Color		 = {};
+
+	int	 HitPoints = 0;
+	int	 Flags	   = 0;
+	bool IsDirty   = false;
+};

--- a/TombEngine/Game/camera.cpp
+++ b/TombEngine/Game/camera.cpp
@@ -1412,13 +1412,13 @@ static std::vector<int> FillCollideableItemList()
 	return itemList;
 }
 
-bool CheckStaticCollideCamera(MESH_INFO* mesh)
+bool CheckStaticCollideCamera(StaticObject* mesh)
 {
-	bool isCloseEnough = Vector3i::Distance(mesh->pos.Position, Camera.pos.ToVector3i()) <= COLL_CHECK_THRESHOLD;
+	bool isCloseEnough = Vector3i::Distance(mesh->Pose.Position, Camera.pos.ToVector3i()) <= COLL_CHECK_THRESHOLD;
 	if (!isCloseEnough)
 		return false;
 
-	if (!(mesh->flags & StaticMeshFlags::SM_VISIBLE))
+	if (!(mesh->Flags & StaticMeshFlags::SM_VISIBLE))
 		return false;
 
 	const auto& bounds = GetBoundsAccurate(*mesh, false);
@@ -1438,9 +1438,9 @@ bool CheckStaticCollideCamera(MESH_INFO* mesh)
 	return true;
 }
 
-std::vector<MESH_INFO*> FillCollideableStaticsList()
+std::vector<StaticObject*> FillCollideableStaticsList()
 {
-	std::vector<MESH_INFO*> staticList;
+	std::vector<StaticObject*> staticList;
 	auto& roomList = g_Level.Rooms[Camera.pos.RoomNumber].neighbors;
 
 	for (int i : roomList)
@@ -1450,12 +1450,12 @@ std::vector<MESH_INFO*> FillCollideableStaticsList()
 		if (!room->Active())
 			continue;
 
-		for (short j = 0; j < room->mesh.size(); j++)
+		for (short j = 0; j < room->Statics.size(); j++)
 		{
-			if (!CheckStaticCollideCamera(&room->mesh[j]))
+			if (!CheckStaticCollideCamera(&room->Statics[j]))
 				continue;
 
-			staticList.push_back(&room->mesh[j]);
+			staticList.push_back(&room->Statics[j]);
 		}
 	}
 
@@ -1499,16 +1499,16 @@ void ItemsCollideCamera()
 		if (!mesh)
 			return;
 
-		auto distance = Vector3i::Distance(mesh->pos.Position, LaraItem->Pose.Position);
+		auto distance = Vector3i::Distance(mesh->Pose.Position, LaraItem->Pose.Position);
 		if (distance > COLL_CANCEL_THRESHOLD)
 			continue;
 
 		auto bounds = GetBoundsAccurate(*mesh, false);
-		if (TestBoundsCollideCamera(bounds, mesh->pos, CAMERA_RADIUS))
-			ItemPushCamera(&bounds, &mesh->pos, RADIUS);
+		if (TestBoundsCollideCamera(bounds, mesh->Pose, CAMERA_RADIUS))
+			ItemPushCamera(&bounds, &mesh->Pose, RADIUS);
 
 		TEN::Renderer::g_Renderer.AddDebugBox(
-			bounds.ToBoundingOrientedBox(mesh->pos),
+			bounds.ToBoundingOrientedBox(mesh->Pose),
 			Vector4(1.0f, 0.0f, 0.0f, 1.0f), RendererDebugPage::CollisionStats);
 	}
 

--- a/TombEngine/Game/collision/collide_item.h
+++ b/TombEngine/Game/collision/collide_item.h
@@ -5,7 +5,7 @@ class FloorInfo;
 struct CollisionInfo;
 struct CollisionResult;
 struct ItemInfo;
-struct MESH_INFO;
+class StaticObject;
 
 constexpr auto ITEM_RADIUS_YMAX					   = BLOCK(3);
 constexpr auto VEHICLE_COLLISION_TERMINAL_VELOCITY = 30.0f;
@@ -27,8 +27,8 @@ struct ObjectCollisionBounds
 
 struct CollidedObjectData
 {
-	std::vector<ItemInfo*>	ItemPtrs   = {};
-	std::vector<MESH_INFO*> StaticPtrs = {};
+	std::vector<ItemInfo*>	   ItemPtrs	  = {};
+	std::vector<StaticObject*> StaticPtrs = {};
 
 	bool IsEmpty() const { return (ItemPtrs.empty() && StaticPtrs.empty()); };
 };
@@ -48,10 +48,10 @@ bool ItemNearTarget(const Vector3i& origin, ItemInfo* targetEntity, int radius);
 bool Move3DPosTo3DPos(ItemInfo* item, Pose& fromPose, const Pose& toPose, int velocity, short turnRate);
 
 bool TestBoundsCollide(ItemInfo* item, ItemInfo* laraItem, int radius);
-bool TestBoundsCollideStatic(ItemInfo* item, const MESH_INFO& mesh, int radius);
+bool TestBoundsCollideStatic(ItemInfo* item, const StaticObject& mesh, int radius);
 bool ItemPushItem(ItemInfo* item0, ItemInfo* item1, CollisionInfo* coll, bool enableSpasm, char bigPushFlags);
 bool ItemPushItem(ItemInfo* item, ItemInfo* item2);
-bool ItemPushStatic(ItemInfo* laraItem, const MESH_INFO& mesh, CollisionInfo* coll);
+bool ItemPushStatic(ItemInfo* laraItem, const StaticObject& mesh, CollisionInfo* coll);
 void ItemPushBridge(ItemInfo& item, CollisionInfo& coll);
 
 bool CollideSolidBounds(ItemInfo* item, const GameBoundingBox& box, const Pose& pose, CollisionInfo* coll);

--- a/TombEngine/Game/collision/collide_room.h
+++ b/TombEngine/Game/collision/collide_room.h
@@ -3,11 +3,11 @@
 #include "Math/Math.h"
 #include "Objects/game_object_ids.h"
 
-struct ItemInfo;
 class FloorInfo;
-struct ROOM_INFO;
-struct MESH_INFO;
+class StaticObject;
 enum RoomEnvFlags;
+struct ItemInfo;
+struct ROOM_INFO;
 
 constexpr auto NO_LOWER_BOUND = -NO_HEIGHT;	// Used by coll->Setup.LowerFloorBound.
 constexpr auto NO_UPPER_BOUND = NO_HEIGHT;	// Used by coll->Setup.UpperFloorBound.

--- a/TombEngine/Game/control/box.cpp
+++ b/TombEngine/Game/control/box.cpp
@@ -2141,9 +2141,9 @@ void InitializeItemBoxData()
 
 	for (auto& room : g_Level.Rooms)
 	{
-		for (const auto& mesh : room.mesh)
+		for (const auto& mesh : room.Statics)
 		{
-			long index = ((mesh.pos.Position.z - room.z) / BLOCK(1)) + room.zSize * ((mesh.pos.Position.x - room.x) / BLOCK(1));
+			long index = ((mesh.Pose.Position.z - room.z) / BLOCK(1)) + room.zSize * ((mesh.Pose.Position.x - room.x) / BLOCK(1));
 			if (index > room.floor.size())
 				continue;
 
@@ -2153,11 +2153,11 @@ void InitializeItemBoxData()
 
 			if (!(g_Level.Boxes[floor->Box].flags & BLOCKED))
 			{
-				int floorHeight = floor->GetSurfaceHeight(mesh.pos.Position.x, mesh.pos.Position.z, true);
+				int floorHeight = floor->GetSurfaceHeight(mesh.Pose.Position.x, mesh.Pose.Position.z, true);
 				const auto& bBox = GetBoundsAccurate(mesh, false);
 
-				if (floorHeight <= mesh.pos.Position.y - bBox.Y2 + CLICK(2) &&
-					floorHeight < mesh.pos.Position.y - bBox.Y1)
+				if (floorHeight <= mesh.Pose.Position.y - bBox.Y2 + CLICK(2) &&
+					floorHeight < mesh.Pose.Position.y - bBox.Y1)
 				{
 					if (bBox.X1 == 0 || bBox.X2 == 0 || bBox.Z1 == 0 || bBox.Z2 == 0 ||
 					  ((bBox.X1 < 0) ^ (bBox.X2 < 0)) && ((bBox.Z1 < 0) ^ (bBox.Z2 < 0)))

--- a/TombEngine/Game/control/control.cpp
+++ b/TombEngine/Game/control/control.cpp
@@ -342,14 +342,14 @@ void UpdateShatters()
 		SmashedMeshCount--;
 
 		auto* floor = GetFloor(
-			SmashedMesh[SmashedMeshCount]->pos.Position.x,
-			SmashedMesh[SmashedMeshCount]->pos.Position.y,
-			SmashedMesh[SmashedMeshCount]->pos.Position.z,
+			SmashedMesh[SmashedMeshCount]->Pose.Position.x,
+			SmashedMesh[SmashedMeshCount]->Pose.Position.y,
+			SmashedMesh[SmashedMeshCount]->Pose.Position.z,
 			&SmashedMeshRoom[SmashedMeshCount]);
 
-		TestTriggers(SmashedMesh[SmashedMeshCount]->pos.Position.x,
-			SmashedMesh[SmashedMeshCount]->pos.Position.y,
-			SmashedMesh[SmashedMeshCount]->pos.Position.z,
+		TestTriggers(SmashedMesh[SmashedMeshCount]->Pose.Position.x,
+			SmashedMesh[SmashedMeshCount]->Pose.Position.y,
+			SmashedMesh[SmashedMeshCount]->Pose.Position.z,
 			SmashedMeshRoom[SmashedMeshCount], true);
 
 		TestVolumes(SmashedMeshRoom[SmashedMeshCount], SmashedMesh[SmashedMeshCount]);

--- a/TombEngine/Game/control/control.h
+++ b/TombEngine/Game/control/control.h
@@ -10,7 +10,7 @@ class GameBoundingBox;
 struct AnimData;
 struct CollisionInfo;
 struct ItemInfo;
-struct MESH_INFO;
+class StaticObject;
 struct ROOM_INFO;
 
 enum class GameStatus

--- a/TombEngine/Game/control/event.h
+++ b/TombEngine/Game/control/event.h
@@ -2,7 +2,7 @@
 #include <variant>
 
 struct CAMERA_INFO;
-struct MESH_INFO;
+class StaticObject;
 
 namespace TEN::Control::Volumes
 {
@@ -11,7 +11,7 @@ namespace TEN::Control::Volumes
 	using Activator = std::variant<
 		std::nullptr_t,
 		short,
-		MESH_INFO*,
+		StaticObject*,
 		CAMERA_INFO*>;
 
 	enum class ActivatorFlags

--- a/TombEngine/Game/control/los.h
+++ b/TombEngine/Game/control/los.h
@@ -7,7 +7,7 @@ constexpr auto NO_LOS_ITEM = INT_MAX;
 
 bool LOS(const GameVector* origin, GameVector* target);
 bool GetTargetOnLOS(GameVector* origin, GameVector* target, bool drawTarget, bool isFiring);
-int	 ObjectOnLOS2(GameVector* origin, GameVector* target, Vector3i* vec, MESH_INFO** mesh, GAME_OBJECT_ID priorityObjectID = GAME_OBJECT_ID::ID_NO_OBJECT);
+int	 ObjectOnLOS2(GameVector* origin, GameVector* target, Vector3i* vec, StaticObject** mesh, GAME_OBJECT_ID priorityObjectID = GAME_OBJECT_ID::ID_NO_OBJECT);
 bool LOSAndReturnTarget(GameVector* origin, GameVector* target, int push);
 
 std::optional<Vector3> GetStaticObjectLos(const Vector3& origin, int roomNumber, const Vector3& dir, float dist, bool onlySolid);

--- a/TombEngine/Game/control/volume.cpp
+++ b/TombEngine/Game/control/volume.cpp
@@ -237,9 +237,9 @@ namespace TEN::Control::Volumes
 		TestVolumes(camera->pos.RoomNumber, box, ActivatorFlags::Flyby, camera);
 	}
 
-	void TestVolumes(short roomNumber, MESH_INFO* mesh)
+	void TestVolumes(short roomNumber, StaticObject* mesh)
 	{
-		auto box = GetBoundsAccurate(*mesh, false).ToBoundingOrientedBox(mesh->pos);
+		auto box = GetBoundsAccurate(*mesh, false).ToBoundingOrientedBox(mesh->Pose);
 		
 		TestVolumes(roomNumber, box, ActivatorFlags::Static, mesh);
 	}

--- a/TombEngine/Game/control/volume.h
+++ b/TombEngine/Game/control/volume.h
@@ -40,7 +40,7 @@ namespace TEN::Control::Volumes
 
 	void TestVolumes(short roomNumber, const BoundingOrientedBox& box, ActivatorFlags activatorFlag, Activator activator);
 	void TestVolumes(short itemNumber, const CollisionSetup* coll = nullptr);
-	void TestVolumes(short roomNumber, MESH_INFO* mesh);
+	void TestVolumes(short roomNumber, StaticObject* mesh);
 	void TestVolumes(CAMERA_INFO* camera);
 
 	void HandleEvent(Event& event, Activator& activator);

--- a/TombEngine/Game/effects/debris.cpp
+++ b/TombEngine/Game/effects/debris.cpp
@@ -14,7 +14,7 @@ using namespace TEN::Math::Random;
 ShatterImpactInfo ShatterImpactData;
 SHATTER_ITEM ShatterItem;
 short SmashedMeshCount;
-MESH_INFO* SmashedMesh[32];
+StaticObject* SmashedMesh[32];
 short SmashedMeshRoom[32];
 std::array<DebrisFragment, MAX_DEBRIS> DebrisFragments;
 
@@ -57,7 +57,7 @@ DebrisFragment* GetFreeDebrisFragment()
 	return nullptr;
 }
 
-void ShatterObject(SHATTER_ITEM* item, MESH_INFO* mesh, int num, short roomNumber, int noZXVel)
+void ShatterObject(SHATTER_ITEM* item, StaticObject* staticPtr, int num, short roomNumber, int noZXVel)
 {
 	int meshIndex = 0;
 	short yRot = 0;
@@ -65,22 +65,22 @@ void ShatterObject(SHATTER_ITEM* item, MESH_INFO* mesh, int num, short roomNumbe
 	Vector3 pos;
 	bool isStatic;
 
-	if (mesh)
+	if (staticPtr != nullptr)
 	{
-		if (!(mesh->flags & StaticMeshFlags::SM_VISIBLE))
+		if (!(staticPtr->Flags & StaticMeshFlags::SM_VISIBLE))
 			return;
 
 		isStatic = true;
-		meshIndex = StaticObjects[mesh->staticNumber].meshNumber;
-		yRot = mesh->pos.Orientation.y;
-		pos = Vector3(mesh->pos.Position.x, mesh->pos.Position.y, mesh->pos.Position.z);
-		scale = mesh->scale;
+		meshIndex = staticPtr->AssetPtr->meshNumber;
+		yRot = staticPtr->Pose.Orientation.y;
+		pos = Vector3(staticPtr->Pose.Position.x, staticPtr->Pose.Position.y, staticPtr->Pose.Position.z);
+		scale = staticPtr->Scale;
 
-		if (mesh->HitPoints <= 0)
-			mesh->flags &= ~StaticMeshFlags::SM_VISIBLE;
+		if (staticPtr->HitPoints <= 0)
+			staticPtr->Flags &= ~StaticMeshFlags::SM_VISIBLE;
 
 		SmashedMeshRoom[SmashedMeshCount] = roomNumber;
-		SmashedMesh[SmashedMeshCount] = mesh;
+		SmashedMesh[SmashedMeshCount] = staticPtr;
 		SmashedMeshCount++;
 	}
 	else
@@ -182,7 +182,7 @@ void ShatterObject(SHATTER_ITEM* item, MESH_INFO* mesh, int num, short roomNumbe
 				fragment->velocity = CalculateFragmentImpactVelocity(fragment->worldPosition, ShatterImpactData.impactDirection, ShatterImpactData.impactLocation);
 				fragment->roomNumber = roomNumber;
 				fragment->numBounces = 0;
-				fragment->color = isStatic ? mesh->color : item->color;
+				fragment->color = isStatic ? staticPtr->Color : item->color;
 				fragment->lightMode = fragmentsMesh->lightMode;
 			}
 		}

--- a/TombEngine/Game/effects/debris.h
+++ b/TombEngine/Game/effects/debris.h
@@ -77,11 +77,11 @@ extern SHATTER_ITEM ShatterItem;
 extern std::array<DebrisFragment, MAX_DEBRIS> DebrisFragments;
 extern ShatterImpactInfo ShatterImpactData;
 extern short SmashedMeshCount;
-extern MESH_INFO* SmashedMesh[32];
+extern StaticObject* SmashedMesh[32];
 extern short SmashedMeshRoom[32];
 
 bool ExplodeItemNode(ItemInfo* item, int node, int noXZVel, int bits);
-void ShatterObject(SHATTER_ITEM* item, MESH_INFO* mesh, int num, short roomNumber, int noZXVel);
+void ShatterObject(SHATTER_ITEM* item, StaticObject* staticPtr, int num, short roomNumber, int noZXVel);
 DebrisFragment* GetFreeDebrisFragment();
 Vector3 CalculateFragmentImpactVelocity(const Vector3& fragmentWorldPosition, const Vector3& impactDirection, const Vector3& impactLocation);
 void DisableDebris();

--- a/TombEngine/Game/people.cpp
+++ b/TombEngine/Game/people.cpp
@@ -133,7 +133,7 @@ bool Targetable(ItemInfo* item, AI_INFO* ai)
 		enemy->Pose.Position.z,
 		enemy->RoomNumber); // TODO: Check why this line didn't exist in the first place. -- TokyoSU 2022.08.05
 
-	MESH_INFO* mesh = nullptr;
+	StaticObject* mesh = nullptr;
 	Vector3i vector = {};
 	int losItemIndex = ObjectOnLOS2(&origin, &target, &vector, &mesh);
 	if (losItemIndex == item->Index)

--- a/TombEngine/Game/pickup/pickup.cpp
+++ b/TombEngine/Game/pickup/pickup.cpp
@@ -894,11 +894,9 @@ void DropPickups(ItemInfo* item)
 			}
 		}
 
-		for (auto* staticPtr : collObjects.StaticPtrs)
+		for (const auto* staticPtr : collObjects.StaticPtrs)
 		{
-			auto& object = StaticObjects[staticPtr->staticNumber];
-
-			auto box = object.collisionBox.ToBoundingOrientedBox(staticPtr->pos);
+			auto box = staticPtr->AssetPtr->collisionBox.ToBoundingOrientedBox(staticPtr->Pose);
 			if (box.Intersects(sphere))
 			{
 				collidedWithObject = true;
@@ -994,14 +992,14 @@ const GameBoundingBox* FindPlinth(ItemInfo* item)
 {
 	auto* room = &g_Level.Rooms[item->RoomNumber];
 	
-	for (int i = 0; i < room->mesh.size(); i++)
+	for (int i = 0; i < room->Statics.size(); i++)
 	{
-		auto* mesh = &room->mesh[i];
+		auto* mesh = &room->Statics[i];
 
-		if (!(mesh->flags & StaticMeshFlags::SM_VISIBLE))
+		if (!(mesh->Flags & StaticMeshFlags::SM_VISIBLE))
 			continue;
 
-		if (item->Pose.Position.x != mesh->pos.Position.x || item->Pose.Position.z != mesh->pos.Position.z)
+		if (item->Pose.Position.x != mesh->Pose.Position.x || item->Pose.Position.z != mesh->Pose.Position.z)
 			continue;
 
 		const auto& bounds = GetBestFrame(*item).BoundingBox;

--- a/TombEngine/Game/room.cpp
+++ b/TombEngine/Game/room.cpp
@@ -194,17 +194,19 @@ FloorInfo* GetSector(ROOM_INFO* room, int x, int z)
 	return &room->floor[sectorID];
 }
 
-GameBoundingBox& GetBoundsAccurate(const MESH_INFO& mesh, bool getVisibilityBox)
+GameBoundingBox& GetBoundsAccurate(const StaticObject& staticObj, bool getVisibilityBox)
 {
 	static auto bounds = GameBoundingBox();
 
 	if (getVisibilityBox)
 	{
-		bounds = StaticObjects[mesh.staticNumber].visibilityBox * mesh.scale;
+		staticObj.AssetPtr->ID;
+
+		bounds = staticObj.AssetPtr->visibilityBox * staticObj.Scale;
 	}
 	else
 	{
-		bounds = StaticObjects[mesh.staticNumber].collisionBox * mesh.scale;
+		bounds = staticObj.AssetPtr->collisionBox * staticObj.Scale;
 	}
 
 	return bounds;

--- a/TombEngine/Game/room.h
+++ b/TombEngine/Game/room.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "Game/StaticObject.h"
 #include "Math/Math.h"
 
 using namespace TEN::Math;
@@ -72,19 +73,6 @@ struct ROOM_LIGHT
 	bool castShadows;
 };
 
-struct MESH_INFO
-{
-	Pose pos;
-	int roomNumber;
-	float scale;
-	short staticNumber;
-	short flags;
-	Vector4 color;
-	short HitPoints;
-	std::string Name;
-	bool Dirty;
-};
-
 struct ROOM_INFO
 {
 	int index;
@@ -110,7 +98,7 @@ struct ROOM_INFO
 
 	std::vector<FloorInfo>	   floor		  = {};
 	std::vector<ROOM_LIGHT>	   lights		  = {};
-	std::vector<MESH_INFO>	   mesh			  = {};
+	std::vector<StaticObject>  Statics		  = {};
 	std::vector<TriggerVolume> triggerVolumes = {};
 
 	std::vector<Vector3>   positions = {};
@@ -133,5 +121,5 @@ Vector3i GetRoomCenter(int roomNumber);
 int IsRoomOutside(int x, int y, int z);
 void InitializeNeighborRoomList();
 
-GameBoundingBox& GetBoundsAccurate(const MESH_INFO& mesh, bool getVisibilityBox);
+GameBoundingBox& GetBoundsAccurate(const StaticObject& staticObj, bool getVisibilityBox);
 FloorInfo* GetSector(ROOM_INFO* room, int x, int z);

--- a/TombEngine/Game/savegame.cpp
+++ b/TombEngine/Game/savegame.cpp
@@ -981,16 +981,16 @@ const std::vector<byte> SaveGame::Build()
 	{
 		auto* room = &g_Level.Rooms[i];
 
-		for (int j = 0; j < room->mesh.size(); j++)
+		for (int j = 0; j < room->Statics.size(); j++)
 		{
 			Save::StaticMeshInfoBuilder staticMesh{ fbb };
 
-			staticMesh.add_pose(&FromPose(room->mesh[j].pos));
-			staticMesh.add_scale(room->mesh[j].scale);
-			staticMesh.add_color(&FromVector4(room->mesh[j].color));
+			staticMesh.add_pose(&FromPose(room->Statics[j].Pose));
+			staticMesh.add_scale(room->Statics[j].Scale);
+			staticMesh.add_color(&FromVector4(room->Statics[j].Color));
 
-			staticMesh.add_flags(room->mesh[j].flags);
-			staticMesh.add_hit_points(room->mesh[j].HitPoints);
+			staticMesh.add_flags(room->Statics[j].Flags);
+			staticMesh.add_hit_points(room->Statics[j].HitPoints);
 			staticMesh.add_room_number(room->index);
 			staticMesh.add_number(j);
 			staticMeshes.push_back(staticMesh.Finish());
@@ -2167,19 +2167,19 @@ static void ParseLevel(const Save::SaveGame* s, bool hubMode)
 		auto room = &g_Level.Rooms[staticMesh->room_number()];
 		int number = staticMesh->number();
 
-		room->mesh[number].pos = ToPose(*staticMesh->pose());
-		room->mesh[number].roomNumber = staticMesh->room_number();
-		room->mesh[number].scale = staticMesh->scale();
-		room->mesh[number].color = ToVector4(staticMesh->color());
+		room->Statics[number].Pose = ToPose(*staticMesh->pose());
+		room->Statics[number].RoomNumber = staticMesh->room_number();
+		room->Statics[number].Scale = staticMesh->scale();
+		room->Statics[number].Color = ToVector4(staticMesh->color());
 
-		room->mesh[number].flags = staticMesh->flags();
-		room->mesh[number].HitPoints = staticMesh->hit_points();
+		room->Statics[number].Flags = staticMesh->flags();
+		room->Statics[number].HitPoints = staticMesh->hit_points();
 		
-		if (!room->mesh[number].flags)
+		if (!room->Statics[number].Flags)
 		{
 			short roomNumber = staticMesh->room_number();
-			FloorInfo* floor = GetFloor(room->mesh[number].pos.Position.x, room->mesh[number].pos.Position.y, room->mesh[number].pos.Position.z, &roomNumber);
-			TestTriggers(room->mesh[number].pos.Position.x, room->mesh[number].pos.Position.y, room->mesh[number].pos.Position.z, staticMesh->room_number(), true, 0);
+			FloorInfo* floor = GetFloor(room->Statics[number].Pose.Position.x, room->Statics[number].Pose.Position.y, room->Statics[number].Pose.Position.z, &roomNumber);
+			TestTriggers(room->Statics[number].Pose.Position.x, room->Statics[number].Pose.Position.y, room->Statics[number].Pose.Position.z, staticMesh->room_number(), true, 0);
 			floor->Stopper = false;
 		}
 	}

--- a/TombEngine/Objects/TR4/Entity/tr4_knight_templar.cpp
+++ b/TombEngine/Objects/TR4/Entity/tr4_knight_templar.cpp
@@ -190,13 +190,13 @@ namespace TEN::Entities::TR4
 
 				if (currentFloor.Stopper)
 				{
-					for (auto& mesh : room.mesh)
+					for (auto& staticObj : room.Statics)
 					{
-						if (abs(pos.x - mesh.pos.Position.x) < BLOCK(1) &&
-							abs(pos.z - mesh.pos.Position.z) < BLOCK(1) &&
-							StaticObjects[mesh.staticNumber].shatterType == ShatterType::None)
+						if (abs(pos.x - staticObj.Pose.Position.x) < BLOCK(1) &&
+							abs(pos.z - staticObj.Pose.Position.z) < BLOCK(1) &&
+							staticObj.AssetPtr->shatterType == ShatterType::None)
 						{
-							ShatterObject(nullptr, &mesh, -64, LaraItem->RoomNumber, 0);
+							ShatterObject(nullptr, &staticObj, -64, LaraItem->RoomNumber, 0);
 							SoundEffect(SFX_TR4_SMASH_ROCK, &item->Pose);
 
 							currentFloor.Stopper = false;

--- a/TombEngine/Objects/TR4/Entity/tr4_skeleton.cpp
+++ b/TombEngine/Objects/TR4/Entity/tr4_skeleton.cpp
@@ -644,15 +644,15 @@ namespace TEN::Entities::TR4
 					auto floor = GetCollision(x, y, z, item->RoomNumber).Block;
 					if (floor->Stopper)
 					{
-						for (int i = 0; i < room->mesh.size(); i++)
+						for (int i = 0; i < room->Statics.size(); i++)
 						{
-							auto* staticMesh = &room->mesh[i];
+							auto& staticObj = room->Statics[i];
 
-							if (abs(pos.x - staticMesh->pos.Position.x) < BLOCK(1) && 
-								abs(pos.z - staticMesh->pos.Position.z) < BLOCK(1) &&
-								StaticObjects[staticMesh->staticNumber].shatterType != ShatterType::None)
+							if (abs(pos.x - staticObj.Pose.Position.x) < BLOCK(1) && 
+								abs(pos.z - staticObj.Pose.Position.z) < BLOCK(1) &&
+								staticObj.AssetPtr->shatterType != ShatterType::None)
 							{
-								ShatterObject(0, staticMesh, -128, LaraItem->RoomNumber, 0);
+								ShatterObject(0, &staticObj, -128, LaraItem->RoomNumber, 0);
 								SoundEffect(SFX_TR4_SMASH_ROCK, &item->Pose);
 								floor->Stopper = false;
 								TestTriggers(item, true);

--- a/TombEngine/Objects/TR4/Entity/tr4_sphinx.cpp
+++ b/TombEngine/Objects/TR4/Entity/tr4_sphinx.cpp
@@ -86,15 +86,15 @@ namespace TEN::Entities::TR4
 		{
 			auto* room = &g_Level.Rooms[item->RoomNumber];
 
-			for (int i = 0; i < room->mesh.size(); i++)
+			for (int i = 0; i < room->Statics.size(); i++)
 			{
-				auto* mesh = &room->mesh[i];
+				auto* staticPtr = &room->Statics[i];
 
-				if (((mesh->pos.Position.z / BLOCK(1)) == (z / BLOCK(1))) &&
-					((mesh->pos.Position.x / BLOCK(1)) == (x / BLOCK(1))) &&
-					StaticObjects[mesh->staticNumber].shatterType != ShatterType::None)
+				if (((staticPtr->Pose.Position.z / BLOCK(1)) == (z / BLOCK(1))) &&
+					((staticPtr->Pose.Position.x / BLOCK(1)) == (x / BLOCK(1))) &&
+					staticPtr->AssetPtr->shatterType != ShatterType::None)
 				{
-					ShatterObject(nullptr, mesh, -64, item->RoomNumber, 0);
+					ShatterObject(nullptr, staticPtr, -64, item->RoomNumber, 0);
 					SoundEffect(SFX_TR4_SMASH_ROCK, &item->Pose);
 
 					probe.Block = false;

--- a/TombEngine/Objects/TR4/Trap/SpikyWall.cpp
+++ b/TombEngine/Objects/TR4/Trap/SpikyWall.cpp
@@ -82,19 +82,19 @@ namespace TEN::Entities::Traps
 			pointColl1.Block->Stopper)
 		{
 			auto& room = g_Level.Rooms[item.RoomNumber];
-			for (auto& mesh : room.mesh)
+			for (auto& staticObj : room.Statics)
 			{
-				if ((abs(pointColl0.Coordinates.x - mesh.pos.Position.x) < BLOCK(1) &&
-					abs(pointColl0.Coordinates.z - mesh.pos.Position.z) < BLOCK(1)) ||
-					abs(pointColl1.Coordinates.x - mesh.pos.Position.x) < BLOCK(1) &&
-					abs(pointColl1.Coordinates.z - mesh.pos.Position.z) < BLOCK(1) &&
-					StaticObjects[mesh.staticNumber].shatterType != ShatterType::None)
+				if ((abs(pointColl0.Coordinates.x - staticObj.Pose.Position.x) < BLOCK(1) &&
+					abs(pointColl0.Coordinates.z - staticObj.Pose.Position.z) < BLOCK(1)) ||
+					abs(pointColl1.Coordinates.x - staticObj.Pose.Position.x) < BLOCK(1) &&
+					abs(pointColl1.Coordinates.z - staticObj.Pose.Position.z) < BLOCK(1) &&
+					staticObj.AssetPtr->shatterType != ShatterType::None)
 				{					
-					if (mesh.HitPoints != 0)
+					if (staticObj.HitPoints != 0)
 						continue;
 
-					mesh.HitPoints -= 1;
-					ShatterObject(nullptr, &mesh, -64, LaraItem->RoomNumber, 0);
+					staticObj.HitPoints -= 1;
+					ShatterObject(nullptr, &staticObj, -64, LaraItem->RoomNumber, 0);
 					SoundEffect(SFX_TR4_SMASH_ROCK, &item.Pose);
 					TestTriggers(item.Pose.Position.x, item.Pose.Position.y, item.Pose.Position.z, item.RoomNumber, true);
 				}

--- a/TombEngine/Objects/TR5/Entity/tr5_gladiator.cpp
+++ b/TombEngine/Objects/TR5/Entity/tr5_gladiator.cpp
@@ -339,17 +339,17 @@ namespace TEN::Entities::Creatures::TR5
 					auto* floor = GetSector(room, pos.x - room->x, pos.z - room->z);
 					if (floor->Stopper)
 					{
-						for (int i = 0; i < room->mesh.size(); i++)
+						for (int i = 0; i < room->Statics.size(); i++)
 						{
-							auto* mesh = &room->mesh[i];
+							auto& staticObj = room->Statics[i];
 
-							if (!((pos.z ^ mesh->pos.Position.z) & 0xFFFFFC00))
+							if (!((pos.z ^ staticObj.Pose.Position.z) & 0xFFFFFC00))
 							{
-								if (!((pos.x ^ mesh->pos.Position.x) & 0xFFFFFC00))
+								if (!((pos.x ^ staticObj.Pose.Position.x) & 0xFFFFFC00))
 								{
-									if (StaticObjects[mesh->staticNumber].shatterType != ShatterType::None)
+									if (staticObj.AssetPtr->shatterType != ShatterType::None)
 									{
-										ShatterObject(0, mesh, -64, LaraItem->RoomNumber, 0);
+										ShatterObject(0, &staticObj, -64, LaraItem->RoomNumber, 0);
 										//SoundEffect(ShatterSounds[gfCurrentLevel - 5][*(v28 + 18)], v28);
 
 										TestTriggers(pos.x, pos.y, pos.z, item->RoomNumber, true);

--- a/TombEngine/Objects/TR5/Entity/tr5_gunship.cpp
+++ b/TombEngine/Objects/TR5/Entity/tr5_gunship.cpp
@@ -88,8 +88,8 @@ namespace TEN::Entities::Creatures::TR5
 				return AnimateItem(item);
 
 			Vector3i hitPos;
-			MESH_INFO* hitMesh = nullptr;
-			int objOnLos = ObjectOnLOS2(&origin, &target, &hitPos, &hitMesh, GAME_OBJECT_ID::ID_LARA);
+			StaticObject* hitStaticPtr = nullptr;
+			int objOnLos = ObjectOnLOS2(&origin, &target, &hitPos, &hitStaticPtr, GAME_OBJECT_ID::ID_LARA);
 
 			if (objOnLos == NO_LOS_ITEM || objOnLos < 0)
 			{
@@ -110,11 +110,11 @@ namespace TEN::Entities::Creatures::TR5
 
 				if (objOnLos < 0 && GetRandomControl() & 1)
 				{
-					if (StaticObjects[hitMesh->staticNumber].shatterType != ShatterType::None)
+					if (hitStaticPtr->AssetPtr->shatterType != ShatterType::None)
 					{
-						ShatterObject(0, hitMesh, 64, target.RoomNumber, 0);
-						TestTriggers(hitMesh->pos.Position.x, hitMesh->pos.Position.y, hitMesh->pos.Position.z, target.RoomNumber, true);
-						SoundEffect(GetShatterSound(hitMesh->staticNumber), &hitMesh->pos);
+						ShatterObject(0, hitStaticPtr, 64, target.RoomNumber, 0);
+						TestTriggers(hitStaticPtr->Pose.Position.x, hitStaticPtr->Pose.Position.y, hitStaticPtr->Pose.Position.z, target.RoomNumber, true);
+						SoundEffect(GetShatterSound(*hitStaticPtr->AssetPtr), &hitStaticPtr->Pose);
 					}
 
 					TriggerRicochetSpark(GameVector(hitPos), 2 * GetRandomControl(), 3, 0);

--- a/TombEngine/Objects/TR5/Entity/tr5_roman_statue.cpp
+++ b/TombEngine/Objects/TR5/Entity/tr5_roman_statue.cpp
@@ -547,16 +547,16 @@ namespace TEN::Entities::Creatures::TR5
 					// If floor is stopped, then try to find static meshes and shatter them, activating heavy triggers below
 					if (floor->Stopper)
 					{
-						for (int i = 0; i < room->mesh.size(); i++)
+						for (int i = 0; i < room->Statics.size(); i++)
 						{
-							auto* mesh = &room->mesh[i];
+							auto& staticObj = room->Statics[i];
 
-							if (!((mesh->pos.Position.z ^ pos.z) & 0xFFFFFC00) && !((mesh->pos.Position.x ^ pos.x) & 0xFFFFFC00))
+							if (!((staticObj.Pose.Position.z ^ pos.z) & 0xFFFFFC00) && !((staticObj.Pose.Position.x ^ pos.x) & 0xFFFFFC00))
 							{
-								if (StaticObjects[mesh->staticNumber].shatterType != ShatterType::None)
+								if (staticObj.AssetPtr->shatterType != ShatterType::None)
 								{
-									ShatterObject(0, mesh, -64, LaraItem->RoomNumber, 0);
-									SoundEffect(GetShatterSound(mesh->staticNumber), (Pose*)mesh);
+									ShatterObject(0, &staticObj, -64, LaraItem->RoomNumber, 0);
+									SoundEffect(GetShatterSound(*staticObj.AssetPtr), &staticObj.Pose);
 
 									floor->Stopper = false;
 

--- a/TombEngine/Objects/TR5/Trap/tr5_explosion.cpp
+++ b/TombEngine/Objects/TR5/Trap/tr5_explosion.cpp
@@ -157,13 +157,13 @@ void ExplosionControl(short itemNumber)
 
 				for (auto* staticPtr : collObjects.StaticPtrs)
 				{
-					if (StaticObjects[staticPtr->staticNumber].shatterType != ShatterType::None)
+					if (staticPtr->AssetPtr->shatterType != ShatterType::None)
 					{
-						TriggerExplosionSparks(staticPtr->pos.Position.x, staticPtr->pos.Position.y, staticPtr->pos.Position.z, 3, -2, 0, item->RoomNumber);
-						staticPtr->pos.Position.y -= 128;
-						TriggerShockwave(&staticPtr->pos, 40, 176, 64, 128, 96, 0, 16, EulerAngles::Identity, 0, true, false, false, (int)ShockwaveStyle::Normal);
-						staticPtr->pos.Position.y += 128;
-						SoundEffect(GetShatterSound(staticPtr->staticNumber), &staticPtr->pos);
+						TriggerExplosionSparks(staticPtr->Pose.Position.x, staticPtr->Pose.Position.y, staticPtr->Pose.Position.z, 3, -2, 0, item->RoomNumber);
+						staticPtr->Pose.Position.y -= 128;
+						TriggerShockwave(&staticPtr->Pose, 40, 176, 64, 128, 96, 0, 16, EulerAngles::Identity, 0, true, false, false, (int)ShockwaveStyle::Normal);
+						staticPtr->Pose.Position.y += 128;
+						SoundEffect(GetShatterSound(*staticPtr->AssetPtr), &staticPtr->Pose);
 						ShatterObject(nullptr, staticPtr, -128, item->RoomNumber, 0);
 					}
 				}

--- a/TombEngine/Renderer/RendererCompatibility.cpp
+++ b/TombEngine/Renderer/RendererCompatibility.cpp
@@ -817,7 +817,7 @@ namespace TEN::Renderer
 		for (int i = 0; i < StaticObjectsIds.size(); i++)
 		{
 			auto staticAssetID = (GAME_OBJECT_ID)StaticObjectsIds[i];
-			auto& staticAsset = GetStaticAsset(staticAssetID);
+			const auto& staticAsset = GetStaticAsset(staticAssetID);
 
 			_staticObjects[staticAssetID] = RendererObject();
 			auto& staticObject = *_staticObjects[staticAssetID];

--- a/TombEngine/Renderer/RendererCompatibility.cpp
+++ b/TombEngine/Renderer/RendererCompatibility.cpp
@@ -28,7 +28,7 @@ namespace TEN::Renderer
 
 		_moveableObjects.resize(ID_NUMBER_OBJECTS);
 		_spriteSequences.resize(ID_NUMBER_OBJECTS);
-		_staticObjects.resize(STATIC_COUNT_MAX);
+		_staticObjects.resize(STATIC_ASSET_COUNT_MAX);
 		_rooms.resize(g_Level.Rooms.size());
 
 		_meshes.clear();
@@ -798,8 +798,8 @@ namespace TEN::Renderer
 		totalIndices = 0;
 		for (int i = 0; i < StaticObjectsIds.size(); i++)
 		{
-			int staticID = StaticObjectsIds[i];
-			const auto& staticObj = StaticObjects[staticID];
+			auto staticID = (GAME_OBJECT_ID)StaticObjectsIds[i];
+			const auto& staticObj = GetStaticAsset(staticID);
 			const auto& mesh = g_Level.Meshes[staticObj.meshNumber];
 
 			for (auto& bucket : mesh.buckets)
@@ -816,8 +816,8 @@ namespace TEN::Renderer
 		lastIndex = 0;
 		for (int i = 0; i < StaticObjectsIds.size(); i++)
 		{
-			int staticAssetID = StaticObjectsIds[i];
-			auto& staticAsset = StaticObjects[staticAssetID];
+			auto staticAssetID = (GAME_OBJECT_ID)StaticObjectsIds[i];
+			auto& staticAsset = GetStaticAsset(staticAssetID);
 
 			_staticObjects[staticAssetID] = RendererObject();
 			auto& staticObject = *_staticObjects[staticAssetID];

--- a/TombEngine/Scripting/Include/VarMapVal.h
+++ b/TombEngine/Scripting/Include/VarMapVal.h
@@ -1,6 +1,6 @@
 #pragma once
 
-struct MESH_INFO;
+class StaticObject;
 struct LevelCameraInfo;
 struct SinkInfo;
 struct SoundSourceInfo;
@@ -10,7 +10,7 @@ struct ROOM_INFO;
 
 using VarMapVal = std::variant<
 	short,
-	std::reference_wrapper<MESH_INFO>,
+	std::reference_wrapper<StaticObject>,
 	std::reference_wrapper<LevelCameraInfo>,
 	std::reference_wrapper<SinkInfo>,
 	std::reference_wrapper<SoundSourceInfo>,

--- a/TombEngine/Scripting/Internal/TEN/Objects/ObjectsHandler.h
+++ b/TombEngine/Scripting/Internal/TEN/Objects/ObjectsHandler.h
@@ -88,12 +88,11 @@ private:
 		std::vector<std::unique_ptr<R>> items = {};
 		for (auto& [key, val] : m_nameMap)
 		{
-			if (!std::holds_alternative<std::reference_wrapper<MESH_INFO>>(val))
+			if (!std::holds_alternative<std::reference_wrapper<StaticObject>>(val))
 				continue;
 			
-			auto meshInfo = std::get<std::reference_wrapper<MESH_INFO>>(val).get();
-
-			if (meshInfo.staticNumber == slot)
+			const auto& staticObj = std::get<std::reference_wrapper<StaticObject>>(val).get();
+			if (staticObj.AssetPtr->ID == slot)
 				items.push_back(GetByName<Static, ScriptReserved_Static>(key));
 		}
 

--- a/TombEngine/Scripting/Internal/TEN/Objects/Static/StaticObject.cpp
+++ b/TombEngine/Scripting/Internal/TEN/Objects/Static/StaticObject.cpp
@@ -18,10 +18,6 @@
 static auto IndexError = index_error_maker(Static, ScriptReserved_Static);
 static auto NewIndexError = newindex_error_maker(Static, ScriptReserved_Static);
 
-Static::Static(StaticObject& staticObj) : _static(staticObj)
-{
-};
-
 void Static::Register(sol::table& parent)
 {
 	parent.new_usertype<Static>(
@@ -53,6 +49,10 @@ void Static::Register(sol::table& parent)
 		ScriptReserved_Disable, &Static::Disable,
 		ScriptReserved_Shatter, &Static::Shatter);
 }
+
+Static::Static(StaticObject& staticObj) : _static(staticObj)
+{
+};
 
 /// Get this static's unique string identifier.
 // @function Static:GetName()

--- a/TombEngine/Scripting/Internal/TEN/Objects/Static/StaticObject.cpp
+++ b/TombEngine/Scripting/Internal/TEN/Objects/Static/StaticObject.cpp
@@ -156,8 +156,8 @@ void Static::SetName(const std::string& name)
 
 /// Set this static's slot ID.
 // @function Static:SetSlot()
-// @tparam int slot New slot ID.
-void Static::SetSlotID(int slotID)
+// @tparam Objects.ObjID slot New slot ID.
+void Static::SetSlotID(GAME_OBJECT_ID slotID)
 {
 	_static.AssetPtr = &GetStaticAsset(slotID);
 	_static.IsDirty = true;

--- a/TombEngine/Scripting/Internal/TEN/Objects/Static/StaticObject.h
+++ b/TombEngine/Scripting/Internal/TEN/Objects/Static/StaticObject.h
@@ -1,49 +1,54 @@
 #pragma once
-
-#include "Scripting/Internal/TEN/Objects/NamedBase.h"
 #include "Game/room.h"
+#include "Scripting/Internal/TEN/Objects/NamedBase.h"
 
-namespace sol {
-	class state;
-}
-
+namespace sol {	class state; }
 class Vec3;
 class Rotation;
 class ScriptColor;
 
-class Static : public NamedBase<Static, MESH_INFO&>
+class Static : public NamedBase<Static, StaticObject&>
 {
 public:
-	using IdentifierType = std::reference_wrapper<MESH_INFO>;
-	Static(MESH_INFO& id);
+	using IdentifierType = std::reference_wrapper<StaticObject>;
+
+	static void Register(sol::table& parent);
+
+	// Constructors and destructors
+	Static(StaticObject& staticObj);
 	~Static() = default;
 
-	Static& operator=(Static const& other) = delete;
-	Static(Static const& other) = delete;
+	Static(const Static& staticObj) = delete;
 
-	static void Register(sol::table & parent);
+	// Getters
+	std::string GetName() const;
+	int			GetSlotID() const;
+	Vec3		GetPosition() const;
+	Rotation	GetRotation() const;
+	float		GetScale() const;
+	ScriptColor GetColor() const;
+	int			GetHitPoints() const;
+	bool		GetSolid() const;
+	bool		GetActive() const;
 
+	// Setters
+	void SetName(const std::string& name);
+	void SetSlotID(int slotID);
+	void SetPosition(const Vec3& pos);
+	void SetRotation(const Rotation& rot);
+	void SetScale(float scale);
+	void SetColor(const ScriptColor& color);
+	void SetHitPoints(int hitPoints);
+	void SetSolid(bool isSolid);
+
+	// Utilities
 	void Enable();
 	void Disable();
-	bool GetActive();
-	bool GetSolid();
-	void SetSolid(bool yes);
-	Rotation GetRot() const;
-	void SetRot(Rotation const& rot);
-	Vec3 GetPos() const;
-	void SetPos(Vec3 const& pos);
-	float GetScale() const;
-	void SetScale(float const& scale);
-	int GetHP() const;
-	void SetHP(short hitPoints);
-	std::string GetName() const;
-	void SetName(std::string const& name);
-	int GetSlot() const;
-	void SetSlot(int slot);
-	ScriptColor GetColor() const;
-	void SetColor(ScriptColor const& col);
 	void Shatter();
 
+	// Operators
+	Static& operator =(const Static& staticObj) = delete;
+
 private:
-	MESH_INFO & m_mesh;
+	StaticObject& _static;
 };

--- a/TombEngine/Scripting/Internal/TEN/Objects/Static/StaticObject.h
+++ b/TombEngine/Scripting/Internal/TEN/Objects/Static/StaticObject.h
@@ -16,9 +16,8 @@ public:
 
 	// Constructors and destructors
 	Static(StaticObject& staticObj);
-	~Static() = default;
-
 	Static(const Static& staticObj) = delete;
+	~Static() = default;
 
 	// Getters
 	std::string GetName() const;

--- a/TombEngine/Scripting/Internal/TEN/Objects/Static/StaticObject.h
+++ b/TombEngine/Scripting/Internal/TEN/Objects/Static/StaticObject.h
@@ -32,7 +32,7 @@ public:
 
 	// Setters
 	void SetName(const std::string& name);
-	void SetSlotID(int slotID);
+	void SetSlotID(GAME_OBJECT_ID slotID);
 	void SetPosition(const Vec3& pos);
 	void SetRotation(const Rotation& rot);
 	void SetScale(float scale);

--- a/TombEngine/Scripting/Internal/TEN/Util/Util.cpp
+++ b/TombEngine/Scripting/Internal/TEN/Util/Util.cpp
@@ -157,7 +157,7 @@ namespace TEN::Scripting::Util
 		auto realScreenPos = PercentToScreen(screenPos.x, screenPos.y);
 		auto ray = GetRayFrom2DPosition(Vector2((int)std::get<0>(realScreenPos), (int)std::get<1>(realScreenPos)));
 
-		MESH_INFO* mesh = nullptr;
+		StaticObject* mesh = nullptr;
 		auto vector = Vector3i::Zero;
 		int itemNumber = ObjectOnLOS2(&ray.first, &ray.second, &vector, &mesh, GAME_OBJECT_ID::ID_LARA);
 

--- a/TombEngine/Sound/sound.cpp
+++ b/TombEngine/Sound/sound.cpp
@@ -1056,16 +1056,21 @@ void PlaySecretTrack()
 	PlaySoundTrack(SoundTracks.at(SecretSoundIndex).Name, SoundTrackType::OneShot);
 }
 
-int GetShatterSound(int shatterID)
+int GetShatterSound(const StaticAsset& asset)
 {
-	auto fxID = StaticObjects[shatterID].shatterSound;
-	if (fxID != -1 && fxID < NUM_SFX)
-		return fxID;
+	auto soundID = asset.shatterSound;
+	if (soundID != NO_VALUE && soundID < NUM_SFX)
+		return soundID;
 
-	if (shatterID < 3)
+	// HACK
+	if (asset.ID < 3)
+	{
 		return SFX_TR5_SMASH_WOOD;
+	}
 	else
+	{
 		return SFX_TR4_SMASH_ROCK;
+	}
 }
 
 void PlaySoundSources()

--- a/TombEngine/Sound/sound.h
+++ b/TombEngine/Sound/sound.h
@@ -160,7 +160,7 @@ void PauseAllSounds(SoundPauseMode mode);
 void ResumeAllSounds(SoundPauseMode mode);
 void SayNo();
 void PlaySoundSources();
-int  GetShatterSound(int shatterID);
+int GetShatterSound(const StaticAsset& asset);
 
 void PlaySoundTrack(const std::string& trackName, SoundTrackType mode, QWORD position = 0);
 void PlaySoundTrack(const std::string& trackName, short mask = 0);

--- a/TombEngine/Specific/level.cpp
+++ b/TombEngine/Specific/level.cpp
@@ -264,7 +264,6 @@ void LoadItems()
 void LoadObjects()
 {
 	Objects.Initialize();
-	//std::memset(g_Level.StaticAssets, 0, sizeof(StaticAsset) * STATIC_ASSET_COUNT_MAX);
 
 	// Load meshes.
 	int meshCount = ReadInt32();
@@ -453,7 +452,7 @@ void LoadObjects()
 		}
 
 		StaticObjectsIds.push_back(id);
-		auto& asset = GetStaticAsset(id);
+		auto& asset = g_Level.StaticAssets[id];
 
 		asset.ID = id;
 		asset.meshNumber = ReadInt32();
@@ -1452,7 +1451,7 @@ void LoadSprites()
 
 		if (spriteID >= ID_NUMBER_OBJECTS)
 		{
-			GetStaticAsset(GAME_OBJECT_ID(spriteID - ID_NUMBER_OBJECTS)).meshNumber = offset;
+			g_Level.StaticAssets[GAME_OBJECT_ID(spriteID - ID_NUMBER_OBJECTS)].meshNumber = offset;
 		}
 		else
 		{

--- a/TombEngine/Specific/level.cpp
+++ b/TombEngine/Specific/level.cpp
@@ -18,6 +18,7 @@
 #include "Game/savegame.h"
 #include "Game/Setup.h"
 #include "Game/spotcam.h"
+#include "Objects/game_object_ids.h"
 #include "Objects/Generic/Doors/generic_doors.h"
 #include "Objects/Sink.h"
 #include "Renderer/Renderer.h"
@@ -263,8 +264,9 @@ void LoadItems()
 void LoadObjects()
 {
 	Objects.Initialize();
-	std::memset(StaticAssets, 0, sizeof(StaticAsset) * STATIC_COUNT_MAX);
+	//std::memset(g_Level.StaticAssets, 0, sizeof(StaticAsset) * STATIC_ASSET_COUNT_MAX);
 
+	// Load meshes.
 	int meshCount = ReadInt32();
 	TENLog("Meshes: " + std::to_string(meshCount), LogLevel::Info);
 
@@ -440,18 +442,18 @@ void LoadObjects()
 
 	for (int i = 0; i < staticCount; i++)
 	{
-		int id = ReadInt32();
-		if (id >= STATIC_COUNT_MAX)
+		auto id = (GAME_OBJECT_ID)ReadInt32();
+		if (id >= STATIC_ASSET_COUNT_MAX)
 		{
 			TENLog(
-				"Attempted to load static ID " + std::to_string(id) + ". Change static ID in WadTool to value below max (" + std::to_string(STATIC_COUNT_MAX) + "). ",
+				"Attempted to load static ID " + std::to_string(id) + ". Change static ID in WadTool to value below max (" + std::to_string(STATIC_ASSET_COUNT_MAX) + "). ",
 				LogLevel::Warning);
 			
-			id = 0;
+			id = (GAME_OBJECT_ID)0;
 		}
 
 		StaticObjectsIds.push_back(id);
-		auto& asset = GetStaticAsset[id];
+		auto& asset = GetStaticAsset(id);
 
 		asset.ID = id;
 		asset.meshNumber = ReadInt32();
@@ -864,7 +866,7 @@ void ReadRooms()
 			staticObj.Scale = ReadFloat();
 			staticObj.Flags = ReadUInt16();
 			staticObj.Color = ReadVector4();
-			staticObj.AssetPtr = &GetStaticAsset(ReadUInt16());
+			staticObj.AssetPtr = &GetStaticAsset((GAME_OBJECT_ID)ReadUInt16());
 			staticObj.HitPoints = ReadInt16();
 			staticObj.Name = ReadString();
 
@@ -1450,7 +1452,7 @@ void LoadSprites()
 
 		if (spriteID >= ID_NUMBER_OBJECTS)
 		{
-			GetStaticAsset(spriteID - ID_NUMBER_OBJECTS).meshNumber = offset;
+			GetStaticAsset(GAME_OBJECT_ID(spriteID - ID_NUMBER_OBJECTS)).meshNumber = offset;
 		}
 		else
 		{

--- a/TombEngine/Specific/level.h
+++ b/TombEngine/Specific/level.h
@@ -14,12 +14,16 @@
 
 using namespace TEN::Control::Volumes;
 
+enum GAME_OBJECT_ID : short;
+struct BOX_INFO;
 struct ChunkId;
 struct LEB128;
+struct OVERLAP;
 struct SampleInfo;
 struct SinkInfo;
-struct BOX_INFO;
-struct OVERLAP;
+struct StaticAsset;
+
+constexpr auto STATIC_ASSET_COUNT_MAX = 1000;
 
 struct TEXTURE
 {
@@ -90,9 +94,10 @@ struct LEVEL
 {
 	// Object data
 	int					  NumItems = 0;
-	std::vector<ItemInfo> Items	   = {};
-	std::vector<MESH>	  Meshes   = {};
-	std::vector<int>	  Bones	   = {};
+	std::vector<ItemInfo> Items	   = {}; // Moveables
+	std::vector<MESH>	  Meshes   = {}; // TODO: Contain in MoveableAsset and StaticAsset.
+	std::vector<int>	  Bones	   = {}; // TODO: Contain in MoveableAsset.
+	std::unordered_map<GAME_OBJECT_ID, StaticAsset> StaticAssets = {};
 
 	// Animation data
 	std::vector<AnimData>				Anims	 = {};

--- a/TombEngine/TombEngine.vcxproj
+++ b/TombEngine/TombEngine.vcxproj
@@ -422,6 +422,7 @@ xcopy /Y "$(SolutionDir)Libs\zlib\x64\*.dll" "$(TargetDir)"</Command>
     <ClInclude Include="Game\savegame.h" />
     <ClInclude Include="Game\Setup.h" />
     <ClInclude Include="Game\spotcam.h" />
+    <ClInclude Include="Game\StaticObject.h" />
     <ClInclude Include="Math\Constants.h" />
     <ClInclude Include="Math\Geometry.h" />
     <ClInclude Include="Math\Interpolation.h" />
@@ -931,6 +932,7 @@ xcopy /Y "$(SolutionDir)Libs\zlib\x64\*.dll" "$(TargetDir)"</Command>
     <ClCompile Include="Game\savegame.cpp" />
     <ClCompile Include="Game\Setup.cpp" />
     <ClCompile Include="Game\spotcam.cpp" />
+    <ClCompile Include="Game\StaticObject.cpp" />
     <ClCompile Include="Math\Geometry.cpp" />
     <ClCompile Include="Math\Interpolation.cpp" />
     <ClCompile Include="Math\Legacy.cpp" />


### PR DESCRIPTION
Foundational refactor of static object structs/classes. A similar refactor will be done to moveables; this is essentially a test run since statics are far less prevalent.

- Move `StaticObjects` global array to `g_Level` and rename it to `StaticAssets`. Temporarily it's been made a `std:unordered_map` because of compilation errors.
- Rename `MESH_INFO` to `StaticObject` and convert it to a class. Move to new dedicated `StaticObject.cpp` and `StaticObject.h` files.
- Rename `StaticInfo` to `StaticAsset` to establish the idea of "loaded assets", overcoming original confusing naming conventions. In-game entities can be "objects" (i.e. `StaticObject`), and the structs they reference for data can be "loaded assets" (i.e. `StaticAsset`). Relation is much clearer.
- Keep const pointers to static assets in the static object instead of a loose slot object ID. Provides better safety and skips the requirement of writing `const auto& object = StaticObjects[staticObj.ObjectID];` every time an asset needs to be accessed.