### PR TITLE
Add Room:GetRoomNumber() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ TombEngine releases are located in this repository (alongside with Tomb Editor):
 * Added Inventory.GetUsedItem(), Inventory.SetUsedItem() and Inventory.ClearUsedItem() functions.
 * Added Input.KeyClearAll()
 * Added Flow.EnableHomeLevel()
+* Added Room:GetRoomNumber()
 * Removed anims.monkeyAutoJump. It is now a player menu configuration.
 * Fixed Volume:GetActive() method
 

--- a/TombEngine/Scripting/Internal/ReservedScriptNames.h
+++ b/TombEngine/Scripting/Internal/ReservedScriptNames.h
@@ -199,6 +199,7 @@ static constexpr char ScriptReserved_GetFlag[]				= "GetFlag";
 static constexpr char ScriptReserved_SetFlag[]				= "SetFlag";
 static constexpr char ScriptReserved_IsTagPresent[]			= "IsTagPresent";
 static constexpr char ScriptReserved_SetReverbType[]		= "SetReverbType";
+static constexpr char ScriptReserved_GetReverbType[]		= "GetReverbType";
 
 // Flow Functions
 static constexpr char ScriptReserved_AddLevel[]					= "AddLevel";

--- a/TombEngine/Scripting/Internal/TEN/Objects/Moveable/MoveableObject.cpp
+++ b/TombEngine/Scripting/Internal/TEN/Objects/Moveable/MoveableObject.cpp
@@ -79,7 +79,7 @@ most can just be ignored (see usage).
 	@tparam string name Lua name of the item
 	@tparam Vec3 position position in level
 	@tparam Rotation rotation rotation rotation about x, y, and z axes (default Rotation(0, 0, 0))
-	@tparam int roomID room ID item is in (default: calculated automatically)
+	@tparam int roomNumber room number item is in (default: calculated automatically)
 	@tparam int animNumber animation number
 	@tparam int frameNumber frame number
 	@tparam int hp HP of item

--- a/TombEngine/Scripting/Internal/TEN/Objects/Room/RoomObject.cpp
+++ b/TombEngine/Scripting/Internal/TEN/Objects/Room/RoomObject.cpp
@@ -51,7 +51,7 @@ void Room::Register(sol::table& parent)
 		/// Get the room's reverb type.
 		// @function Room:GetReverbType
 		// @treturn Objects.RoomReverb room's reverb type
-		ScriptReserved_GetPosition, &Room::GetReverbType,
+		ScriptReserved_GetReverbType, &Room::GetReverbType,
 
 		/// Set the room's reverb type.
 		// @function Room:SetReverbType

--- a/TombEngine/Scripting/Internal/TEN/Objects/Room/RoomObject.cpp
+++ b/TombEngine/Scripting/Internal/TEN/Objects/Room/RoomObject.cpp
@@ -38,6 +38,11 @@ void Room::Register(sol::table& parent)
 		// @treturn bool true if the room is active
 		ScriptReserved_GetActive, &Room::GetActive,
 
+		/// Get the room ID
+		// @function Room:GetRoomNumber
+		// @treturn int the room ID
+		ScriptReserved_GetRoomNumber, & Room::GetRoomNumber,
+
 		/// Get the room's ambient light color.
 		// @function Room:GetColor
 		// @treturn Color ambient light color of the room
@@ -85,6 +90,11 @@ void Room::Register(sol::table& parent)
 bool Room::GetActive() const
 {
 	return m_room.Active();
+}
+
+int Room::GetRoomNumber() const
+{
+	return m_room.RoomNumber;
 }
 
 ScriptColor Room::GetColor() const

--- a/TombEngine/Scripting/Internal/TEN/Objects/Room/RoomObject.h
+++ b/TombEngine/Scripting/Internal/TEN/Objects/Room/RoomObject.h
@@ -20,6 +20,7 @@ public:
 	static void Register(sol::table& parent);
 
 	[[nodiscard]] bool GetActive() const;
+	[[nodiscard]] int GetRoomNumber() const;
 	[[nodiscard]] ScriptColor GetColor() const;
 
 	[[nodiscard]] std::string GetName() const;


### PR DESCRIPTION
## todo

- [x] I have added a changelog entry to CHANGELOG.md file on the branch/fork (if it is an internal change then it is not needed) 
- [x] Pull request meets the Coding Conventions standards: https://github.com/MontyTRC89/TombEngine/blob/master/CONTRIBUTING.md#coding-conventions

## Links to issue(s) this pull request concerns (if applicable)
https://discord.com/channels/1072511394735464498/1073914803711660112/1278842042469842996

## Description of pull request 
- The function Room:GetRoomNumber() returns the room ID (int) of an object of type room. This function is essential for the `Create moveable` node.
- The GetReverbType() method has been corrected. The ScriptReserved variable was incorrect
- Modified `Moveable()` function description for consistency
