### PR TITLE
LOS fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ TombEngine releases are located in this repository (alongside with Tomb Editor):
 ### Bug fixes
 * Fixed original issue with classic switch off trigger incorrectly activating some trigger actions.
 * Fixed leveljump vehicle transfer.
+* Fixed weapons not properly hitting enemies.
+* Fixed laserhead teleporting Lara and making her invisible on death.
 * Fixed sarcophagus pick-ups.
 * Fixed incorrect diving animation when swandiving from a high place.
 * Fixed camera rotating with the player's hips when climbing out of water.

--- a/TombEngine/Objects/TR5/Entity/tr5_laser_head.cpp
+++ b/TombEngine/Objects/TR5/Entity/tr5_laser_head.cpp
@@ -591,9 +591,12 @@ namespace TEN::Entities::Creatures::TR5
 	void DoGuardianDeath(int itemNumber, ItemInfo& item)
 	{
 		const auto& guardian = GetGuardianInfo(item);
-
-		ExplodeItemNode(&g_Level.Items[guardian.BaseItem], 0, 0, 128);
-		KillItem(guardian.BaseItem);
+		
+		if (g_Level.Items[guardian.BaseItem].ObjectNumber == ID_LASERHEAD_BASE)
+		{
+			ExplodeItemNode(&g_Level.Items[guardian.BaseItem], 0, 0, 128);
+			KillItem(guardian.BaseItem);
+		}
 
 		ExplodeItemNode(&item, 0, 0, 128);
 
@@ -605,7 +608,6 @@ namespace TEN::Entities::Creatures::TR5
 		TriggerShockwave(&item.Pose, 32, 160, 64, 0, 128, 64, 36, EulerAngles(0x3000, 0.0f, 0.0f), 0, true, false, false, (int)ShockwaveStyle::Normal);
 		TriggerShockwave(&item.Pose, 32, 160, 64, 0, 128, 64, 36, EulerAngles(0x6000, 0.0f, 0.0f), 0, true, false, false, (int)ShockwaveStyle::Normal);
 
-		g_Level.Items[guardian.PuzzleItem].Pose.Position.y = item.Pose.Position.y;
 		TestTriggers(&item, true);
 
 		SoundEffect(SFX_TR5_GOD_HEAD_BLAST, &item.Pose, SoundEnvironment::Land, 0.5f);

--- a/TombEngine/Objects/TR5/Entity/tr5_laserhead_info.h
+++ b/TombEngine/Objects/TR5/Entity/tr5_laserhead_info.h
@@ -21,6 +21,5 @@ namespace TEN::Entities::Creatures::TR5
 		short yRot;
 		int BaseItem;
 		std::array<int, GUARDIAN_TENTACLE_COUNT> Tentacles = {};
-		int PuzzleItem;
 	};
 }


### PR DESCRIPTION
## todo

- [x] I have added a changelog entry to CHANGELOG.md file on the branch/fork (if it is an internal change then it is not needed) 
- [x] Pull request meets the Coding Conventions standards: https://github.com/MontyTRC89/TombEngine/blob/master/CONTRIBUTING.md#coding-conventions

## Links to issue(s) this pull request concerns (if applicable)

https://github.com/MontyTRC89/TombEngine/issues/1412

## Description of pull request 

This pull request solves problems with incorrect hit detection of player's shots. Also it removes Monty's "deliberately bugged" LOS detection code path because it makes no sense, and the only issue it "fixed" was laserhead's eyes. That issue is actually an asset issue and can be fixed by setting laserhead mesh sphere's radius to zero.