### PR TITLE
Fixed bitwise for itemStatus

### DIFF
--- a/TombEngine/Game/items.h
+++ b/TombEngine/Game/items.h
@@ -109,7 +109,7 @@ struct ItemInfo
 	int			   Index		= 0;			// ItemNumber // TODO: Make int.
 	GAME_OBJECT_ID ObjectNumber = ID_NO_OBJECT; // ObjectID
 
-	/*ItemStatus*/int Status = ITEM_NOT_ACTIVE;
+	ItemStatus Status = ITEM_NOT_ACTIVE;
 	bool	   Active = false;
 
 	// TODO: Refactor linked list.

--- a/TombEngine/Objects/Generic/Object/objects.cpp
+++ b/TombEngine/Objects/Generic/Object/objects.cpp
@@ -258,7 +258,7 @@ void AnimatingControl(short itemNumber)
 	else if (item.TriggerFlags == 2) //Make the animating dissapear when anti-triggered.
 	{
 		RemoveActiveItem(itemNumber);
-		item.Status |= ITEM_INVISIBLE;
+		item.Status = ITEM_INVISIBLE;
 	}
 
 	// TODO: ID_SHOOT_SWITCH2 is probably the bell in Trajan Markets, use Lua for that.

--- a/TombEngine/Objects/TR1/Entity/SkateboardKid.cpp
+++ b/TombEngine/Objects/TR1/Entity/SkateboardKid.cpp
@@ -77,7 +77,7 @@ namespace TEN::Entities::Creatures::TR1
 		AddActiveItem(skateItemNumber);
 
 		skate.Active = false;
-		skate.Status |= ITEM_INVISIBLE;
+		skate.Status = ITEM_INVISIBLE;
 		item.ItemFlags[0] = skateItemNumber;
 	}
 

--- a/TombEngine/Objects/TR2/Entity/tr2_skidman.cpp
+++ b/TombEngine/Objects/TR2/Entity/tr2_skidman.cpp
@@ -81,13 +81,9 @@ namespace TEN::Entities::Creatures::TR2
 		auto& item = g_Level.Items[itemNumber];
 
 		if (item.Flags & IFLAG_REVERSE)
-		{
-			item.Status &= ~ITEM_INVISIBLE;
-		}
+			item.Status = ITEM_NOT_ACTIVE;
 		else
-		{
 			item.Status = ITEM_INVISIBLE;
-		}
 	}
 
 	void SkidooManCollision(short itemNumber, ItemInfo* laraItem, CollisionInfo* coll)

--- a/TombEngine/Objects/TR2/Entity/tr2_spear_guardian.cpp
+++ b/TombEngine/Objects/TR2/Entity/tr2_spear_guardian.cpp
@@ -195,7 +195,7 @@ namespace TEN::Entities::Creatures::TR2
 
 		InitializeCreature(itemNumber);
 		SetAnimation(&item, SPEAR_GUARDIAN_ANIM_AWAKE);
-		item.Status &= ~ITEM_INVISIBLE;
+		item.Status = ITEM_NOT_ACTIVE;
 
 		item.ItemFlags[0] = 0; // Joint index for mesh swap.
 		item.ItemFlags[1] = 1; // Immune state (bool).

--- a/TombEngine/Objects/TR2/Entity/tr2_sword_guardian.cpp
+++ b/TombEngine/Objects/TR2/Entity/tr2_sword_guardian.cpp
@@ -174,7 +174,7 @@ namespace TEN::Entities::Creatures::TR2
 
 		InitializeCreature(itemNumber);
 		SetAnimation(&item, SWORD_GUARDIAN_ANIM_AWAKE);
-		item.Status &= ~ITEM_INVISIBLE;
+		item.Status = ITEM_NOT_ACTIVE;
 
 		item.ItemFlags[0] = 0; // Joint index for mesh swap.
 		item.ItemFlags[1] = 1; // Immune state (bool).

--- a/TombEngine/Objects/TR3/Entity/Shiva.cpp
+++ b/TombEngine/Objects/TR3/Entity/Shiva.cpp
@@ -254,7 +254,7 @@ namespace TEN::Entities::Creatures::TR3
 	void InitializeShiva(short itemNumber)
 	{
 		auto& item = g_Level.Items[itemNumber];
-		item.Status &= ~ITEM_INVISIBLE; // Draw the statue from the start.
+		item.Status = ITEM_NOT_ACTIVE; // Draw the statue from the start.
 
 		InitializeCreature(itemNumber);
 		SetAnimation(&item, SHIVA_ANIM_INACTIVE);

--- a/TombEngine/Objects/TR4/Entity/tr4_dog.cpp
+++ b/TombEngine/Objects/TR4/Entity/tr4_dog.cpp
@@ -81,7 +81,7 @@ namespace TEN::Entities::TR4
 		if (item->TriggerFlags)
 		{
 			SetAnimation(item, DOG_ANIM_AWAKEN);
-			item->Status -= ITEM_INVISIBLE;
+			item->Status = ITEM_NOT_ACTIVE;
 		}
 		else
 			SetAnimation(item, DOG_ANIM_IDLE);

--- a/TombEngine/Objects/TR4/Entity/tr4_mummy.cpp
+++ b/TombEngine/Objects/TR4/Entity/tr4_mummy.cpp
@@ -81,7 +81,7 @@ namespace TEN::Entities::TR4
 		if (item->TriggerFlags == 2)
 		{
 			SetAnimation(item, MUMMY_ANIM_COLLAPSE_END);
-			item->Status -= ITEM_INVISIBLE;
+			item->Status = ITEM_NOT_ACTIVE;
 		}
 		else
 		{

--- a/TombEngine/Objects/TR4/Entity/tr4_skeleton.cpp
+++ b/TombEngine/Objects/TR4/Entity/tr4_skeleton.cpp
@@ -136,7 +136,7 @@ namespace TEN::Entities::TR4
 
 		case 3:
 			SetAnimation(item, SKELETON_ANIM_STANDING_UP);
-			item->Status -= ITEM_INVISIBLE;
+			item->Status = ITEM_NOT_ACTIVE;
 			break;
 		}
 	}

--- a/TombEngine/Objects/TR4/Trap/tr4_cog.cpp
+++ b/TombEngine/Objects/TR4/Trap/tr4_cog.cpp
@@ -19,12 +19,12 @@ namespace TEN::Entities::Traps
 
 		if (TriggerActive(&item))
 		{
-		   item.Status = ITEM_ACTIVE;
+			item.Status = ITEM_ACTIVE;
 			AnimateItem(&item);
 		}
 		else if (item.TriggerFlags == 2)
 		{
-		   item.Status |= ITEM_INVISIBLE;
+			item.Status = ITEM_INVISIBLE;
 		}
 	}
 

--- a/TombEngine/Objects/TR5/Entity/tr5_larson.cpp
+++ b/TombEngine/Objects/TR5/Entity/tr5_larson.cpp
@@ -18,6 +18,8 @@ using namespace TEN::Math;
 
 namespace TEN::Entities::Creatures::TR5
 {
+	constexpr auto LARSON_ALERT_RANGE = SQUARE(BLOCK(2));
+
 	#define STATE_TR5_LARSON_STOP	1
 	#define STATE_TR5_LARSON_WALK	2
 	#define STATE_TR5_LARSON_RUN	3
@@ -58,6 +60,8 @@ namespace TEN::Entities::Creatures::TR5
 			item->Pose.Position.z += STEPUP_HEIGHT;
 	}
 
+	// TODO: Make larson 1:1 from TOMB5 code. TokyoSU: 10/27/2024
+	// This code is a mess...
 	void LarsonControl(short itemNumber)
 	{
 		if (!CreatureActive(itemNumber))
@@ -73,15 +77,14 @@ namespace TEN::Entities::Creatures::TR5
 		short joint2 = 0;
 
 		// TODO: When Larson's HP is below 40, he runs away in Streets of Rome. Keeping block commented for reference.
-		/*if (item->HitPoints <= TR5_LARSON_MIN_HP && !(item->flags & IFLAG_INVISIBLE))
+		if (item->HitPoints <= TR5_LARSON_MIN_HP && !(item->Flags & IFLAG_INVISIBLE))
 		{
 			item->HitPoints = TR5_LARSON_MIN_HP;
-			creature->flags++;
-		}*/
+			creature->Flags++;
+		}
 
 		if (creature->MuzzleFlash[0].Delay != 0)
 			creature->MuzzleFlash[0].Delay--;
-
 		if (creature->MuzzleFlash[1].Delay != 0)
 			creature->MuzzleFlash[1].Delay--;
 
@@ -89,20 +92,13 @@ namespace TEN::Entities::Creatures::TR5
 		{
 			if (CurrentLevel == 2)
 			{
-				item->Animation.IsAirborne = false;
-				item->Status = ITEM_DEACTIVATED;
-				item->Collidable = false;
-				item->HitStatus = false;
+				item->AIBits = AMBUSH;
 				item->ItemFlags[3] = 1;
 			}
 			else
 			{
-				item->Animation.IsAirborne = false;
-				item->Status = ITEM_ACTIVE;
-				item->Collidable = false;
-				item->HitStatus = false;
+				item->AIBits = GUARD;
 			}
-
 			item->TriggerFlags = 0;
 		}
 
@@ -120,25 +116,23 @@ namespace TEN::Entities::Creatures::TR5
 				joint2 = AI.angle;
 
 			// FIXME: This should make Larson run away, but it doesn't work.
-			/*if (creature->flags)
+			// FIXME: 10/27/2024 - TokyoSU: Implemented TOMB5 way, should work now but need test.
+			if (creature->Flags)
 			{
 				item->HitPoints = 60;
-				item->IsAirborne = false;
-				item->HitStatus = false;
-				item->Collidable = false;
-				item->Status = ITEM_DESACTIVATED;
+				item->AIBits = AMBUSH;
 				creature->Flags = 0;
-			}*/
+			}
 
 			GetCreatureMood(item, &AI, true);
 			CreatureMood(item, &AI, true);
 
-			if (AI.distance < SQUARE(BLOCK(2)) &&
+			if (AI.distance < LARSON_ALERT_RANGE &&
 				LaraItem->Animation.Velocity.z > 20.0f ||
 				item->HitStatus ||
 				TargetVisible(item, &AI) != 0)
 			{
-				item->Status &= ~ITEM_ACTIVE;
+				item->AIBits &= ~GUARD;
 				creature->Alerted = true;
 			}
 


### PR DESCRIPTION
## todo

- [X] I have added a changelog entry to CHANGELOG.md file on the branch/fork (if it is an internal change then it is not needed) 
- [X] Pull request meets the Coding Conventions standards: https://github.com/MontyTRC89/TombEngine/blob/master/CONTRIBUTING.md#coding-conventions

## Links to issue(s) this pull request concerns (if applicable)

N/A

## Description of pull request 

Reported by @Lwmte 
The bitwise operation for item.Status dont make sense, so i removed that and remplaced it with correct value.