### PR TITLE
Expose moveable's target state to Lua API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ TombEngine releases are located in this repository (alongside with Tomb Editor):
 * Added Inventory.GetUsedItem(), Inventory.SetUsedItem() and Inventory.ClearUsedItem() functions.
 * Added Input.KeyClearAll() function.
 * Added Moveable.GetJointRotation() and optional 'offset' parameter for Moveable.GetJointPosition().
+* Added Moveable.GetTargetState() function.
 * Added Room:GetRoomNumber() function.
 * Removed anims.monkeyAutoJump. It is now a player menu configuration.
 * Fixed Volume:GetActive() method.

--- a/Documentation/doc/2 classes/Objects.Moveable.html
+++ b/Documentation/doc/2 classes/Objects.Moveable.html
@@ -154,6 +154,10 @@ pickups, and Lara herself (see also <a href="../2 classes/Objects.LaraObject.htm
 	<td class="summary">Retrieve the index of the current state.</td>
 	</tr>
 	<tr>
+	<td class="name" ><a href="#Moveable:GetTargetState">Moveable:GetTargetState()</a></td>
+	<td class="summary">Retrieve the index of the target state.</td>
+	</tr>
+	<tr>
 	<td class="name" ><a href="#Moveable:SetState">Moveable:SetState(index)</a></td>
 	<td class="summary">Set the object's state to the one specified by the given index.</td>
 	</tr>
@@ -678,6 +682,28 @@ shiva:SetObjectID(TEN.Objects.ObjID.BIGMEDI_ITEM)</pre>
 
            <span class="types"><span class="type">int</span></span>
         the index of the active state
+    </ol>
+
+
+
+
+</dd>
+    <dt>
+    <a name = "Moveable:GetTargetState"></a>
+    <strong>Moveable:GetTargetState()</strong>
+    </dt>
+    <dd>
+    Retrieve the index of the target state.
+ This corresponds to the state the object is trying to get into, which is sometimes different from the active state.
+
+
+
+
+    <h3>Returns:</h3>
+    <ol>
+
+           <span class="types"><span class="type">int</span></span>
+        the index of the target state
     </ol>
 
 

--- a/TombEngine/Scripting/Internal/ReservedScriptNames.h
+++ b/TombEngine/Scripting/Internal/ReservedScriptNames.h
@@ -149,6 +149,7 @@ static constexpr char ScriptReserved_SetFrameNumber[]		= "SetFrame";
 static constexpr char ScriptReserved_GetAnimNumber[]		= "GetAnim";
 static constexpr char ScriptReserved_SetAnimNumber[]		= "SetAnim";
 static constexpr char ScriptReserved_GetStateNumber[]		= "GetState";
+static constexpr char ScriptReserved_GetTargetStateNumber[]	= "GetTargetState";
 static constexpr char ScriptReserved_SetStateNumber[]		= "SetState";
 static constexpr char ScriptReserved_GetOCB[]				= "GetOCB";
 static constexpr char ScriptReserved_SetOCB[]				= "SetOCB";

--- a/TombEngine/Scripting/Internal/TEN/Objects/Moveable/MoveableObject.cpp
+++ b/TombEngine/Scripting/Internal/TEN/Objects/Moveable/MoveableObject.cpp
@@ -223,6 +223,12 @@ void Moveable::Register(sol::state& state, sol::table& parent)
 // @treturn int the index of the active state
 	ScriptReserved_GetStateNumber, &Moveable::GetStateNumber,
 
+/// Retrieve the index of the target state.
+// This corresponds to the state the object is trying to get into, which is sometimes different from the active state.
+// @function Moveable:GetTargetState
+// @treturn int the index of the target state
+	ScriptReserved_GetTargetStateNumber, &Moveable::GetTargetStateNumber,
+
 /// Set the object's state to the one specified by the given index.
 // Performs no bounds checking. *Ensure the number given is correct, else
 // object may end up in corrupted animation state.*
@@ -844,6 +850,11 @@ void Moveable::SetAIBits(aiBitsType const & bits)
 int Moveable::GetStateNumber() const
 {
 	return m_item->Animation.ActiveState;
+}
+
+int Moveable::GetTargetStateNumber() const
+{
+	return m_item->Animation.TargetState;
 }
 
 void Moveable::SetStateNumber(int stateNumber)

--- a/TombEngine/Scripting/Internal/TEN/Objects/Moveable/MoveableObject.h
+++ b/TombEngine/Scripting/Internal/TEN/Objects/Moveable/MoveableObject.h
@@ -56,6 +56,7 @@ public:
 	void SetRot(const Rotation& rot);
 
 	[[nodiscard]] int GetStateNumber() const;
+	[[nodiscard]] int GetTargetStateNumber() const;
 	void SetStateNumber(int stateNumber);
 
 	[[nodiscard]] int GetAnimNumber() const;


### PR DESCRIPTION
## todo

- [X] I have added a changelog entry to CHANGELOG.md file on the branch/fork (if it is an internal change then it is not needed) 
- [X] Pull request meets the Coding Conventions standards: https://github.com/MontyTRC89/TombEngine/blob/master/CONTRIBUTING.md#coding-conventions

## Links to issue(s) this pull request concerns (if applicable)

N/A

## Description of pull request 

Adds `Moveable:GetTargetState()` to the Lua API to retrieve the *target* state of a moveable.
The API only had `Moveable:GetState()`, which refers to the *current* state.