### PR TITLE
Load after death

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ TombEngine releases are located in this repository (alongside with Tomb Editor):
 * Added the ability to display "Lara's Home" entry in the main menu.
 * Added the ability to change pickup item count by modifying item hit points.
 * Added F12 as alternative to PrtSc for screenshots.
+* Added ability to invoke load game dialog after death by pressing any key.
 * Added visible mouse pointer in windowed mode.
 * Added new sound conditions: Quicksand and Underwater.
   - Quicksand - sound effect plays when a moveable is in quicksand.

--- a/TombEngine/Game/control/control.cpp
+++ b/TombEngine/Game/control/control.cpp
@@ -631,7 +631,8 @@ GameStatus HandleMenuCalls(bool isTitle)
 
 	bool playerAlive = LaraItem->HitPoints > 0;
 	
-	bool doLoad      = IsClicked(In::Load) || (!IsClicked(In::Inventory) && !NoAction() && Lara.Control.Count.Death > DEATH_INPUT_TIMEOUT);
+	bool doLoad      = IsClicked(In::Load) || 
+					   (!IsClicked(In::Inventory) && !NoAction() && SaveGame::IsLoadGamePossible() && Lara.Control.Count.Death > DEATH_INPUT_TIMEOUT);
 	bool doSave      = IsClicked(In::Save) && playerAlive;
 	bool doPause     = IsClicked(In::Pause) && playerAlive;
 	bool doInventory = (IsClicked(In::Inventory) || g_Gui.GetEnterInventory() != NO_VALUE) && playerAlive;
@@ -646,9 +647,6 @@ GameStatus HandleMenuCalls(bool isTitle)
 	else if (doLoad && g_GameFlow->IsLoadSaveEnabled() && g_Gui.GetInventoryMode() != InventoryMode::Load)
 	{
 		SaveGame::LoadHeaders();
-
-		if (!SaveGame::IsLoadGamePossible())
-			return gameStatus;
 
 		g_Gui.SetInventoryMode(InventoryMode::Load);
 

--- a/TombEngine/Game/control/control.cpp
+++ b/TombEngine/Game/control/control.cpp
@@ -646,6 +646,10 @@ GameStatus HandleMenuCalls(bool isTitle)
 	else if (doLoad && g_GameFlow->IsLoadSaveEnabled() && g_Gui.GetInventoryMode() != InventoryMode::Load)
 	{
 		SaveGame::LoadHeaders();
+
+		if (!SaveGame::IsLoadGamePossible())
+			return gameStatus;
+
 		g_Gui.SetInventoryMode(InventoryMode::Load);
 
 		if (g_Gui.CallInventory(LaraItem, false))

--- a/TombEngine/Game/gui.cpp
+++ b/TombEngine/Game/gui.cpp
@@ -3506,11 +3506,13 @@ namespace TEN::Gui
 
 	LoadResult GuiController::DoLoad()
 	{
+		constexpr auto DEATH_NO_INPUT_LOAD_TIMEOUT = 1 * FPS;
+
 		bool canLoop = g_Configuration.MenuOptionLoopingMode == MenuOptionLoopingMode::SaveLoadOnly ||
 					   g_Configuration.MenuOptionLoopingMode == MenuOptionLoopingMode::AllMenus;
 
-		// If load menu is accessed after death, make sure to wait 1 second to allow player to stop spamming input.
-		if (GetLaraInfo(*LaraItem).Control.Count.Death > 0 && TimeInMenu < FPS)
+		// If load menu is accessed after death, delay input polling to allow player to stop spamming input.
+		if (GetLaraInfo(*LaraItem).Control.Count.Death > 0 && TimeInMenu < DEATH_NO_INPUT_LOAD_TIMEOUT)
 			return LoadResult::None;
 
 		SelectedSaveSlot = GetLoopedSelectedOption(SelectedSaveSlot, SAVEGAME_MAX - 1, canLoop);

--- a/TombEngine/Game/gui.cpp
+++ b/TombEngine/Game/gui.cpp
@@ -3469,6 +3469,11 @@ namespace TEN::Gui
 	{
 		bool canLoop = g_Configuration.MenuOptionLoopingMode == MenuOptionLoopingMode::SaveLoadOnly ||
 					   g_Configuration.MenuOptionLoopingMode == MenuOptionLoopingMode::AllMenus;
+
+		// If load menu is accessed after death, make sure to wait 1 second to allow player to stop spamming input.
+		if (GetLaraInfo(*LaraItem).Control.Count.Death > 0 && TimeInMenu < FPS)
+			return LoadResult::None;
+
 		SelectedSaveSlot = GetLoopedSelectedOption(SelectedSaveSlot, SAVEGAME_MAX - 1, canLoop);
 
 		if (GuiIsSelected())

--- a/TombEngine/Game/savegame.cpp
+++ b/TombEngine/Game/savegame.cpp
@@ -209,8 +209,10 @@ bool SaveGame::DoesSaveGameExist(int slot, bool silent)
 bool SaveGame::IsLoadGamePossible()
 {
 	for (int i = 0; i < SAVEGAME_MAX; i++)
+	{
 		if (Infos[i].Present)
 			return true;
+	}
 
 	return false;
 }

--- a/TombEngine/Game/savegame.cpp
+++ b/TombEngine/Game/savegame.cpp
@@ -206,6 +206,15 @@ bool SaveGame::DoesSaveGameExist(int slot, bool silent)
 	return true;
 }
 
+bool SaveGame::IsLoadGamePossible()
+{
+	for (int i = 0; i < SAVEGAME_MAX; i++)
+		if (Infos[i].Present)
+			return true;
+
+	return false;
+}
+
 std::string SaveGame::GetSavegameFilename(int slot)
 {
 	return (FullSaveDirectory + SAVEGAME_FILE_MASK + std::to_string(slot));

--- a/TombEngine/Game/savegame.h
+++ b/TombEngine/Game/savegame.h
@@ -64,6 +64,7 @@ public:
 	static void Delete(int slot);
 
 	static bool DoesSaveGameExist(int slot, bool silent = false);
+	static bool IsLoadGamePossible();
 
 	static void SaveHub(int index);
 	static void LoadHub(int index);


### PR DESCRIPTION
## Checklist

- [x] I have added a changelog entry to CHANGELOG.md file on the branch/fork (if it is an internal change then it is not needed) 
- [x] Pull request meets the Coding Conventions standards: https://github.com/MontyTRC89/TombEngine/blob/master/CONTRIBUTING.md#coding-conventions

## Links to issue(s) this pull request concerns (if applicable)

N/A

## Description of pull request 

Alters the behaviour of game loop after player death:

- If any key except Esc key is pressed after death delay has passed, load game dialog is invoked.
- If Esc key is pressed after death delay has passed, game goes back to title, as always.

Load game dialog is only invoked if there are any valid savegames in any slot. Otherwise, game always goes back to title.