### PR TITLE
Adngel fix death camera

### DIFF
--- a/TombEngine/Game/camera.cpp
+++ b/TombEngine/Game/camera.cpp
@@ -1289,7 +1289,10 @@ void CalculateCamera(const CollisionInfo& coll)
 	Camera.DisableInterpolation = (Camera.DisableInterpolation || Camera.lastType != Camera.type);
 	Camera.lastType = Camera.type;
 
-	if ((Camera.type != CameraType::Heavy || Camera.timer == -1) && !IsDeathCamera())
+	if (CalculateDeathCamera())
+		return;
+
+	if (Camera.type != CameraType::Heavy || Camera.timer == -1)
 	{
 		Camera.type = CameraType::Chase;
 		Camera.speed = 10;
@@ -1304,7 +1307,7 @@ void CalculateCamera(const CollisionInfo& coll)
 	}
 }
 
-bool IsDeathCamera ()
+bool CalculateDeathCamera()
 {
 	// If player is alive, it's not a death camera.
 	if (LaraItem->HitPoints > 0)

--- a/TombEngine/Game/camera.cpp
+++ b/TombEngine/Game/camera.cpp
@@ -1306,12 +1306,15 @@ void CalculateCamera(const CollisionInfo& coll)
 
 bool IsDeathCamera ()
 {
+	// If player is alive, it's not a death camera.
 	if (LaraItem->HitPoints > 0)
 		return false;
-
+	
+	// If Lara is in a special death animation (from extra_anims) triggered by enemies.
 	if (LaraItem->Animation.AnimObjectID == ID_LARA_EXTRA_ANIMS)
 		return true;
 
+	// Teeth spikes death animation
 	if (LaraItem->Animation.AnimNumber == LA_SPIKE_DEATH)
 	{
 		Camera.pos.RoomNumber = LaraItem->RoomNumber;
@@ -1322,6 +1325,7 @@ bool IsDeathCamera ()
 		return true;
 	}
 
+	// Rolling ball death animation
 	if (LaraItem->Animation.AnimNumber == LA_BOULDER_DEATH)
 	{
 		Camera.pos.RoomNumber = LaraItem->RoomNumber;

--- a/TombEngine/Game/camera.cpp
+++ b/TombEngine/Game/camera.cpp
@@ -1317,31 +1317,13 @@ bool CalculateDeathCamera()
 	if (LaraItem->Animation.AnimObjectID == ID_LARA_EXTRA_ANIMS)
 		return true;
 
-	// Teeth spikes death animation
-	if (LaraItem->Animation.AnimNumber == LA_SPIKE_DEATH)
+	// Special death animations
+	if (LaraItem->Animation.AnimNumber == LA_SPIKE_DEATH || 
+		LaraItem->Animation.AnimNumber == LA_BOULDER_DEATH || 
+		LaraItem->Animation.AnimNumber == LA_TRAIN_OVERBOARD_DEATH)
 	{
-		Camera.pos.RoomNumber = LaraItem->RoomNumber;
-		Camera.flags = CF_FOLLOW_CENTER;
-		Camera.targetAngle = ANGLE(-150.0f);
-		Camera.targetElevation = ANGLE(-25.0f);
-		Camera.targetDistance = BLOCK(1.5);
 		return true;
 	}
-
-	// Rolling ball death animation
-	if (LaraItem->Animation.AnimNumber == LA_BOULDER_DEATH)
-	{
-		Camera.pos.RoomNumber = LaraItem->RoomNumber;
-		Camera.flags = CF_FOLLOW_CENTER;
-		Camera.targetAngle = ANGLE(100.0f);
-		Camera.targetElevation = ANGLE(-25.0f);
-		Camera.targetDistance = BLOCK(2);
-		return true;
-	}
-
-	// TODO: Polish camera when the train mechanics were operative.
-	/*if (LaraItem->Animation.AnimNumber == LA_TRAIN_OVERBOARD_DEATH)
-		return true;*/
 
 	return false;
 }

--- a/TombEngine/Game/camera.cpp
+++ b/TombEngine/Game/camera.cpp
@@ -1289,7 +1289,7 @@ void CalculateCamera(const CollisionInfo& coll)
 	Camera.DisableInterpolation = (Camera.DisableInterpolation || Camera.lastType != Camera.type);
 	Camera.lastType = Camera.type;
 
-	if (Camera.type != CameraType::Heavy || Camera.timer == -1)
+	if ((Camera.type != CameraType::Heavy || Camera.timer == -1) && !IsDeathCamera())
 	{
 		Camera.type = CameraType::Chase;
 		Camera.speed = 10;
@@ -1302,6 +1302,41 @@ void CalculateCamera(const CollisionInfo& coll)
 		Camera.flags = 0;
 		Camera.laraNode = -1;
 	}
+}
+
+bool IsDeathCamera ()
+{
+	if (LaraItem->HitPoints > 0)
+		return false;
+
+	if (LaraItem->Animation.AnimObjectID == ID_LARA_EXTRA_ANIMS)
+		return true;
+
+	if (LaraItem->Animation.AnimNumber == LA_SPIKE_DEATH)
+	{
+		Camera.pos.RoomNumber = LaraItem->RoomNumber;
+		Camera.flags = CF_FOLLOW_CENTER;
+		Camera.targetAngle = ANGLE(-150.0f);
+		Camera.targetElevation = ANGLE(-25.0f);
+		Camera.targetDistance = BLOCK(1.5);
+		return true;
+	}
+
+	if (LaraItem->Animation.AnimNumber == LA_BOULDER_DEATH)
+	{
+		Camera.pos.RoomNumber = LaraItem->RoomNumber;
+		Camera.flags = CF_FOLLOW_CENTER;
+		Camera.targetAngle = ANGLE(100.0f);
+		Camera.targetElevation = ANGLE(-25.0f);
+		Camera.targetDistance = BLOCK(2);
+		return true;
+	}
+
+	// TODO: Polish camera when the train mechanics were operative.
+	/*if (LaraItem->Animation.AnimNumber == LA_TRAIN_OVERBOARD_DEATH)
+		return true;*/
+
+	return false;
 }
 
 bool TestBoundsCollideCamera(const GameBoundingBox& bounds, const Pose& pose, short radius)

--- a/TombEngine/Game/camera.h
+++ b/TombEngine/Game/camera.h
@@ -105,7 +105,7 @@ void BinocularCamera(ItemInfo* item);
 void ConfirmCameraTargetPos();
 void CalculateCamera(const CollisionInfo& coll);
 void RumbleScreen();
-bool IsDeathCamera();
+bool CalculateDeathCamera();
 bool TestBoundsCollideCamera(const GameBoundingBox& bounds, const Pose& pose, short radius);
 void ItemPushCamera(GameBoundingBox* bounds, Pose* pos, short radius);
 void ItemsCollideCamera();

--- a/TombEngine/Game/camera.h
+++ b/TombEngine/Game/camera.h
@@ -105,6 +105,7 @@ void BinocularCamera(ItemInfo* item);
 void ConfirmCameraTargetPos();
 void CalculateCamera(const CollisionInfo& coll);
 void RumbleScreen();
+bool IsDeathCamera();
 bool TestBoundsCollideCamera(const GameBoundingBox& bounds, const Pose& pose, short radius);
 void ItemPushCamera(GameBoundingBox* bounds, Pose* pos, short radius);
 void ItemsCollideCamera();

--- a/TombEngine/Objects/TR4/Trap/tr4_teethspike.cpp
+++ b/TombEngine/Objects/TR4/Trap/tr4_teethspike.cpp
@@ -1,6 +1,7 @@
 #include "framework.h"
 #include "Objects/TR4/Trap/tr4_teethspike.h"
 
+#include "Game/camera.h"
 #include "Game/collision/collide_item.h"
 #include "Game/collision/collide_room.h"
 #include "Game/collision/Point.h"
@@ -161,6 +162,11 @@ namespace TEN::Entities::Traps
 					{
 						SetAnimation(LaraItem, LA_SPIKE_DEATH);
 						LaraItem->Animation.IsAirborne = false;
+
+						Camera.flags = CF_FOLLOW_CENTER;
+						Camera.targetAngle = ANGLE(-150.0f);
+						Camera.targetElevation = ANGLE(-25.0f);
+						Camera.targetDistance = BLOCK(2);
 					}
 				}
 			}

--- a/TombEngine/Objects/TR5/Object/tr5_rollingball.cpp
+++ b/TombEngine/Objects/TR5/Object/tr5_rollingball.cpp
@@ -41,6 +41,12 @@ void RollingBallCollision(short itemNumber, ItemInfo* laraItem, CollisionInfo* c
 			!TestEnvironment(RoomEnvFlags::ENV_FLAG_WATER, laraItem))
 		{
 			SetAnimation(laraItem, LA_BOULDER_DEATH);
+
+			Camera.pos.RoomNumber = LaraItem->RoomNumber;
+			Camera.flags = CF_FOLLOW_CENTER;
+			Camera.targetAngle = ANGLE(170.0f);
+			Camera.targetElevation = ANGLE(-25.0f);
+			Camera.targetDistance = BLOCK(2);
 		}
 	}
 	else
@@ -365,7 +371,8 @@ void ClassicRollingBallCollision(short itemNum, ItemInfo* lara, CollisionInfo* c
 						
 				Camera.flags = CF_FOLLOW_CENTER;
 				Camera.targetAngle = ANGLE(170);
-				Camera.targetElevation = -ANGLE(25);
+				Camera.targetElevation = -ANGLE(-25);
+				Camera.targetDistance = BLOCK(2);
 
 				for (int i = 0; i < 15; i++)
 				{

--- a/TombEngine/Objects/TR5/Object/tr5_rollingball.cpp
+++ b/TombEngine/Objects/TR5/Object/tr5_rollingball.cpp
@@ -42,7 +42,6 @@ void RollingBallCollision(short itemNumber, ItemInfo* laraItem, CollisionInfo* c
 		{
 			SetAnimation(laraItem, LA_BOULDER_DEATH);
 
-			Camera.pos.RoomNumber = LaraItem->RoomNumber;
 			Camera.flags = CF_FOLLOW_CENTER;
 			Camera.targetAngle = ANGLE(170.0f);
 			Camera.targetElevation = ANGLE(-25.0f);
@@ -370,8 +369,8 @@ void ClassicRollingBallCollision(short itemNum, ItemInfo* lara, CollisionInfo* c
 				SetAnimation(lara, LA_BOULDER_DEATH);
 						
 				Camera.flags = CF_FOLLOW_CENTER;
-				Camera.targetAngle = ANGLE(170);
-				Camera.targetElevation = -ANGLE(-25);
+				Camera.targetAngle = ANGLE(170.0f);
+				Camera.targetElevation = -ANGLE(-25.0f);
 				Camera.targetDistance = BLOCK(2);
 
 				for (int i = 0; i < 15; i++)


### PR DESCRIPTION
## todo

- [x] I have added a changelog entry to CHANGELOG.md file on the branch/fork (if it is an internal change then it is not needed) 
- [x] Pull request meets the Coding Conventions standards: https://github.com/MontyTRC89/TombEngine/blob/master/CONTRIBUTING.md#coding-conventions

## Description of pull request 
This PR addresses a camera bug occurring when Lara dies on a slope, causing a glitched, bouncing behavior. The issue originates from commit 53a7797.

That commit intended to fix camera behavior during special death animations. The camera code was refreshing the camera values on every frame, overwriting the specific values set for special death animations. To prevent this, that commit added a condition checking if Lara was alive before overwriting the Chase camera values. However, due to the lack of refreshing, this caused the default Chase camera to behave incorrectly when Lara died without triggering a special camera. (Like the camera bouncing when Lara dies on slopes).

This PR refines the conditions for camera refresh control. Now, it will ignore camera refreshing not only when Lara is dead but also when she is performing specific death animations.

### Key Changes:
- Added IsDeathCamera function to apply additional conditions during the Chase camera update, preventing interference with specific death animations.
- Configured unique camera angles and distances for spike and boulder deaths