### PR TITLE
Expose wind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ TombEngine releases are located in this repository (alongside with Tomb Editor):
 	
 ### Lua API changes
 
+* Added Effects.GetWind() function.
+
 ## [Version 1.5](https://github.com/TombEngine/TombEditorReleases/releases/tag/v1.7.2) - 2024-11-03
 
 ### Bug fixes

--- a/Documentation/doc/1 modules/Effects.html
+++ b/Documentation/doc/1 modules/Effects.html
@@ -142,6 +142,10 @@
 	<td class="name" ><a href="#MakeEarthquake">MakeEarthquake(strength)</a></td>
 	<td class="summary">Make an earthquake</td>
 	</tr>
+	<tr>
+	<td class="name" ><a href="#GetWind">GetWind()</a></td>
+	<td class="summary">Get the current wind for the current frame.</td>
+	</tr>
 </table>
 
 <br/>
@@ -493,6 +497,28 @@
         </li>
     </ul>
 
+
+
+
+
+</dd>
+    <dt>
+    <a name = "GetWind"></a>
+    <strong>GetWind()</strong>
+    </dt>
+    <dd>
+    Get the current wind for the current frame.
+ This represents the 3D displacement applied by the engine on things like particles affected by wind.
+
+
+
+
+    <h3>Returns:</h3>
+    <ol>
+
+           <span class="types"><a class="type" href="../3 primitive classes/Vec3.html#">Vec3</a></span>
+        The wind.
+    </ol>
 
 
 

--- a/TombEngine/Scripting/Internal/ReservedScriptNames.h
+++ b/TombEngine/Scripting/Internal/ReservedScriptNames.h
@@ -297,6 +297,7 @@ static constexpr char ScriptReserved_EmitBlood[]					= "EmitBlood";
 static constexpr char ScriptReserved_EmitFire[]						= "EmitFire";
 static constexpr char ScriptReserved_MakeExplosion[]				= "MakeExplosion";
 static constexpr char ScriptReserved_MakeEarthquake[]				= "MakeEarthquake";
+static constexpr char ScriptReserved_GetWind[]		        		= "GetWind";
 static constexpr char ScriptReserved_Vibrate[]						= "Vibrate";
 static constexpr char ScriptReserved_FlashScreen[]					= "FlashScreen";
 static constexpr char ScriptReserved_FadeIn[]						= "FadeIn";

--- a/TombEngine/Scripting/Internal/TEN/Effects/EffectsFunctions.cpp
+++ b/TombEngine/Scripting/Internal/TEN/Effects/EffectsFunctions.cpp
@@ -6,6 +6,7 @@
 #include "Game/control/los.h"
 #include "Game/effects/DisplaySprite.h"
 #include "Game/effects/effects.h"
+#include "Game/effects/weather.h"
 #include "Game/effects/Electricity.h"
 #include "Game/effects/explosion.h"
 #include "Game/effects/spark.h"
@@ -31,6 +32,7 @@ Functions to generate effects.
 
 using namespace TEN::Effects::DisplaySprite;
 using namespace TEN::Effects::Electricity;
+using namespace TEN::Effects::Environment;
 using namespace TEN::Effects::Explosion;
 using namespace TEN::Effects::Spark;
 
@@ -308,6 +310,15 @@ namespace TEN::Scripting::Effects
 		Camera.bounce = -str;
 	}
 
+	/// Get the current wind for the current frame.
+	// This represents the 3D displacement applied by the engine on things like particles affected by wind.
+	// @function GetWind
+	// @treturn Vec3 The wind.
+	static Vec3 GetWind()
+	{
+		return Vec3(Weather.Wind());
+	}
+
 	void Register(sol::state* state, sol::table& parent) 
 	{
 		auto tableEffects = sol::table(state->lua_state(), sol::create);
@@ -321,6 +332,7 @@ namespace TEN::Scripting::Effects
 		tableEffects.set_function(ScriptReserved_MakeExplosion, &MakeExplosion);
 		tableEffects.set_function(ScriptReserved_EmitFire, &EmitFire);
 		tableEffects.set_function(ScriptReserved_MakeEarthquake, &Earthquake);
+		tableEffects.set_function(ScriptReserved_GetWind, &GetWind);
 
 		auto handler = LuaHandler{ state };
 		handler.MakeReadOnlyTable(tableEffects, ScriptReserved_BlendID, BLEND_IDS);

--- a/TombEngine/Scripting/Internal/TEN/Effects/EffectsFunctions.cpp
+++ b/TombEngine/Scripting/Internal/TEN/Effects/EffectsFunctions.cpp
@@ -6,11 +6,11 @@
 #include "Game/control/los.h"
 #include "Game/effects/DisplaySprite.h"
 #include "Game/effects/effects.h"
-#include "Game/effects/weather.h"
 #include "Game/effects/Electricity.h"
 #include "Game/effects/explosion.h"
 #include "Game/effects/spark.h"
 #include "Game/effects/tomb4fx.h"
+#include "Game/effects/weather.h"
 #include "Game/Setup.h"
 #include "Objects/Utils/object_helper.h"
 #include "Scripting/Internal/LuaHandler.h"
@@ -310,10 +310,10 @@ namespace TEN::Scripting::Effects
 		Camera.bounce = -str;
 	}
 
-	/// Get the current wind for the current frame.
+	/// Get the wind vector for the current game frame.
 	// This represents the 3D displacement applied by the engine on things like particles affected by wind.
-	// @function GetWind
-	// @treturn Vec3 The wind.
+	// @function GetWind()
+	// @treturn Vec3 Wind vector.
 	static Vec3 GetWind()
 	{
 		return Vec3(Weather.Wind());


### PR DESCRIPTION
## Checklist

- [X] I have added a changelog entry to CHANGELOG.md file on the branch/fork (if it is an internal change then it is not needed) 
- [X] Pull request meets the Coding Conventions standards: https://github.com/MontyTRC89/TombEngine/blob/master/CONTRIBUTING.md#coding-conventions

## Links to issue(s) this pull request concerns (if applicable)

N/A

## Description of pull request 
This exposes to Lua the **wind vector** that was applied to the current frame by the engine.
This allows applying the same wind (or an altered version of it) to a custom object, or even Lara herself (for example if she's using a parachute).

I named the branch `expose_weather_parameters` in case other things related to weather come to mind (for example the wind's base strength, and direction, and maybe even overwriting them), but the PR is ready to use as-is otherwise.

_Feel free to amend the description in the doc, I'm not convinced myself with it!_