### PR TITLE
Waterfall emitter formatting fix

### DIFF
--- a/TombEngine/Objects/TR5/Emitter/Waterfall.cpp
+++ b/TombEngine/Objects/TR5/Emitter/Waterfall.cpp
@@ -25,18 +25,18 @@ namespace TEN::Effects::WaterfallEmitter
     {
         Velocity,
         WaterfallSpriteScale,
-        Density,
+        Sparseness,
         MistSpriteScale,
         Sound
     };
 
-	constexpr auto WATERFALL_LIFE_MAX			= 100;
-	constexpr auto WATERFALL_SPLASH_SPRITE_ID	= 0;
-	constexpr auto WATERFALL_STREAM_1_SPRITE_ID = 1;
-	constexpr auto WATERFALL_STREAM_2_SPRITE_ID = 2;
+    constexpr auto WATERFALL_LIFE_MAX = 100;
+    constexpr auto WATERFALL_SPLASH_SPRITE_ID = 0;
+    constexpr auto WATERFALL_STREAM_1_SPRITE_ID = 1;
+    constexpr auto WATERFALL_STREAM_2_SPRITE_ID = 2;
 
-	void InitializeWaterfall(short itemNumber)
-	{
+    void InitializeWaterfall(short itemNumber)
+    {
         auto& item = g_Level.Items[itemNumber];
 
         // Customize x and z vel.
@@ -46,14 +46,14 @@ namespace TEN::Effects::WaterfallEmitter
         item.ItemFlags[WaterfallItemFlags::WaterfallSpriteScale] = 3;
 
         // Customize density.
-        item.ItemFlags[WaterfallItemFlags::Density] = 120;
+        item.ItemFlags[WaterfallItemFlags::Sparseness] = 120;
 
         // Customize waterfallmist sprite scale.
         item.ItemFlags[WaterfallItemFlags::MistSpriteScale] = 3;
 
         // Customize waterfall sound.   0 = ON, 1 = OFF.
         item.ItemFlags[WaterfallItemFlags::Sound] = 0;
-	}
+    }
 
     void ControlWaterfall(short itemNumber)
     {
@@ -67,7 +67,7 @@ namespace TEN::Effects::WaterfallEmitter
         short scale = item.ItemFlags[WaterfallItemFlags::WaterfallSpriteScale];
         scale = Random::GenerateInt(scale, scale + 2);
 
-        float density = item.TriggerFlags < 5 ? std::clamp(int(item.ItemFlags[WaterfallItemFlags::Density]), 10, 256) : std::clamp(int(item.ItemFlags[WaterfallItemFlags::Density]), 80, 256);
+        float density = item.TriggerFlags < 5 ? std::clamp(int(item.ItemFlags[WaterfallItemFlags::Sparseness]), 10, 256) : std::clamp(int(item.ItemFlags[WaterfallItemFlags::Sparseness]), 80, 256);
         density = density / 256.0f;
 
         if (!item.ItemFlags[WaterfallItemFlags::Sound])
@@ -89,8 +89,6 @@ namespace TEN::Effects::WaterfallEmitter
             auto relOffset = Vector3(Random::GenerateFloat(-waterfallWidth / 2.0f, waterfallWidth / 2.0f), 0.0f, 0.0f);
             auto offset = Vector3::Transform(relOffset, rotMatrix);
             auto pos = item.Pose.Position.ToVector3() + offset;
-            auto orient2 = EulerAngles(item.Pose.Orientation.x, item.Pose.Orientation.y, item.Pose.Orientation.z);
-            auto origin2 = Geometry::TranslatePoint(Vector3(pos.x, pos.y, pos.z), orient2, BLOCK(0));
 
             vel.y = Random::GenerateFloat(0.0f, 16.0f);
 
@@ -134,13 +132,13 @@ namespace TEN::Effects::WaterfallEmitter
 
                 targetPos.x += velocity.x / (84 / stepSize);
                 targetPos.y += yVel;
-                targetPos.z += velocity.z / (84/ stepSize);
+                targetPos.z += velocity.z / (84 / stepSize);
 
                 auto pointColl = GetPointCollision(targetPos, item.RoomNumber);
-                
-                auto originPoint = GameVector(origin2, item.RoomNumber);
+
+                auto originPoint = GameVector(pos, item.RoomNumber);
                 auto target = GameVector(targetPos, pointColl.GetRoomNumber());
-                             
+
                 if (TestEnvironment(ENV_FLAG_WATER, Vector3i(targetPos.x, targetPos.y, targetPos.z), part.roomNumber) ||
                     TestEnvironment(ENV_FLAG_SWAMP, Vector3i(targetPos.x, targetPos.y, targetPos.z), part.roomNumber))
                 {
@@ -150,21 +148,21 @@ namespace TEN::Effects::WaterfallEmitter
 
                 else if (!LOS(&originPoint, &target))
                 {
-					if (pointColl.GetRoomNumber() == NO_VALUE || pointColl.GetSector().IsWall(targetPos.x, targetPos.z))
-					{
+                    if (pointColl.GetRoomNumber() == NO_VALUE || pointColl.GetSector().IsWall(targetPos.x, targetPos.z))
+                    {
                         targetPos.y -= (yVel / 2.7f);
-						break;
-					}
+                        break;
+                    }
                     else
                     {
-                        targetPos.y = pointColl.GetFloorHeight();                      
+                        targetPos.y = pointColl.GetFloorHeight();
                         break;
                     }
                 }
             }
 
             part.targetPos = targetPos;
- 
+
             char colorOffset = Random::GenerateInt(-8, 8);
 
             part.sR = std::clamp((int)startColor.x + colorOffset, 0, UCHAR_MAX);
@@ -188,20 +186,20 @@ namespace TEN::Effects::WaterfallEmitter
             part.flags = SP_SCALE | SP_DEF | SP_ROTATE;
         }
     }
-  
-	void SpawnWaterfallMist(const Vector3& pos, int roomNumber, float scalar, float size, const Color& color)
-	{
-		auto& part = *GetFreeParticle();
 
-		auto colorOffset = Vector3i(40.0f, 40.0f, 40.0f);
+    void SpawnWaterfallMist(const Vector3& pos, int roomNumber, float scalar, float size, const Color& color)
+    {
+        auto& part = *GetFreeParticle();
 
-		auto startColor = (Vector3i(color.x, color.y, color.z) + colorOffset);
-		auto endColor = (Vector3i(color.x, color.y, color.z) + colorOffset);
+        auto colorOffset = Vector3i(40.0f, 40.0f, 40.0f);
+
+        auto startColor = (Vector3i(color.x, color.y, color.z) + colorOffset);
+        auto endColor = (Vector3i(color.x, color.y, color.z) + colorOffset);
 
         part.on = true;
 
-		part.SpriteSeqID = ID_WATERFALL_SPRITES;
-		part.SpriteID = Random::TestProbability(1 / 2.0f) ? WATERFALL_STREAM_2_SPRITE_ID : WATERFALL_STREAM_1_SPRITE_ID;
+        part.SpriteSeqID = ID_WATERFALL_SPRITES;
+        part.SpriteID = Random::TestProbability(1 / 2.0f) ? WATERFALL_STREAM_2_SPRITE_ID : WATERFALL_STREAM_1_SPRITE_ID;
 
         part.StoreInterpolationData();
 
@@ -210,71 +208,71 @@ namespace TEN::Effects::WaterfallEmitter
         part.PrevZ = pos.z;
         part.PrevScalar = scalar;
 
-		part.x = pos.x;
-		part.y = Random::GenerateInt(-16, 0) + pos.y;
-		part.z = pos.z;
+        part.x = pos.x;
+        part.y = Random::GenerateInt(-16, 0) + pos.y;
+        part.z = pos.z;
 
         part.roomNumber = roomNumber;
 
-		int colorVariation = (Random::GenerateInt(-8, 8)); 
-		part.sR = std::clamp((int)startColor.x + colorVariation, 0, UCHAR_MAX);
-		part.sG = std::clamp((int)startColor.y + colorVariation, 0, UCHAR_MAX);
-		part.sB = std::clamp((int)startColor.z + colorVariation, 0, UCHAR_MAX);
-		part.dR = std::clamp((int)endColor.x + colorVariation, 0, UCHAR_MAX);
-		part.dG = std::clamp((int)endColor.y + colorVariation, 0, UCHAR_MAX);
-		part.dB = std::clamp((int)endColor.z + colorVariation, 0, UCHAR_MAX);
+        int colorVariation = (Random::GenerateInt(-8, 8));
+        part.sR = std::clamp((int)startColor.x + colorVariation, 0, UCHAR_MAX);
+        part.sG = std::clamp((int)startColor.y + colorVariation, 0, UCHAR_MAX);
+        part.sB = std::clamp((int)startColor.z + colorVariation, 0, UCHAR_MAX);
+        part.dR = std::clamp((int)endColor.x + colorVariation, 0, UCHAR_MAX);
+        part.dG = std::clamp((int)endColor.y + colorVariation, 0, UCHAR_MAX);
+        part.dB = std::clamp((int)endColor.z + colorVariation, 0, UCHAR_MAX);
 
-		part.colFadeSpeed = 1;
-		part.blendMode = BlendMode::Additive;
-		part.life =
-		part.sLife = 8;
-		part.fadeToBlack = part.life;
+        part.colFadeSpeed = 1;
+        part.blendMode = BlendMode::Additive;
+        part.life =
+            part.sLife = 8;
+        part.fadeToBlack = part.life;
 
-		part.xVel = 0;
-		part.yVel = -Random::GenerateInt(63, 64);
-		part.zVel = 0;
+        part.xVel = 0;
+        part.yVel = -Random::GenerateInt(63, 64);
+        part.zVel = 0;
 
-		part.friction = 3;
-		part.rotAng = Random::GenerateAngle();
+        part.friction = 3;
+        part.rotAng = Random::GenerateAngle();
         part.scalar = scalar;
         part.targetPos = Vector3::Zero;
 
-		part.rotAdd = Random::GenerateInt(-16, 16);
-		part.gravity = 0;
-		part.maxYvel = 0;
+        part.rotAdd = Random::GenerateInt(-16, 16);
+        part.gravity = 0;
+        part.maxYvel = 0;
 
-		float size1 = (GetRandomControl() & 8) + size;
-		part.size =
-		part.sSize = size1 / 4;
-		part.dSize = size1;
+        float size1 = (GetRandomControl() & 8) + size;
+        part.size =
+            part.sSize = size1 / 4;
+        part.dSize = size1;
 
-		part.flags = SP_SCALE | SP_DEF | SP_ROTATE;
-	}
+        part.flags = SP_SCALE | SP_DEF | SP_ROTATE;
+    }
 
-	bool HandleWaterfallParticle(Particle& particle)
-	{
-		if (particle.SpriteSeqID != ID_WATERFALL_SPRITES)
-			return false;
-			
+    bool HandleWaterfallParticle(Particle& particle)
+    {
+        if (particle.SpriteSeqID != ID_WATERFALL_SPRITES)
+            return false;
+
         if (particle.targetPos == Vector3::Zero)
             return false;
 
-		if (particle.y < particle.targetPos.y)
-			return false;
+        if (particle.y < particle.targetPos.y)
+            return false;
 
-		particle.targetPos.y = particle.y - 80;
-		particle.targetPos.x = particle.x;
-		particle.targetPos.z = particle.z;
+        particle.targetPos.y = particle.y - 80;
+        particle.targetPos.x = particle.x;
+        particle.targetPos.z = particle.z;
 
-		if (particle.fxObj != NO_VALUE)
-		{
-			auto& item = g_Level.Items[particle.fxObj];
-			if (Random::TestProbability(1.0f / 2.0f))
-				SpawnWaterfallMist(particle.targetPos, particle.roomNumber, item.ItemFlags[3], WATERFALL_SPRITE_SIZE, Color(particle.sR, particle.sG, particle.sB));
-		}
+        if (particle.fxObj != NO_VALUE)
+        {
+            auto& item = g_Level.Items[particle.fxObj];
+            if (Random::TestProbability(1.0f / 2.0f))
+                SpawnWaterfallMist(particle.targetPos, particle.roomNumber, item.ItemFlags[3], WATERFALL_SPRITE_SIZE, Color(particle.sR, particle.sG, particle.sB));
+        }
 
-		particle.life = 0;
-		particle.on = false;
-		return true;
-	}
+        particle.life = 0;
+        particle.on = false;
+        return true;
+    }
 }


### PR DESCRIPTION
## Checklist
- [X] Pull request meets the Coding Conventions standards: 


Removed the values "orient2" and "origin2" because it is already set with "pos".

The higher the density value, the thinner the waterfall, and lower values ​​make a thicker waterfall so I changed the name of the value "density" into "sparseness". 
