### PR TITLE
Sort Screenshots by YYYYMMDD #1372

### DIFF
--- a/TombEngine/Renderer/RendererHelper.cpp
+++ b/TombEngine/Renderer/RendererHelper.cpp
@@ -619,14 +619,21 @@ namespace TEN::Renderer
 
 		time(&rawtime);
 		auto time = localtime(&rawtime);
-		strftime(buffer, sizeof(buffer), "/TEN-%d-%m-%Y-%H-%M-%S.png", time);
+		strftime(buffer, sizeof(buffer), "/TEN-%Y%m%d_", time);
 
+		auto now = std::chrono::system_clock::now();
+		auto duration = now.time_since_epoch();
+		auto milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(
+			duration)
+			.count();
+
+		auto nameFile = buffer + std::to_string(milliseconds).substr(7, 12) + ".png";
 		auto screenPath = g_GameFlow->GetGameDir() + "Screenshots";
 
 		if (!std::filesystem::is_directory(screenPath))
 			std::filesystem::create_directory(screenPath);
 
-		screenPath += buffer;
+		screenPath += nameFile;
 		SaveWICTextureToFile(_context.Get(), _backBuffer.Texture.Get(), GUID_ContainerFormatPng, TEN::Utils::ToWString(screenPath).c_str(),
 			&GUID_WICPixelFormat24bppBGR, nullptr, true);
 	}

--- a/TombEngine/Renderer/RendererHelper.cpp
+++ b/TombEngine/Renderer/RendererHelper.cpp
@@ -623,8 +623,8 @@ namespace TEN::Renderer
 
 		auto now = std::chrono::system_clock::now();
 		auto duration = now.time_since_epoch();
-		auto milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(
-			duration)
+		auto milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>
+			(duration)
 			.count();
 
 		auto nameFile = buffer + std::to_string(milliseconds).substr(7, 12) + ".png";

--- a/TombEngine/Renderer/RendererHelper.cpp
+++ b/TombEngine/Renderer/RendererHelper.cpp
@@ -619,21 +619,14 @@ namespace TEN::Renderer
 
 		time(&rawtime);
 		auto time = localtime(&rawtime);
-		strftime(buffer, sizeof(buffer), "/TEN-%Y%m%d_", time);
+		strftime(buffer, sizeof(buffer), "/TEN-%Y-%m-%d_%H-%M-%S.png", time);
 
-		auto now = std::chrono::system_clock::now();
-		auto duration = now.time_since_epoch();
-		auto milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>
-			(duration)
-			.count();
-
-		auto nameFile = buffer + std::to_string(milliseconds).substr(7, 12) + ".png";
 		auto screenPath = g_GameFlow->GetGameDir() + "Screenshots";
 
 		if (!std::filesystem::is_directory(screenPath))
 			std::filesystem::create_directory(screenPath);
 
-		screenPath += nameFile;
+		screenPath += buffer;
 		SaveWICTextureToFile(_context.Get(), _backBuffer.Texture.Get(), GUID_ContainerFormatPng, TEN::Utils::ToWString(screenPath).c_str(),
 			&GUID_WICPixelFormat24bppBGR, nullptr, true);
 	}

--- a/TombEngine/framework.h
+++ b/TombEngine/framework.h
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <array>
-#include <atomic>
 #include <d3d11.h>
 #include <d3dcompiler.h>
 #include <deque>
@@ -21,7 +20,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string>
-#include <queue>
 #include <vector>
 
 using namespace DirectX;

--- a/TombEngine/framework.h
+++ b/TombEngine/framework.h
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <d3d11.h>
 #include <d3dcompiler.h>
 #include <deque>
@@ -20,6 +21,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string>
+#include <queue>
 #include <vector>
 
 using namespace DirectX;


### PR DESCRIPTION
## Checklist

- [ ] I have added a changelog entry to CHANGELOG.md file on the branch/fork (if it is an internal change then it is not needed) 
- [x] Pull request meets the Coding Conventions standards: https://github.com/MontyTRC89/TombEngine/blob/master/CONTRIBUTING.md#coding-conventions

## Description of pull request 
Modified the screenshot filename format to ensure chronological and alphabetical sorting.
Updated the date format from DD-MM-YYYY-HH-MM-SS to YYYYMMDD_  followed by a millisecond-based timestamp, appending just the last 5 digits for proper sorting,

Example:
Before: TEN-03-03-2025-14-30-15.png
After: TEN-20250303_98765.png -- Last digits vary based on exact capture moment
