### PR TITLE
Save level parameters in a savegame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ TombEngine releases are located in this repository (alongside with Tomb Editor):
 * Added various Translate() methods to Vec2 and Vec3 script objects.
 * Added alpha transparency functionality for statics and moveables by using SetColor() method.
 * Added extra arguments for sprite object slots and starting rotation value for EmitParticle function.
+* Added ability to save Flow.Level fields to a savegame, such as fog or sky color.
   
 ## [Version 1.7.1](https://github.com/TombEngine/TombEditorReleases/releases/tag/v1.7.4) - 2025-04-01
 

--- a/TombEngine/Game/control/control.cpp
+++ b/TombEngine/Game/control/control.cpp
@@ -579,6 +579,8 @@ void InitializeScripting(int levelIndex, bool loadGame)
 
 void DeInitializeScripting(int levelIndex, GameStatus reason)
 {
+	g_GameFlow->LoadFlowScript();
+
 	g_GameScript->FreeLevelScripts();
 	g_GameScriptEntities->FreeEntities();
 

--- a/TombEngine/Game/savegame.cpp
+++ b/TombEngine/Game/savegame.cpp
@@ -1091,16 +1091,16 @@ const std::vector<byte> SaveGame::Build()
 	auto* level = (Level*)g_GameFlow->GetLevel(CurrentLevel);
 	Save::LevelDataBuilder levelData { fbb };
 	levelData.add_fog_enabled(level->Fog.Enabled);
-	levelData.add_fog_color(&Save::Vector3(level->Fog.R, level->Fog.G, level->Fog.B));
+	levelData.add_fog_color(level->Fog.GetColor());
 	levelData.add_fog_min_distance(level->Fog.MinDistance);
 	levelData.add_fog_max_distance(level->Fog.MaxDistance);
-	levelData.add_lensflare_color(&FromVector3(level->LensFlare.GetColor()));
+	levelData.add_lensflare_color(level->LensFlare.GetColor());
 	levelData.add_lensflare_pitch(level->LensFlare.GetPitch());
 	levelData.add_lensflare_yaw(level->LensFlare.GetYaw());
 	levelData.add_lensflare_sprite_id(level->LensFlare.GetSunSpriteID());
 	levelData.add_level_far_view(level->LevelFarView);
-	levelData.add_sky_layer_1_color(&FromVector3(level->GetSkyLayerColor(0)));
-	levelData.add_sky_layer_2_color(&FromVector3(level->GetSkyLayerColor(1)));
+	levelData.add_sky_layer_1_color(level->GetSkyLayerColor(0));
+	levelData.add_sky_layer_2_color(level->GetSkyLayerColor(1));
 	levelData.add_sky_layer_1_enabled(level->GetSkyLayerEnabled(0));
 	levelData.add_sky_layer_2_enabled(level->GetSkyLayerEnabled(1));
 	levelData.add_sky_layer_1_speed(level->GetSkyLayerSpeed(0));
@@ -1763,29 +1763,28 @@ static void ParseLua(const Save::SaveGame* s, bool hubMode)
 
 	auto* level = (Level*)g_GameFlow->GetLevel(CurrentLevel);
 
-	level->Fog.R = (byte)s->level_data()->fog_color()->x();
-	level->Fog.G = (byte)s->level_data()->fog_color()->y();
-	level->Fog.B = (byte)s->level_data()->fog_color()->z();
 	level->Fog.Enabled = s->level_data()->fog_enabled();
 	level->Fog.MaxDistance = s->level_data()->fog_max_distance();
 	level->Fog.MinDistance = s->level_data()->fog_min_distance();
+	level->Fog.SetColor(s->level_data()->fog_color());
 
 	level->Layer1.Enabled = s->level_data()->sky_layer_1_enabled();
 	level->Layer1.CloudSpeed = s->level_data()->sky_layer_1_speed();
-	level->Layer1.R = (byte)s->level_data()->sky_layer_1_color()->x();
-	level->Layer1.G = (byte)s->level_data()->sky_layer_1_color()->y();
-	level->Layer1.B = (byte)s->level_data()->sky_layer_1_color()->z();
+	level->Layer1.SetColor(s->level_data()->sky_layer_1_color());
 
 	level->Layer2.Enabled = s->level_data()->sky_layer_2_enabled();
 	level->Layer2.CloudSpeed = s->level_data()->sky_layer_2_speed();
-	level->Layer2.R = (byte)s->level_data()->sky_layer_2_color()->x();
-	level->Layer2.G = (byte)s->level_data()->sky_layer_2_color()->y();
-	level->Layer2.B = (byte)s->level_data()->sky_layer_2_color()->z();
+	level->Layer2.SetColor(s->level_data()->sky_layer_2_color());
 
-	level->LensFlare.SetColor(ToVector3(s->level_data()->lensflare_color()));
 	level->LensFlare.SetSunSpriteID(s->level_data()->lensflare_sprite_id());
 	level->LensFlare.SetPitch(s->level_data()->lensflare_pitch());
 	level->LensFlare.SetYaw(s->level_data()->lensflare_yaw());
+	level->LensFlare.SetColor(s->level_data()->lensflare_color());
+
+	level->Starfield.SetStarCount(s->level_data()->starfield_star_count());
+	level->Starfield.SetMeteorCount(s->level_data()->starfield_meteor_count());
+	level->Starfield.SetMeteorSpawnDensity(s->level_data()->starfield_meteor_spawn_density());
+	level->Starfield.SetMeteorVelocity(s->level_data()->starfield_meteor_velocity());
 
 	level->Storm = s->level_data()->storm_enabled();
 	level->Weather = (WeatherType)s->level_data()->weather_type();

--- a/TombEngine/Scripting/Internal/TEN/Flow/FlowHandler.cpp
+++ b/TombEngine/Scripting/Internal/TEN/Flow/FlowHandler.cpp
@@ -414,6 +414,8 @@ void FlowHandler::LoadFlowScript()
 {
 	TENLog("Loading gameflow script, strings, and settings...", LogLevel::Info);
 
+	Levels.clear();
+
 	_handler.ExecuteScript(_gameDir + "Scripts/Gameflow.lua");
 	_handler.ExecuteScript(_gameDir + "Scripts/SystemStrings.lua", true);
 	_handler.ExecuteScript(_gameDir + "Scripts/Strings.lua", true);

--- a/TombEngine/Scripting/Internal/TEN/Flow/FlowHandler.h
+++ b/TombEngine/Scripting/Internal/TEN/Flow/FlowHandler.h
@@ -11,6 +11,7 @@
 #include "Scripting/Internal/TEN/Flow/Level/FlowLevel.h"
 #include "Scripting/Internal/TEN/Flow/Settings/Settings.h"
 #include "Scripting/Internal/TEN/Flow/Statistics/Statistics.h"
+#include "Specific/savegame/flatbuffers/ten_savegame_generated.h"
 
 class FlowHandler : public ScriptInterfaceFlowHandler
 {

--- a/TombEngine/Scripting/Internal/TEN/Flow/LensFlare/LensFlare.cpp
+++ b/TombEngine/Scripting/Internal/TEN/Flow/LensFlare/LensFlare.cpp
@@ -39,9 +39,9 @@ namespace TEN::Scripting
 
 	/// Create a LensFlare object.
 	// @function LensFlare
-	// @tparam float Pitch angle in degrees.
-	// @tparam float Yaw angle in degrees.
-	// @tparam Color Color.
+	// @tparam float pitch Pitch angle in degrees.
+	// @tparam float yaw Yaw angle in degrees.
+	// @tparam Color color Color of the lensflare.
 	// @treturn LensFlare A new LensFlare object.
 	LensFlare::LensFlare(float pitch, float yaw, const ScriptColor& color)
 	{
@@ -91,7 +91,7 @@ namespace TEN::Scripting
 
 	/// Set this lens flare's sun sprite ID.
 	// @function LensFlare:SetSunSpriteID
-	// @tparam int New sun sprite ID.
+	// @tparam int spriteID New sun sprite ID.
 	void LensFlare::SetSunSpriteID(int spriteID)
 	{
 		// Sprite ID out of range; return early.
@@ -106,7 +106,7 @@ namespace TEN::Scripting
 
 	/// Set this lens flare's pitch angle.
 	// @function LensFlare:SetPitch
-	// @tparam float New pitch angle in degrees.
+	// @tparam float pitch New pitch angle in degrees.
 	void LensFlare::SetPitch(float pitch)
 	{
 		_rotation.x = pitch;
@@ -114,7 +114,7 @@ namespace TEN::Scripting
 
 	/// Set this lens flare's yaw angle.
 	// @function LensFlare:SetYaw
-	// @tparam float New yaw angle in degrees.
+	// @tparam float yaw New yaw angle in degrees.
 	void LensFlare::SetYaw(float yaw)
 	{
 		_rotation.y = yaw;
@@ -122,7 +122,7 @@ namespace TEN::Scripting
 	
 	/// Set this lens flare's color.
 	// @function LensFlare:SetColor
-	// @tparam Color New color.
+	// @tparam Color color New color.
 	void LensFlare::SetColor(const ScriptColor& color)
 	{
 		_color = color;

--- a/TombEngine/Scripting/Internal/TEN/Flow/Starfield/Starfield.cpp
+++ b/TombEngine/Scripting/Internal/TEN/Flow/Starfield/Starfield.cpp
@@ -50,6 +50,8 @@ namespace TEN::Scripting
 	// @function Starfield
 	// @tparam int starCount Star count. __Max: 6000__
 	// @tparam int meteorCount Meteor count. __Max: 100__
+	// @tparam int meteorSpawnDensity Meteor spawn density.
+	// @tparam int meteorVel Meteor velocity.
 	// @treturn Starfield A new Starfield object.
 	Starfield::Starfield(int starCount, int meteorCount, int meteorSpawnDensity, float meteorVel)
 	{
@@ -115,7 +117,7 @@ namespace TEN::Scripting
 
 	/// Set this starfield's number of stars.
 	// @function Starfield:SetStarCount
-	// @tparam int New star count.
+	// @tparam int count New star count.
 	void Starfield::SetStarCount(int count)
 	{
 		if (count < 0 || count > STAR_COUNT_MAX)
@@ -126,7 +128,7 @@ namespace TEN::Scripting
 
 	/// Set this starfield's number of meteors.
 	// @function Starfield:SetMeteorCount
-	// @tparam int New meteor count.
+	// @tparam int count New meteor count.
 	void Starfield::SetMeteorCount(int count)
 	{
 		if (count < 0 || count > METEOR_COUNT_MAX)
@@ -137,7 +139,7 @@ namespace TEN::Scripting
 
 	/// Set this starfield's meteor spawn density.
 	// @function Starfield:SetMeteorSpawnDensity
-	// @tparam int New meteor spawn density.
+	// @tparam int density New meteor spawn density.
 	void Starfield::SetMeteorSpawnDensity(int spawnDensity)
 	{
 		_meteorSpawnDensity = spawnDensity;
@@ -145,7 +147,7 @@ namespace TEN::Scripting
 
 	/// Set this starfield's meteor velocity.
 	// @function Starfield:SetMeteorVelocity
-	// @tparam float New meteor velocity.
+	// @tparam float velocity New meteor velocity.
 	void Starfield::SetMeteorVelocity(float vel)
 	{
 		_meteorVelocity = vel;

--- a/TombEngine/Specific/savegame/flatbuffers/ten_savegame_generated.h
+++ b/TombEngine/Specific/savegame/flatbuffers/ten_savegame_generated.h
@@ -548,19 +548,19 @@ struct LevelDataT : public flatbuffers::NativeTable {
   int32_t weather_type = 0;
   float weather_strength = 0.0f;
   bool fog_enabled = false;
-  std::unique_ptr<TEN::Save::Vector3> fog_color{};
+  int32_t fog_color = 0;
   int32_t fog_min_distance = 0;
   int32_t fog_max_distance = 0;
   bool sky_layer_1_enabled = false;
-  std::unique_ptr<TEN::Save::Vector3> sky_layer_1_color{};
+  int32_t sky_layer_1_color = 0;
   int32_t sky_layer_1_speed = 0;
   bool sky_layer_2_enabled = false;
-  std::unique_ptr<TEN::Save::Vector3> sky_layer_2_color{};
+  int32_t sky_layer_2_color = 0;
   int32_t sky_layer_2_speed = 0;
   int32_t lensflare_sprite_id = 0;
   float lensflare_pitch = 0.0f;
   float lensflare_yaw = 0.0f;
-  std::unique_ptr<TEN::Save::Vector3> lensflare_color{};
+  int32_t lensflare_color = 0;
   int32_t starfield_star_count = 0;
   int32_t starfield_meteor_count = 0;
   int32_t starfield_meteor_spawn_density = 0;
@@ -610,8 +610,8 @@ struct LevelData FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   bool fog_enabled() const {
     return GetField<uint8_t>(VT_FOG_ENABLED, 0) != 0;
   }
-  const TEN::Save::Vector3 *fog_color() const {
-    return GetStruct<const TEN::Save::Vector3 *>(VT_FOG_COLOR);
+  int32_t fog_color() const {
+    return GetField<int32_t>(VT_FOG_COLOR, 0);
   }
   int32_t fog_min_distance() const {
     return GetField<int32_t>(VT_FOG_MIN_DISTANCE, 0);
@@ -622,8 +622,8 @@ struct LevelData FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   bool sky_layer_1_enabled() const {
     return GetField<uint8_t>(VT_SKY_LAYER_1_ENABLED, 0) != 0;
   }
-  const TEN::Save::Vector3 *sky_layer_1_color() const {
-    return GetStruct<const TEN::Save::Vector3 *>(VT_SKY_LAYER_1_COLOR);
+  int32_t sky_layer_1_color() const {
+    return GetField<int32_t>(VT_SKY_LAYER_1_COLOR, 0);
   }
   int32_t sky_layer_1_speed() const {
     return GetField<int32_t>(VT_SKY_LAYER_1_SPEED, 0);
@@ -631,8 +631,8 @@ struct LevelData FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   bool sky_layer_2_enabled() const {
     return GetField<uint8_t>(VT_SKY_LAYER_2_ENABLED, 0) != 0;
   }
-  const TEN::Save::Vector3 *sky_layer_2_color() const {
-    return GetStruct<const TEN::Save::Vector3 *>(VT_SKY_LAYER_2_COLOR);
+  int32_t sky_layer_2_color() const {
+    return GetField<int32_t>(VT_SKY_LAYER_2_COLOR, 0);
   }
   int32_t sky_layer_2_speed() const {
     return GetField<int32_t>(VT_SKY_LAYER_2_SPEED, 0);
@@ -646,8 +646,8 @@ struct LevelData FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   float lensflare_yaw() const {
     return GetField<float>(VT_LENSFLARE_YAW, 0.0f);
   }
-  const TEN::Save::Vector3 *lensflare_color() const {
-    return GetStruct<const TEN::Save::Vector3 *>(VT_LENSFLARE_COLOR);
+  int32_t lensflare_color() const {
+    return GetField<int32_t>(VT_LENSFLARE_COLOR, 0);
   }
   int32_t starfield_star_count() const {
     return GetField<int32_t>(VT_STARFIELD_STAR_COUNT, 0);
@@ -668,19 +668,19 @@ struct LevelData FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            VerifyField<int32_t>(verifier, VT_WEATHER_TYPE) &&
            VerifyField<float>(verifier, VT_WEATHER_STRENGTH) &&
            VerifyField<uint8_t>(verifier, VT_FOG_ENABLED) &&
-           VerifyField<TEN::Save::Vector3>(verifier, VT_FOG_COLOR) &&
+           VerifyField<int32_t>(verifier, VT_FOG_COLOR) &&
            VerifyField<int32_t>(verifier, VT_FOG_MIN_DISTANCE) &&
            VerifyField<int32_t>(verifier, VT_FOG_MAX_DISTANCE) &&
            VerifyField<uint8_t>(verifier, VT_SKY_LAYER_1_ENABLED) &&
-           VerifyField<TEN::Save::Vector3>(verifier, VT_SKY_LAYER_1_COLOR) &&
+           VerifyField<int32_t>(verifier, VT_SKY_LAYER_1_COLOR) &&
            VerifyField<int32_t>(verifier, VT_SKY_LAYER_1_SPEED) &&
            VerifyField<uint8_t>(verifier, VT_SKY_LAYER_2_ENABLED) &&
-           VerifyField<TEN::Save::Vector3>(verifier, VT_SKY_LAYER_2_COLOR) &&
+           VerifyField<int32_t>(verifier, VT_SKY_LAYER_2_COLOR) &&
            VerifyField<int32_t>(verifier, VT_SKY_LAYER_2_SPEED) &&
            VerifyField<int32_t>(verifier, VT_LENSFLARE_SPRITE_ID) &&
            VerifyField<float>(verifier, VT_LENSFLARE_PITCH) &&
            VerifyField<float>(verifier, VT_LENSFLARE_YAW) &&
-           VerifyField<TEN::Save::Vector3>(verifier, VT_LENSFLARE_COLOR) &&
+           VerifyField<int32_t>(verifier, VT_LENSFLARE_COLOR) &&
            VerifyField<int32_t>(verifier, VT_STARFIELD_STAR_COUNT) &&
            VerifyField<int32_t>(verifier, VT_STARFIELD_METEOR_COUNT) &&
            VerifyField<int32_t>(verifier, VT_STARFIELD_METEOR_SPAWN_DENSITY) &&
@@ -711,8 +711,8 @@ struct LevelDataBuilder {
   void add_fog_enabled(bool fog_enabled) {
     fbb_.AddElement<uint8_t>(LevelData::VT_FOG_ENABLED, static_cast<uint8_t>(fog_enabled), 0);
   }
-  void add_fog_color(const TEN::Save::Vector3 *fog_color) {
-    fbb_.AddStruct(LevelData::VT_FOG_COLOR, fog_color);
+  void add_fog_color(int32_t fog_color) {
+    fbb_.AddElement<int32_t>(LevelData::VT_FOG_COLOR, fog_color, 0);
   }
   void add_fog_min_distance(int32_t fog_min_distance) {
     fbb_.AddElement<int32_t>(LevelData::VT_FOG_MIN_DISTANCE, fog_min_distance, 0);
@@ -723,8 +723,8 @@ struct LevelDataBuilder {
   void add_sky_layer_1_enabled(bool sky_layer_1_enabled) {
     fbb_.AddElement<uint8_t>(LevelData::VT_SKY_LAYER_1_ENABLED, static_cast<uint8_t>(sky_layer_1_enabled), 0);
   }
-  void add_sky_layer_1_color(const TEN::Save::Vector3 *sky_layer_1_color) {
-    fbb_.AddStruct(LevelData::VT_SKY_LAYER_1_COLOR, sky_layer_1_color);
+  void add_sky_layer_1_color(int32_t sky_layer_1_color) {
+    fbb_.AddElement<int32_t>(LevelData::VT_SKY_LAYER_1_COLOR, sky_layer_1_color, 0);
   }
   void add_sky_layer_1_speed(int32_t sky_layer_1_speed) {
     fbb_.AddElement<int32_t>(LevelData::VT_SKY_LAYER_1_SPEED, sky_layer_1_speed, 0);
@@ -732,8 +732,8 @@ struct LevelDataBuilder {
   void add_sky_layer_2_enabled(bool sky_layer_2_enabled) {
     fbb_.AddElement<uint8_t>(LevelData::VT_SKY_LAYER_2_ENABLED, static_cast<uint8_t>(sky_layer_2_enabled), 0);
   }
-  void add_sky_layer_2_color(const TEN::Save::Vector3 *sky_layer_2_color) {
-    fbb_.AddStruct(LevelData::VT_SKY_LAYER_2_COLOR, sky_layer_2_color);
+  void add_sky_layer_2_color(int32_t sky_layer_2_color) {
+    fbb_.AddElement<int32_t>(LevelData::VT_SKY_LAYER_2_COLOR, sky_layer_2_color, 0);
   }
   void add_sky_layer_2_speed(int32_t sky_layer_2_speed) {
     fbb_.AddElement<int32_t>(LevelData::VT_SKY_LAYER_2_SPEED, sky_layer_2_speed, 0);
@@ -747,8 +747,8 @@ struct LevelDataBuilder {
   void add_lensflare_yaw(float lensflare_yaw) {
     fbb_.AddElement<float>(LevelData::VT_LENSFLARE_YAW, lensflare_yaw, 0.0f);
   }
-  void add_lensflare_color(const TEN::Save::Vector3 *lensflare_color) {
-    fbb_.AddStruct(LevelData::VT_LENSFLARE_COLOR, lensflare_color);
+  void add_lensflare_color(int32_t lensflare_color) {
+    fbb_.AddElement<int32_t>(LevelData::VT_LENSFLARE_COLOR, lensflare_color, 0);
   }
   void add_starfield_star_count(int32_t starfield_star_count) {
     fbb_.AddElement<int32_t>(LevelData::VT_STARFIELD_STAR_COUNT, starfield_star_count, 0);
@@ -780,19 +780,19 @@ inline flatbuffers::Offset<LevelData> CreateLevelData(
     int32_t weather_type = 0,
     float weather_strength = 0.0f,
     bool fog_enabled = false,
-    const TEN::Save::Vector3 *fog_color = 0,
+    int32_t fog_color = 0,
     int32_t fog_min_distance = 0,
     int32_t fog_max_distance = 0,
     bool sky_layer_1_enabled = false,
-    const TEN::Save::Vector3 *sky_layer_1_color = 0,
+    int32_t sky_layer_1_color = 0,
     int32_t sky_layer_1_speed = 0,
     bool sky_layer_2_enabled = false,
-    const TEN::Save::Vector3 *sky_layer_2_color = 0,
+    int32_t sky_layer_2_color = 0,
     int32_t sky_layer_2_speed = 0,
     int32_t lensflare_sprite_id = 0,
     float lensflare_pitch = 0.0f,
     float lensflare_yaw = 0.0f,
-    const TEN::Save::Vector3 *lensflare_color = 0,
+    int32_t lensflare_color = 0,
     int32_t starfield_star_count = 0,
     int32_t starfield_meteor_count = 0,
     int32_t starfield_meteor_spawn_density = 0,
@@ -8734,19 +8734,19 @@ inline void LevelData::UnPackTo(LevelDataT *_o, const flatbuffers::resolver_func
   { auto _e = weather_type(); _o->weather_type = _e; }
   { auto _e = weather_strength(); _o->weather_strength = _e; }
   { auto _e = fog_enabled(); _o->fog_enabled = _e; }
-  { auto _e = fog_color(); if (_e) _o->fog_color = std::unique_ptr<TEN::Save::Vector3>(new TEN::Save::Vector3(*_e)); }
+  { auto _e = fog_color(); _o->fog_color = _e; }
   { auto _e = fog_min_distance(); _o->fog_min_distance = _e; }
   { auto _e = fog_max_distance(); _o->fog_max_distance = _e; }
   { auto _e = sky_layer_1_enabled(); _o->sky_layer_1_enabled = _e; }
-  { auto _e = sky_layer_1_color(); if (_e) _o->sky_layer_1_color = std::unique_ptr<TEN::Save::Vector3>(new TEN::Save::Vector3(*_e)); }
+  { auto _e = sky_layer_1_color(); _o->sky_layer_1_color = _e; }
   { auto _e = sky_layer_1_speed(); _o->sky_layer_1_speed = _e; }
   { auto _e = sky_layer_2_enabled(); _o->sky_layer_2_enabled = _e; }
-  { auto _e = sky_layer_2_color(); if (_e) _o->sky_layer_2_color = std::unique_ptr<TEN::Save::Vector3>(new TEN::Save::Vector3(*_e)); }
+  { auto _e = sky_layer_2_color(); _o->sky_layer_2_color = _e; }
   { auto _e = sky_layer_2_speed(); _o->sky_layer_2_speed = _e; }
   { auto _e = lensflare_sprite_id(); _o->lensflare_sprite_id = _e; }
   { auto _e = lensflare_pitch(); _o->lensflare_pitch = _e; }
   { auto _e = lensflare_yaw(); _o->lensflare_yaw = _e; }
-  { auto _e = lensflare_color(); if (_e) _o->lensflare_color = std::unique_ptr<TEN::Save::Vector3>(new TEN::Save::Vector3(*_e)); }
+  { auto _e = lensflare_color(); _o->lensflare_color = _e; }
   { auto _e = starfield_star_count(); _o->starfield_star_count = _e; }
   { auto _e = starfield_meteor_count(); _o->starfield_meteor_count = _e; }
   { auto _e = starfield_meteor_spawn_density(); _o->starfield_meteor_spawn_density = _e; }
@@ -8766,19 +8766,19 @@ inline flatbuffers::Offset<LevelData> CreateLevelData(flatbuffers::FlatBufferBui
   auto _weather_type = _o->weather_type;
   auto _weather_strength = _o->weather_strength;
   auto _fog_enabled = _o->fog_enabled;
-  auto _fog_color = _o->fog_color ? _o->fog_color.get() : 0;
+  auto _fog_color = _o->fog_color;
   auto _fog_min_distance = _o->fog_min_distance;
   auto _fog_max_distance = _o->fog_max_distance;
   auto _sky_layer_1_enabled = _o->sky_layer_1_enabled;
-  auto _sky_layer_1_color = _o->sky_layer_1_color ? _o->sky_layer_1_color.get() : 0;
+  auto _sky_layer_1_color = _o->sky_layer_1_color;
   auto _sky_layer_1_speed = _o->sky_layer_1_speed;
   auto _sky_layer_2_enabled = _o->sky_layer_2_enabled;
-  auto _sky_layer_2_color = _o->sky_layer_2_color ? _o->sky_layer_2_color.get() : 0;
+  auto _sky_layer_2_color = _o->sky_layer_2_color;
   auto _sky_layer_2_speed = _o->sky_layer_2_speed;
   auto _lensflare_sprite_id = _o->lensflare_sprite_id;
   auto _lensflare_pitch = _o->lensflare_pitch;
   auto _lensflare_yaw = _o->lensflare_yaw;
-  auto _lensflare_color = _o->lensflare_color ? _o->lensflare_color.get() : 0;
+  auto _lensflare_color = _o->lensflare_color;
   auto _starfield_star_count = _o->starfield_star_count;
   auto _starfield_meteor_count = _o->starfield_meteor_count;
   auto _starfield_meteor_spawn_density = _o->starfield_meteor_spawn_density;

--- a/TombEngine/Specific/savegame/flatbuffers/ten_savegame_generated.h
+++ b/TombEngine/Specific/savegame/flatbuffers/ten_savegame_generated.h
@@ -13,6 +13,10 @@ namespace Save {
 
 struct RoomVector;
 
+struct LevelData;
+struct LevelDataBuilder;
+struct LevelDataT;
+
 struct Room;
 struct RoomBuilder;
 struct RoomT;
@@ -536,6 +540,295 @@ FLATBUFFERS_STRUCT_END(KeyValPair, 8);
 struct KeyValPair::Traits {
   using type = KeyValPair;
 };
+
+struct LevelDataT : public flatbuffers::NativeTable {
+  typedef LevelData TableType;
+  int32_t level_far_view = 0;
+  bool storm_enabled = false;
+  int32_t weather_type = 0;
+  float weather_strength = 0.0f;
+  bool fog_enabled = false;
+  std::unique_ptr<TEN::Save::Vector3> fog_color{};
+  int32_t fog_min_distance = 0;
+  int32_t fog_max_distance = 0;
+  bool sky_layer_1_enabled = false;
+  std::unique_ptr<TEN::Save::Vector3> sky_layer_1_color{};
+  int32_t sky_layer_1_speed = 0;
+  bool sky_layer_2_enabled = false;
+  std::unique_ptr<TEN::Save::Vector3> sky_layer_2_color{};
+  int32_t sky_layer_2_speed = 0;
+  int32_t lensflare_sprite_id = 0;
+  float lensflare_pitch = 0.0f;
+  float lensflare_yaw = 0.0f;
+  std::unique_ptr<TEN::Save::Vector3> lensflare_color{};
+  int32_t starfield_star_count = 0;
+  int32_t starfield_meteor_count = 0;
+  int32_t starfield_meteor_spawn_density = 0;
+  int32_t starfield_meteor_velocity = 0;
+};
+
+struct LevelData FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef LevelDataT NativeTableType;
+  typedef LevelDataBuilder Builder;
+  struct Traits;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
+    VT_LEVEL_FAR_VIEW = 4,
+    VT_STORM_ENABLED = 6,
+    VT_WEATHER_TYPE = 8,
+    VT_WEATHER_STRENGTH = 10,
+    VT_FOG_ENABLED = 12,
+    VT_FOG_COLOR = 14,
+    VT_FOG_MIN_DISTANCE = 16,
+    VT_FOG_MAX_DISTANCE = 18,
+    VT_SKY_LAYER_1_ENABLED = 20,
+    VT_SKY_LAYER_1_COLOR = 22,
+    VT_SKY_LAYER_1_SPEED = 24,
+    VT_SKY_LAYER_2_ENABLED = 26,
+    VT_SKY_LAYER_2_COLOR = 28,
+    VT_SKY_LAYER_2_SPEED = 30,
+    VT_LENSFLARE_SPRITE_ID = 32,
+    VT_LENSFLARE_PITCH = 34,
+    VT_LENSFLARE_YAW = 36,
+    VT_LENSFLARE_COLOR = 38,
+    VT_STARFIELD_STAR_COUNT = 40,
+    VT_STARFIELD_METEOR_COUNT = 42,
+    VT_STARFIELD_METEOR_SPAWN_DENSITY = 44,
+    VT_STARFIELD_METEOR_VELOCITY = 46
+  };
+  int32_t level_far_view() const {
+    return GetField<int32_t>(VT_LEVEL_FAR_VIEW, 0);
+  }
+  bool storm_enabled() const {
+    return GetField<uint8_t>(VT_STORM_ENABLED, 0) != 0;
+  }
+  int32_t weather_type() const {
+    return GetField<int32_t>(VT_WEATHER_TYPE, 0);
+  }
+  float weather_strength() const {
+    return GetField<float>(VT_WEATHER_STRENGTH, 0.0f);
+  }
+  bool fog_enabled() const {
+    return GetField<uint8_t>(VT_FOG_ENABLED, 0) != 0;
+  }
+  const TEN::Save::Vector3 *fog_color() const {
+    return GetStruct<const TEN::Save::Vector3 *>(VT_FOG_COLOR);
+  }
+  int32_t fog_min_distance() const {
+    return GetField<int32_t>(VT_FOG_MIN_DISTANCE, 0);
+  }
+  int32_t fog_max_distance() const {
+    return GetField<int32_t>(VT_FOG_MAX_DISTANCE, 0);
+  }
+  bool sky_layer_1_enabled() const {
+    return GetField<uint8_t>(VT_SKY_LAYER_1_ENABLED, 0) != 0;
+  }
+  const TEN::Save::Vector3 *sky_layer_1_color() const {
+    return GetStruct<const TEN::Save::Vector3 *>(VT_SKY_LAYER_1_COLOR);
+  }
+  int32_t sky_layer_1_speed() const {
+    return GetField<int32_t>(VT_SKY_LAYER_1_SPEED, 0);
+  }
+  bool sky_layer_2_enabled() const {
+    return GetField<uint8_t>(VT_SKY_LAYER_2_ENABLED, 0) != 0;
+  }
+  const TEN::Save::Vector3 *sky_layer_2_color() const {
+    return GetStruct<const TEN::Save::Vector3 *>(VT_SKY_LAYER_2_COLOR);
+  }
+  int32_t sky_layer_2_speed() const {
+    return GetField<int32_t>(VT_SKY_LAYER_2_SPEED, 0);
+  }
+  int32_t lensflare_sprite_id() const {
+    return GetField<int32_t>(VT_LENSFLARE_SPRITE_ID, 0);
+  }
+  float lensflare_pitch() const {
+    return GetField<float>(VT_LENSFLARE_PITCH, 0.0f);
+  }
+  float lensflare_yaw() const {
+    return GetField<float>(VT_LENSFLARE_YAW, 0.0f);
+  }
+  const TEN::Save::Vector3 *lensflare_color() const {
+    return GetStruct<const TEN::Save::Vector3 *>(VT_LENSFLARE_COLOR);
+  }
+  int32_t starfield_star_count() const {
+    return GetField<int32_t>(VT_STARFIELD_STAR_COUNT, 0);
+  }
+  int32_t starfield_meteor_count() const {
+    return GetField<int32_t>(VT_STARFIELD_METEOR_COUNT, 0);
+  }
+  int32_t starfield_meteor_spawn_density() const {
+    return GetField<int32_t>(VT_STARFIELD_METEOR_SPAWN_DENSITY, 0);
+  }
+  int32_t starfield_meteor_velocity() const {
+    return GetField<int32_t>(VT_STARFIELD_METEOR_VELOCITY, 0);
+  }
+  bool Verify(flatbuffers::Verifier &verifier) const {
+    return VerifyTableStart(verifier) &&
+           VerifyField<int32_t>(verifier, VT_LEVEL_FAR_VIEW) &&
+           VerifyField<uint8_t>(verifier, VT_STORM_ENABLED) &&
+           VerifyField<int32_t>(verifier, VT_WEATHER_TYPE) &&
+           VerifyField<float>(verifier, VT_WEATHER_STRENGTH) &&
+           VerifyField<uint8_t>(verifier, VT_FOG_ENABLED) &&
+           VerifyField<TEN::Save::Vector3>(verifier, VT_FOG_COLOR) &&
+           VerifyField<int32_t>(verifier, VT_FOG_MIN_DISTANCE) &&
+           VerifyField<int32_t>(verifier, VT_FOG_MAX_DISTANCE) &&
+           VerifyField<uint8_t>(verifier, VT_SKY_LAYER_1_ENABLED) &&
+           VerifyField<TEN::Save::Vector3>(verifier, VT_SKY_LAYER_1_COLOR) &&
+           VerifyField<int32_t>(verifier, VT_SKY_LAYER_1_SPEED) &&
+           VerifyField<uint8_t>(verifier, VT_SKY_LAYER_2_ENABLED) &&
+           VerifyField<TEN::Save::Vector3>(verifier, VT_SKY_LAYER_2_COLOR) &&
+           VerifyField<int32_t>(verifier, VT_SKY_LAYER_2_SPEED) &&
+           VerifyField<int32_t>(verifier, VT_LENSFLARE_SPRITE_ID) &&
+           VerifyField<float>(verifier, VT_LENSFLARE_PITCH) &&
+           VerifyField<float>(verifier, VT_LENSFLARE_YAW) &&
+           VerifyField<TEN::Save::Vector3>(verifier, VT_LENSFLARE_COLOR) &&
+           VerifyField<int32_t>(verifier, VT_STARFIELD_STAR_COUNT) &&
+           VerifyField<int32_t>(verifier, VT_STARFIELD_METEOR_COUNT) &&
+           VerifyField<int32_t>(verifier, VT_STARFIELD_METEOR_SPAWN_DENSITY) &&
+           VerifyField<int32_t>(verifier, VT_STARFIELD_METEOR_VELOCITY) &&
+           verifier.EndTable();
+  }
+  LevelDataT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  void UnPackTo(LevelDataT *_o, const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  static flatbuffers::Offset<LevelData> Pack(flatbuffers::FlatBufferBuilder &_fbb, const LevelDataT* _o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+};
+
+struct LevelDataBuilder {
+  typedef LevelData Table;
+  flatbuffers::FlatBufferBuilder &fbb_;
+  flatbuffers::uoffset_t start_;
+  void add_level_far_view(int32_t level_far_view) {
+    fbb_.AddElement<int32_t>(LevelData::VT_LEVEL_FAR_VIEW, level_far_view, 0);
+  }
+  void add_storm_enabled(bool storm_enabled) {
+    fbb_.AddElement<uint8_t>(LevelData::VT_STORM_ENABLED, static_cast<uint8_t>(storm_enabled), 0);
+  }
+  void add_weather_type(int32_t weather_type) {
+    fbb_.AddElement<int32_t>(LevelData::VT_WEATHER_TYPE, weather_type, 0);
+  }
+  void add_weather_strength(float weather_strength) {
+    fbb_.AddElement<float>(LevelData::VT_WEATHER_STRENGTH, weather_strength, 0.0f);
+  }
+  void add_fog_enabled(bool fog_enabled) {
+    fbb_.AddElement<uint8_t>(LevelData::VT_FOG_ENABLED, static_cast<uint8_t>(fog_enabled), 0);
+  }
+  void add_fog_color(const TEN::Save::Vector3 *fog_color) {
+    fbb_.AddStruct(LevelData::VT_FOG_COLOR, fog_color);
+  }
+  void add_fog_min_distance(int32_t fog_min_distance) {
+    fbb_.AddElement<int32_t>(LevelData::VT_FOG_MIN_DISTANCE, fog_min_distance, 0);
+  }
+  void add_fog_max_distance(int32_t fog_max_distance) {
+    fbb_.AddElement<int32_t>(LevelData::VT_FOG_MAX_DISTANCE, fog_max_distance, 0);
+  }
+  void add_sky_layer_1_enabled(bool sky_layer_1_enabled) {
+    fbb_.AddElement<uint8_t>(LevelData::VT_SKY_LAYER_1_ENABLED, static_cast<uint8_t>(sky_layer_1_enabled), 0);
+  }
+  void add_sky_layer_1_color(const TEN::Save::Vector3 *sky_layer_1_color) {
+    fbb_.AddStruct(LevelData::VT_SKY_LAYER_1_COLOR, sky_layer_1_color);
+  }
+  void add_sky_layer_1_speed(int32_t sky_layer_1_speed) {
+    fbb_.AddElement<int32_t>(LevelData::VT_SKY_LAYER_1_SPEED, sky_layer_1_speed, 0);
+  }
+  void add_sky_layer_2_enabled(bool sky_layer_2_enabled) {
+    fbb_.AddElement<uint8_t>(LevelData::VT_SKY_LAYER_2_ENABLED, static_cast<uint8_t>(sky_layer_2_enabled), 0);
+  }
+  void add_sky_layer_2_color(const TEN::Save::Vector3 *sky_layer_2_color) {
+    fbb_.AddStruct(LevelData::VT_SKY_LAYER_2_COLOR, sky_layer_2_color);
+  }
+  void add_sky_layer_2_speed(int32_t sky_layer_2_speed) {
+    fbb_.AddElement<int32_t>(LevelData::VT_SKY_LAYER_2_SPEED, sky_layer_2_speed, 0);
+  }
+  void add_lensflare_sprite_id(int32_t lensflare_sprite_id) {
+    fbb_.AddElement<int32_t>(LevelData::VT_LENSFLARE_SPRITE_ID, lensflare_sprite_id, 0);
+  }
+  void add_lensflare_pitch(float lensflare_pitch) {
+    fbb_.AddElement<float>(LevelData::VT_LENSFLARE_PITCH, lensflare_pitch, 0.0f);
+  }
+  void add_lensflare_yaw(float lensflare_yaw) {
+    fbb_.AddElement<float>(LevelData::VT_LENSFLARE_YAW, lensflare_yaw, 0.0f);
+  }
+  void add_lensflare_color(const TEN::Save::Vector3 *lensflare_color) {
+    fbb_.AddStruct(LevelData::VT_LENSFLARE_COLOR, lensflare_color);
+  }
+  void add_starfield_star_count(int32_t starfield_star_count) {
+    fbb_.AddElement<int32_t>(LevelData::VT_STARFIELD_STAR_COUNT, starfield_star_count, 0);
+  }
+  void add_starfield_meteor_count(int32_t starfield_meteor_count) {
+    fbb_.AddElement<int32_t>(LevelData::VT_STARFIELD_METEOR_COUNT, starfield_meteor_count, 0);
+  }
+  void add_starfield_meteor_spawn_density(int32_t starfield_meteor_spawn_density) {
+    fbb_.AddElement<int32_t>(LevelData::VT_STARFIELD_METEOR_SPAWN_DENSITY, starfield_meteor_spawn_density, 0);
+  }
+  void add_starfield_meteor_velocity(int32_t starfield_meteor_velocity) {
+    fbb_.AddElement<int32_t>(LevelData::VT_STARFIELD_METEOR_VELOCITY, starfield_meteor_velocity, 0);
+  }
+  explicit LevelDataBuilder(flatbuffers::FlatBufferBuilder &_fbb)
+        : fbb_(_fbb) {
+    start_ = fbb_.StartTable();
+  }
+  flatbuffers::Offset<LevelData> Finish() {
+    const auto end = fbb_.EndTable(start_);
+    auto o = flatbuffers::Offset<LevelData>(end);
+    return o;
+  }
+};
+
+inline flatbuffers::Offset<LevelData> CreateLevelData(
+    flatbuffers::FlatBufferBuilder &_fbb,
+    int32_t level_far_view = 0,
+    bool storm_enabled = false,
+    int32_t weather_type = 0,
+    float weather_strength = 0.0f,
+    bool fog_enabled = false,
+    const TEN::Save::Vector3 *fog_color = 0,
+    int32_t fog_min_distance = 0,
+    int32_t fog_max_distance = 0,
+    bool sky_layer_1_enabled = false,
+    const TEN::Save::Vector3 *sky_layer_1_color = 0,
+    int32_t sky_layer_1_speed = 0,
+    bool sky_layer_2_enabled = false,
+    const TEN::Save::Vector3 *sky_layer_2_color = 0,
+    int32_t sky_layer_2_speed = 0,
+    int32_t lensflare_sprite_id = 0,
+    float lensflare_pitch = 0.0f,
+    float lensflare_yaw = 0.0f,
+    const TEN::Save::Vector3 *lensflare_color = 0,
+    int32_t starfield_star_count = 0,
+    int32_t starfield_meteor_count = 0,
+    int32_t starfield_meteor_spawn_density = 0,
+    int32_t starfield_meteor_velocity = 0) {
+  LevelDataBuilder builder_(_fbb);
+  builder_.add_starfield_meteor_velocity(starfield_meteor_velocity);
+  builder_.add_starfield_meteor_spawn_density(starfield_meteor_spawn_density);
+  builder_.add_starfield_meteor_count(starfield_meteor_count);
+  builder_.add_starfield_star_count(starfield_star_count);
+  builder_.add_lensflare_color(lensflare_color);
+  builder_.add_lensflare_yaw(lensflare_yaw);
+  builder_.add_lensflare_pitch(lensflare_pitch);
+  builder_.add_lensflare_sprite_id(lensflare_sprite_id);
+  builder_.add_sky_layer_2_speed(sky_layer_2_speed);
+  builder_.add_sky_layer_2_color(sky_layer_2_color);
+  builder_.add_sky_layer_1_speed(sky_layer_1_speed);
+  builder_.add_sky_layer_1_color(sky_layer_1_color);
+  builder_.add_fog_max_distance(fog_max_distance);
+  builder_.add_fog_min_distance(fog_min_distance);
+  builder_.add_fog_color(fog_color);
+  builder_.add_weather_strength(weather_strength);
+  builder_.add_weather_type(weather_type);
+  builder_.add_level_far_view(level_far_view);
+  builder_.add_sky_layer_2_enabled(sky_layer_2_enabled);
+  builder_.add_sky_layer_1_enabled(sky_layer_1_enabled);
+  builder_.add_fog_enabled(fog_enabled);
+  builder_.add_storm_enabled(storm_enabled);
+  return builder_.Finish();
+}
+
+struct LevelData::Traits {
+  using type = LevelData;
+  static auto constexpr Create = CreateLevelData;
+};
+
+flatbuffers::Offset<LevelData> CreateLevelData(flatbuffers::FlatBufferBuilder &_fbb, const LevelDataT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 
 struct RoomT : public flatbuffers::NativeTable {
   typedef Room TableType;
@@ -7499,6 +7792,7 @@ struct SaveGameT : public flatbuffers::NativeTable {
   std::unique_ptr<TEN::Save::SaveGameHeaderT> header{};
   std::unique_ptr<TEN::Save::SaveGameStatisticsT> game{};
   std::unique_ptr<TEN::Save::SaveGameStatisticsT> level{};
+  std::unique_ptr<TEN::Save::LevelDataT> level_data{};
   int32_t secret_bits = 0;
   std::unique_ptr<TEN::Save::CameraT> camera{};
   std::unique_ptr<TEN::Save::LaraT> lara{};
@@ -7564,61 +7858,62 @@ struct SaveGame FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
     VT_HEADER = 4,
     VT_GAME = 6,
     VT_LEVEL = 8,
-    VT_SECRET_BITS = 10,
-    VT_CAMERA = 12,
-    VT_LARA = 14,
-    VT_ROOMS = 16,
-    VT_ITEMS = 18,
-    VT_NEXT_ITEM_FREE = 20,
-    VT_NEXT_ITEM_ACTIVE = 22,
-    VT_ROOM_ITEMS = 24,
-    VT_FISH_SWARM = 26,
-    VT_FXINFOS = 28,
-    VT_NEXT_FX_FREE = 30,
-    VT_NEXT_FX_ACTIVE = 32,
-    VT_FIXED_CAMERAS = 34,
-    VT_SINKS = 36,
-    VT_STATIC_MESHES = 38,
-    VT_FLYBY_CAMERAS = 40,
-    VT_PARTICLES = 42,
-    VT_RATS = 44,
-    VT_SPIDERS = 46,
-    VT_SCARABS = 48,
-    VT_BATS = 50,
-    VT_FLIP_MAPS = 52,
-    VT_FLIP_STATS = 54,
-    VT_FLIP_EFFECT = 56,
-    VT_FLIP_TIMER = 58,
-    VT_FLIP_STATUS = 60,
-    VT_CURRENT_FOV = 62,
-    VT_LAST_INV_ITEM = 64,
-    VT_ACTION_QUEUE = 66,
-    VT_SOUNDTRACKS = 68,
-    VT_CD_FLAGS = 70,
-    VT_POSTPROCESS_MODE = 72,
-    VT_POSTPROCESS_STRENGTH = 74,
-    VT_POSTPROCESS_TINT = 76,
-    VT_ROPE = 78,
-    VT_PENDULUM = 80,
-    VT_ALTERNATE_PENDULUM = 82,
-    VT_VOLUMES = 84,
-    VT_GLOBAL_EVENT_SETS = 86,
-    VT_VOLUME_EVENT_SETS = 88,
-    VT_SCRIPT_VARS = 90,
-    VT_CALLBACKS_PRE_START = 92,
-    VT_CALLBACKS_POST_START = 94,
-    VT_CALLBACKS_PRE_END = 96,
-    VT_CALLBACKS_POST_END = 98,
-    VT_CALLBACKS_PRE_SAVE = 100,
-    VT_CALLBACKS_POST_SAVE = 102,
-    VT_CALLBACKS_PRE_LOAD = 104,
-    VT_CALLBACKS_POST_LOAD = 106,
-    VT_CALLBACKS_PRE_LOOP = 108,
-    VT_CALLBACKS_POST_LOOP = 110,
-    VT_CALLBACKS_PRE_USEITEM = 112,
-    VT_CALLBACKS_POST_USEITEM = 114,
-    VT_CALLBACKS_PRE_FREEZE = 116,
-    VT_CALLBACKS_POST_FREEZE = 118
+    VT_LEVEL_DATA = 10,
+    VT_SECRET_BITS = 12,
+    VT_CAMERA = 14,
+    VT_LARA = 16,
+    VT_ROOMS = 18,
+    VT_ITEMS = 20,
+    VT_NEXT_ITEM_FREE = 22,
+    VT_NEXT_ITEM_ACTIVE = 24,
+    VT_ROOM_ITEMS = 26,
+    VT_FISH_SWARM = 28,
+    VT_FXINFOS = 30,
+    VT_NEXT_FX_FREE = 32,
+    VT_NEXT_FX_ACTIVE = 34,
+    VT_FIXED_CAMERAS = 36,
+    VT_SINKS = 38,
+    VT_STATIC_MESHES = 40,
+    VT_FLYBY_CAMERAS = 42,
+    VT_PARTICLES = 44,
+    VT_RATS = 46,
+    VT_SPIDERS = 48,
+    VT_SCARABS = 50,
+    VT_BATS = 52,
+    VT_FLIP_MAPS = 54,
+    VT_FLIP_STATS = 56,
+    VT_FLIP_EFFECT = 58,
+    VT_FLIP_TIMER = 60,
+    VT_FLIP_STATUS = 62,
+    VT_CURRENT_FOV = 64,
+    VT_LAST_INV_ITEM = 66,
+    VT_ACTION_QUEUE = 68,
+    VT_SOUNDTRACKS = 70,
+    VT_CD_FLAGS = 72,
+    VT_POSTPROCESS_MODE = 74,
+    VT_POSTPROCESS_STRENGTH = 76,
+    VT_POSTPROCESS_TINT = 78,
+    VT_ROPE = 80,
+    VT_PENDULUM = 82,
+    VT_ALTERNATE_PENDULUM = 84,
+    VT_VOLUMES = 86,
+    VT_GLOBAL_EVENT_SETS = 88,
+    VT_VOLUME_EVENT_SETS = 90,
+    VT_SCRIPT_VARS = 92,
+    VT_CALLBACKS_PRE_START = 94,
+    VT_CALLBACKS_POST_START = 96,
+    VT_CALLBACKS_PRE_END = 98,
+    VT_CALLBACKS_POST_END = 100,
+    VT_CALLBACKS_PRE_SAVE = 102,
+    VT_CALLBACKS_POST_SAVE = 104,
+    VT_CALLBACKS_PRE_LOAD = 106,
+    VT_CALLBACKS_POST_LOAD = 108,
+    VT_CALLBACKS_PRE_LOOP = 110,
+    VT_CALLBACKS_POST_LOOP = 112,
+    VT_CALLBACKS_PRE_USEITEM = 114,
+    VT_CALLBACKS_POST_USEITEM = 116,
+    VT_CALLBACKS_PRE_FREEZE = 118,
+    VT_CALLBACKS_POST_FREEZE = 120
   };
   const TEN::Save::SaveGameHeader *header() const {
     return GetPointer<const TEN::Save::SaveGameHeader *>(VT_HEADER);
@@ -7628,6 +7923,9 @@ struct SaveGame FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   }
   const TEN::Save::SaveGameStatistics *level() const {
     return GetPointer<const TEN::Save::SaveGameStatistics *>(VT_LEVEL);
+  }
+  const TEN::Save::LevelData *level_data() const {
+    return GetPointer<const TEN::Save::LevelData *>(VT_LEVEL_DATA);
   }
   int32_t secret_bits() const {
     return GetField<int32_t>(VT_SECRET_BITS, 0);
@@ -7802,6 +8100,8 @@ struct SaveGame FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            verifier.VerifyTable(game()) &&
            VerifyOffset(verifier, VT_LEVEL) &&
            verifier.VerifyTable(level()) &&
+           VerifyOffset(verifier, VT_LEVEL_DATA) &&
+           verifier.VerifyTable(level_data()) &&
            VerifyField<int32_t>(verifier, VT_SECRET_BITS) &&
            VerifyOffset(verifier, VT_CAMERA) &&
            verifier.VerifyTable(camera()) &&
@@ -7949,6 +8249,9 @@ struct SaveGameBuilder {
   }
   void add_level(flatbuffers::Offset<TEN::Save::SaveGameStatistics> level) {
     fbb_.AddOffset(SaveGame::VT_LEVEL, level);
+  }
+  void add_level_data(flatbuffers::Offset<TEN::Save::LevelData> level_data) {
+    fbb_.AddOffset(SaveGame::VT_LEVEL_DATA, level_data);
   }
   void add_secret_bits(int32_t secret_bits) {
     fbb_.AddElement<int32_t>(SaveGame::VT_SECRET_BITS, secret_bits, 0);
@@ -8131,6 +8434,7 @@ inline flatbuffers::Offset<SaveGame> CreateSaveGame(
     flatbuffers::Offset<TEN::Save::SaveGameHeader> header = 0,
     flatbuffers::Offset<TEN::Save::SaveGameStatistics> game = 0,
     flatbuffers::Offset<TEN::Save::SaveGameStatistics> level = 0,
+    flatbuffers::Offset<TEN::Save::LevelData> level_data = 0,
     int32_t secret_bits = 0,
     flatbuffers::Offset<TEN::Save::Camera> camera = 0,
     flatbuffers::Offset<TEN::Save::Lara> lara = 0,
@@ -8241,6 +8545,7 @@ inline flatbuffers::Offset<SaveGame> CreateSaveGame(
   builder_.add_lara(lara);
   builder_.add_camera(camera);
   builder_.add_secret_bits(secret_bits);
+  builder_.add_level_data(level_data);
   builder_.add_level(level);
   builder_.add_game(game);
   builder_.add_header(header);
@@ -8258,6 +8563,7 @@ inline flatbuffers::Offset<SaveGame> CreateSaveGameDirect(
     flatbuffers::Offset<TEN::Save::SaveGameHeader> header = 0,
     flatbuffers::Offset<TEN::Save::SaveGameStatistics> game = 0,
     flatbuffers::Offset<TEN::Save::SaveGameStatistics> level = 0,
+    flatbuffers::Offset<TEN::Save::LevelData> level_data = 0,
     int32_t secret_bits = 0,
     flatbuffers::Offset<TEN::Save::Camera> camera = 0,
     flatbuffers::Offset<TEN::Save::Lara> lara = 0,
@@ -8354,6 +8660,7 @@ inline flatbuffers::Offset<SaveGame> CreateSaveGameDirect(
       header,
       game,
       level,
+      level_data,
       secret_bits,
       camera,
       lara,
@@ -8412,6 +8719,95 @@ inline flatbuffers::Offset<SaveGame> CreateSaveGameDirect(
 }
 
 flatbuffers::Offset<SaveGame> CreateSaveGame(flatbuffers::FlatBufferBuilder &_fbb, const SaveGameT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+
+inline LevelDataT *LevelData::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
+  auto _o = std::make_unique<LevelDataT>();
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
+}
+
+inline void LevelData::UnPackTo(LevelDataT *_o, const flatbuffers::resolver_function_t *_resolver) const {
+  (void)_o;
+  (void)_resolver;
+  { auto _e = level_far_view(); _o->level_far_view = _e; }
+  { auto _e = storm_enabled(); _o->storm_enabled = _e; }
+  { auto _e = weather_type(); _o->weather_type = _e; }
+  { auto _e = weather_strength(); _o->weather_strength = _e; }
+  { auto _e = fog_enabled(); _o->fog_enabled = _e; }
+  { auto _e = fog_color(); if (_e) _o->fog_color = std::unique_ptr<TEN::Save::Vector3>(new TEN::Save::Vector3(*_e)); }
+  { auto _e = fog_min_distance(); _o->fog_min_distance = _e; }
+  { auto _e = fog_max_distance(); _o->fog_max_distance = _e; }
+  { auto _e = sky_layer_1_enabled(); _o->sky_layer_1_enabled = _e; }
+  { auto _e = sky_layer_1_color(); if (_e) _o->sky_layer_1_color = std::unique_ptr<TEN::Save::Vector3>(new TEN::Save::Vector3(*_e)); }
+  { auto _e = sky_layer_1_speed(); _o->sky_layer_1_speed = _e; }
+  { auto _e = sky_layer_2_enabled(); _o->sky_layer_2_enabled = _e; }
+  { auto _e = sky_layer_2_color(); if (_e) _o->sky_layer_2_color = std::unique_ptr<TEN::Save::Vector3>(new TEN::Save::Vector3(*_e)); }
+  { auto _e = sky_layer_2_speed(); _o->sky_layer_2_speed = _e; }
+  { auto _e = lensflare_sprite_id(); _o->lensflare_sprite_id = _e; }
+  { auto _e = lensflare_pitch(); _o->lensflare_pitch = _e; }
+  { auto _e = lensflare_yaw(); _o->lensflare_yaw = _e; }
+  { auto _e = lensflare_color(); if (_e) _o->lensflare_color = std::unique_ptr<TEN::Save::Vector3>(new TEN::Save::Vector3(*_e)); }
+  { auto _e = starfield_star_count(); _o->starfield_star_count = _e; }
+  { auto _e = starfield_meteor_count(); _o->starfield_meteor_count = _e; }
+  { auto _e = starfield_meteor_spawn_density(); _o->starfield_meteor_spawn_density = _e; }
+  { auto _e = starfield_meteor_velocity(); _o->starfield_meteor_velocity = _e; }
+}
+
+inline flatbuffers::Offset<LevelData> LevelData::Pack(flatbuffers::FlatBufferBuilder &_fbb, const LevelDataT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
+  return CreateLevelData(_fbb, _o, _rehasher);
+}
+
+inline flatbuffers::Offset<LevelData> CreateLevelData(flatbuffers::FlatBufferBuilder &_fbb, const LevelDataT *_o, const flatbuffers::rehasher_function_t *_rehasher) {
+  (void)_rehasher;
+  (void)_o;
+  struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const LevelDataT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
+  auto _level_far_view = _o->level_far_view;
+  auto _storm_enabled = _o->storm_enabled;
+  auto _weather_type = _o->weather_type;
+  auto _weather_strength = _o->weather_strength;
+  auto _fog_enabled = _o->fog_enabled;
+  auto _fog_color = _o->fog_color ? _o->fog_color.get() : 0;
+  auto _fog_min_distance = _o->fog_min_distance;
+  auto _fog_max_distance = _o->fog_max_distance;
+  auto _sky_layer_1_enabled = _o->sky_layer_1_enabled;
+  auto _sky_layer_1_color = _o->sky_layer_1_color ? _o->sky_layer_1_color.get() : 0;
+  auto _sky_layer_1_speed = _o->sky_layer_1_speed;
+  auto _sky_layer_2_enabled = _o->sky_layer_2_enabled;
+  auto _sky_layer_2_color = _o->sky_layer_2_color ? _o->sky_layer_2_color.get() : 0;
+  auto _sky_layer_2_speed = _o->sky_layer_2_speed;
+  auto _lensflare_sprite_id = _o->lensflare_sprite_id;
+  auto _lensflare_pitch = _o->lensflare_pitch;
+  auto _lensflare_yaw = _o->lensflare_yaw;
+  auto _lensflare_color = _o->lensflare_color ? _o->lensflare_color.get() : 0;
+  auto _starfield_star_count = _o->starfield_star_count;
+  auto _starfield_meteor_count = _o->starfield_meteor_count;
+  auto _starfield_meteor_spawn_density = _o->starfield_meteor_spawn_density;
+  auto _starfield_meteor_velocity = _o->starfield_meteor_velocity;
+  return TEN::Save::CreateLevelData(
+      _fbb,
+      _level_far_view,
+      _storm_enabled,
+      _weather_type,
+      _weather_strength,
+      _fog_enabled,
+      _fog_color,
+      _fog_min_distance,
+      _fog_max_distance,
+      _sky_layer_1_enabled,
+      _sky_layer_1_color,
+      _sky_layer_1_speed,
+      _sky_layer_2_enabled,
+      _sky_layer_2_color,
+      _sky_layer_2_speed,
+      _lensflare_sprite_id,
+      _lensflare_pitch,
+      _lensflare_yaw,
+      _lensflare_color,
+      _starfield_star_count,
+      _starfield_meteor_count,
+      _starfield_meteor_spawn_density,
+      _starfield_meteor_velocity);
+}
 
 inline RoomT *Room::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
   auto _o = std::make_unique<RoomT>();
@@ -10665,6 +11061,7 @@ inline void SaveGame::UnPackTo(SaveGameT *_o, const flatbuffers::resolver_functi
   { auto _e = header(); if (_e) _o->header = std::unique_ptr<TEN::Save::SaveGameHeaderT>(_e->UnPack(_resolver)); }
   { auto _e = game(); if (_e) _o->game = std::unique_ptr<TEN::Save::SaveGameStatisticsT>(_e->UnPack(_resolver)); }
   { auto _e = level(); if (_e) _o->level = std::unique_ptr<TEN::Save::SaveGameStatisticsT>(_e->UnPack(_resolver)); }
+  { auto _e = level_data(); if (_e) _o->level_data = std::unique_ptr<TEN::Save::LevelDataT>(_e->UnPack(_resolver)); }
   { auto _e = secret_bits(); _o->secret_bits = _e; }
   { auto _e = camera(); if (_e) _o->camera = std::unique_ptr<TEN::Save::CameraT>(_e->UnPack(_resolver)); }
   { auto _e = lara(); if (_e) _o->lara = std::unique_ptr<TEN::Save::LaraT>(_e->UnPack(_resolver)); }
@@ -10733,6 +11130,7 @@ inline flatbuffers::Offset<SaveGame> CreateSaveGame(flatbuffers::FlatBufferBuild
   auto _header = _o->header ? CreateSaveGameHeader(_fbb, _o->header.get(), _rehasher) : 0;
   auto _game = _o->game ? CreateSaveGameStatistics(_fbb, _o->game.get(), _rehasher) : 0;
   auto _level = _o->level ? CreateSaveGameStatistics(_fbb, _o->level.get(), _rehasher) : 0;
+  auto _level_data = _o->level_data ? CreateLevelData(_fbb, _o->level_data.get(), _rehasher) : 0;
   auto _secret_bits = _o->secret_bits;
   auto _camera = _o->camera ? CreateCamera(_fbb, _o->camera.get(), _rehasher) : 0;
   auto _lara = _o->lara ? CreateLara(_fbb, _o->lara.get(), _rehasher) : 0;
@@ -10793,6 +11191,7 @@ inline flatbuffers::Offset<SaveGame> CreateSaveGame(flatbuffers::FlatBufferBuild
       _header,
       _game,
       _level,
+      _level_data,
       _secret_bits,
       _camera,
       _lara,

--- a/TombEngine/Specific/savegame/schema/ten_savegame.fbs
+++ b/TombEngine/Specific/savegame/schema/ten_savegame.fbs
@@ -14,22 +14,22 @@ table LevelData {
 	weather_strength: float;
 	
 	fog_enabled: bool;
-	fog_color: Vector3;
+	fog_color: int32;
 	fog_min_distance: int32;
 	fog_max_distance: int32;
 
 	sky_layer_1_enabled: bool;
-	sky_layer_1_color: Vector3;
+	sky_layer_1_color: int32;
 	sky_layer_1_speed: int32;
 
 	sky_layer_2_enabled: bool;
-	sky_layer_2_color: Vector3;
+	sky_layer_2_color: int32;
 	sky_layer_2_speed: int32;
 
 	lensflare_sprite_id: int32;
 	lensflare_pitch: float;
 	lensflare_yaw: float;
-	lensflare_color: Vector3;
+	lensflare_color: int32;
 
 	starfield_star_count: int32;
 	starfield_meteor_count: int32;

--- a/TombEngine/Specific/savegame/schema/ten_savegame.fbs
+++ b/TombEngine/Specific/savegame/schema/ten_savegame.fbs
@@ -6,6 +6,37 @@ struct RoomVector {
 	y_location: uint32;
 }
 
+table LevelData {
+	level_far_view: int32;
+
+	storm_enabled: bool;
+	weather_type: int32;
+	weather_strength: float;
+	
+	fog_enabled: bool;
+	fog_color: Vector3;
+	fog_min_distance: int32;
+	fog_max_distance: int32;
+
+	sky_layer_1_enabled: bool;
+	sky_layer_1_color: Vector3;
+	sky_layer_1_speed: int32;
+
+	sky_layer_2_enabled: bool;
+	sky_layer_2_color: Vector3;
+	sky_layer_2_speed: int32;
+
+	lensflare_sprite_id: int32;
+	lensflare_pitch: float;
+	lensflare_yaw: float;
+	lensflare_color: Vector3;
+
+	starfield_star_count: int32;
+	starfield_meteor_count: int32;
+	starfield_meteor_spawn_density: int32;
+	starfield_meteor_velocity: int32;
+}
+
 table Room {
 	index: int32;
 	name: string;
@@ -541,6 +572,7 @@ table SaveGame {
 	header: SaveGameHeader;
 	game: SaveGameStatistics;
 	level: SaveGameStatistics;
+	level_data: LevelData;
 	secret_bits: int32;
 	camera: Camera;
 	lara: Lara;


### PR DESCRIPTION
## Checklist

- [x] I have added a changelog entry to CHANGELOG.md file on the branch/fork (if it is an internal change then it is not needed) 
- [x] Pull request meets the Coding Conventions standards: https://github.com/MontyTRC89/TombEngine/blob/master/CONTRIBUTING.md#coding-conventions

## Links to issue(s) this pull request concerns (if applicable)

N/A

## Description of pull request 

Saves parameters of a `Flow.Level` structure to a savegame, such as fog color/distance or sky layer color/speed. Also properly resets those parameters if new game is started or level is restarted.