### PR TITLE
Fix namaspace of `DisplaySprite`

### DIFF
--- a/TombEngine/Scripting/Internal/TEN/View/ViewHandler.cpp
+++ b/TombEngine/Scripting/Internal/TEN/View/ViewHandler.cpp
@@ -367,6 +367,9 @@ namespace TEN::Scripting::View
 		tableView.set_function("PlayFlyBy", &PlayFlyby);
 
 		// Register types.
+		ScriptDisplaySprite::Register(*state, tableView);
+
+		// Register types COMPATIBILITY
 		ScriptDisplaySprite::Register(*state, parent);
 
 		// Register enums.


### PR DESCRIPTION
## Checklist

- [x] I have added a changelog entry to CHANGELOG.md file on the branch/fork (if it is an internal change then it is not needed) 
- [x] Pull request meets the Coding Conventions standards: https://github.com/MontyTRC89/TombEngine/blob/master/CONTRIBUTING.md#coding-conventions

## Links to issue(s) this pull request concerns (if applicable)

n/a

## Description of pull request 
DisplaySprite class registered with the correct namespace `TEN.View.DisplaySprite`. `TEN.DisplaySprite` has been preserved for backward compatibility.
The lua code works fine:
```lua
local centerScreen = TEN.View.DisplaySprite(1354, 31, TEN.Vec2(50, 50), 0, TEN.Vec2(10,10))
local bottomScreen = TEN.DisplaySprite(1354, 31, TEN.Vec2(50, 90), 0, TEN.Vec2(10,10))
```