### PR TITLE
Improve CSS organization in compile.bat

### DIFF
--- a/Documentation/compile.bat
+++ b/Documentation/compile.bat
@@ -1,6 +1,8 @@
 @echo off
-setlocal
+setlocal enabledelayedexpansion
 set DOC_DIR=.\doc
+set CSS_DIR=%DOC_DIR%\css
+set CUSTOM_CSS_DIR=.\css
 set LDOC_DIR=.\compiler\ldoc
 set LUA_PATH=.\compiler\?.lua
 set LUA_CPATH=.\compiler\?.dll
@@ -22,6 +24,49 @@ echo Running LDoc compiler...
 if %ERRORLEVEL% neq 0 (
     echo LDoc compilation failed with error code %ERRORLEVEL%
     exit /b %ERRORLEVEL%
+)
+
+echo Organizing CSS files...
+mkdir %CSS_DIR%
+if exist "%DOC_DIR%\ldoc.css" (
+    move /Y %DOC_DIR%\ldoc.css %CSS_DIR%\
+    echo CSS moved to css folder
+    
+    echo Updating CSS references in HTML files...
+    powershell -Command "(Get-ChildItem '%DOC_DIR%' -Filter *.html -Recurse) | ForEach-Object { (Get-Content $_.FullName -Raw) -replace 'ldoc\.css', 'css/ldoc.css' | Set-Content $_.FullName -NoNewline }"
+)
+
+if exist "%CUSTOM_CSS_DIR%" (
+    echo Processing custom CSS files...
+    xcopy /Y /Q "%CUSTOM_CSS_DIR%\*.css" "%CSS_DIR%\"
+    
+    echo Adding custom CSS links to HTML files...
+    for %%d in ("%DOC_DIR%") do set "docFullPath=%%~fd"
+    
+    for %%f in (%CUSTOM_CSS_DIR%\*.css) do (
+        set "cssName=%%~nf"
+        
+        for /r "%DOC_DIR%" %%h in (!cssName!.html) do (
+            if exist "%%h" (
+                set "htmlDir=%%~dph"
+                set "htmlDir=!htmlDir:~0,-1!"
+                set "relPath=!htmlDir:%docFullPath%=!"
+                set "depth=0"
+                
+                if not "!relPath!"=="" (
+                    for %%a in ("!relPath:\=" "!") do set /a depth+=1
+                )
+                
+                set "cssPath="
+                if !depth! gtr 0 (
+                    for /l %%i in (1,1,!depth!) do set "cssPath=!cssPath!../"
+                )
+                set "cssPath=!cssPath!css/!cssName!.css"
+                
+                powershell -Command "$content = Get-Content '%%h' -Raw; $link = '    <link rel=\"stylesheet\" href=\"!cssPath!\">' + [Environment]::NewLine + '</head>'; $content = $content -replace '</head>', $link; Set-Content '%%h' $content -NoNewline"
+            )
+        )
+    )
 )
 
 echo Post-processing Settings XML structure...

--- a/Documentation/compile.bat
+++ b/Documentation/compile.bat
@@ -43,7 +43,7 @@ if exist "%CUSTOM_CSS_DIR%" (
     echo Adding custom CSS links to HTML files...
     for %%d in ("%DOC_DIR%") do set "docFullPath=%%~fd"
     
-    for %%f in (%CUSTOM_CSS_DIR%\*.css) do (
+    for %%f in ("%CUSTOM_CSS_DIR%\*.css") do (
         set "cssName=%%~nf"
         
         for /r "%DOC_DIR%" %%h in (!cssName!.html) do (

--- a/Documentation/compile.bat
+++ b/Documentation/compile.bat
@@ -27,7 +27,7 @@ if %ERRORLEVEL% neq 0 (
 )
 
 echo Organizing CSS files...
-mkdir %CSS_DIR%
+if not exist "%CSS_DIR%" mkdir "%CSS_DIR%"
 if exist "%DOC_DIR%\ldoc.css" (
     move /Y %DOC_DIR%\ldoc.css %CSS_DIR%\
     echo CSS moved to css folder


### PR DESCRIPTION
CSS files are now moved to a dedicated css directory, and HTML files are updated to reference the new location. Custom CSS files are copied and linked automatically, enhancing maintainability and modularity of documentation styling.

## Checklist

- [ ] I have added a changelog entry to CHANGELOG.md file on the branch/fork (if it is an internal change then it is not needed) 
- [x] Pull request meets the Coding Conventions standards: https://github.com/MontyTRC89/TombEngine/blob/master/CONTRIBUTING.md#coding-conventions

## Links to issue(s) this pull request concerns (if applicable)

n/a

## Description of pull request 
CSS files are now moved to a dedicated css directory, and HTML files are updated to reference the new location. Custom CSS files are copied and linked automatically, enhancing maintainability and modularity of documentation styling.