### PR TITLE
Fix ShortenTENCalls function

### DIFF
--- a/TombEngine/Scripting/Internal/TEN/Logic/LogicHandler.cpp
+++ b/TombEngine/Scripting/Internal/TEN/Logic/LogicHandler.cpp
@@ -977,12 +977,12 @@ void LogicHandler::ResetVariables()
 
 void LogicHandler::ShortenTENCalls()
 {
-	auto str = R"(
+	auto str = R"(local ShortenInner 
 	local exceptions = {
-		"DisplaySprite"
+		DisplaySprite = true,
 	}
 
-	local ShortenInner = function(tab)
+	ShortenInner = function(tab)
 		for k, v in pairs(tab) do
 			if _G[k] and not exceptions[k] then
 				print("WARNING! Key " .. k .. " already exists in global environment!")


### PR DESCRIPTION
## Checklist

- [x] I have added a changelog entry to CHANGELOG.md file on the branch/fork (if it is an internal change then it is not needed) 
- [x] Pull request meets the Coding Conventions standards: https://github.com/MontyTRC89/TombEngine/blob/master/CONTRIBUTING.md#coding-conventions

## Links to issue(s) this pull request concerns (if applicable)

n/a

## Description of pull request 
Added an `exception` table inside the `ShortenTENCalls` function to avoid receiving duplicate table warnings for specific tables