### PR TITLE
Add `TestNeighborRooms()`

### DIFF
--- a/TombEngine/Game/collision/collide_room.cpp
+++ b/TombEngine/Game/collision/collide_room.cpp
@@ -11,11 +11,13 @@
 #include "Game/room.h"
 #include "Math/Math.h"
 #include "Sound/sound.h"
+#include "Specific/trutils.h"
 
 using namespace TEN::Collision::Floordata;
 using namespace TEN::Collision::Point;
 using namespace TEN::Collision::Room;
 using namespace TEN::Math;
+using namespace TEN::Utils;
 
 void ShiftItem(ItemInfo* item, CollisionInfo* coll)
 {
@@ -736,6 +738,12 @@ void AlignEntityToSurface(ItemInfo* item, const Vector2& ellipse, float alpha, s
 int GetQuadrant(short angle)
 {
 	return (unsigned short(angle + ANGLE(45.0f)) / ANGLE(90.0f));
+}
+
+bool TestNeighborRooms(int roomNumber0, int roomNumber1)
+{
+	const auto& room0 = g_Level.Rooms[roomNumber0];
+	return Contains(room0.NeighborRoomNumbers, roomNumber1);
 }
 
 // Determines vertical surfaces and gets nearest ledge angle.

--- a/TombEngine/Game/collision/collide_room.h
+++ b/TombEngine/Game/collision/collide_room.h
@@ -146,6 +146,8 @@ void SnapItemToGrid(ItemInfo* item, CollisionInfo* coll);
 
 void AlignEntityToSurface(ItemInfo* item, const Vector2& ellipse, float alpha = 0.75f, short constraintAngle = ANGLE(70.0f));
 
+bool TestNeighborRooms(int roomNumber0, int roomNumber1);
+
 // TODO: Deprecated.
 bool TestEnvironment(RoomEnvFlags environmentType, int x, int y, int z, int roomNumber);
 bool TestEnvironment(RoomEnvFlags environmentType, const Vector3i& pos, int roomNumber);

--- a/TombEngine/Objects/TR1/Trap/DamoclesSword.cpp
+++ b/TombEngine/Objects/TR1/Trap/DamoclesSword.cpp
@@ -26,8 +26,8 @@ namespace TEN::Entities::Traps
 	constexpr auto DAMOCLES_SWORD_VELOCITY_MIN = BLOCK(1 / 20.0f);
 	constexpr auto DAMOCLES_SWORD_VELOCITY_MAX = BLOCK(1 / 8.0f);
 
-	constexpr auto DAMOCLES_SWORD_IMPALE_DEPTH			  = -BLOCK(1 / 8.0f);
-	constexpr auto DAMOCLES_SWORD_ACTIVATE_RANGE_2D		  = BLOCK(1.5f);
+	constexpr auto DAMOCLES_SWORD_IMPALE_DEPTH            = -BLOCK(1 / 8.0f);
+	constexpr auto DAMOCLES_SWORD_ACTIVATE_RANGE_2D       = BLOCK(1.5f);
 	constexpr auto DAMOCLES_SWORD_ACTIVATE_RANGE_VERTICAL = BLOCK(3);
 
 	constexpr auto DAMOCLES_SWORD_TURN_RATE_MAX = ANGLE(5.0f);
@@ -47,7 +47,7 @@ namespace TEN::Entities::Traps
 	void ControlDamoclesSword(short itemNumber)
 	{
 		auto& item = g_Level.Items[itemNumber];
-		const auto& laraItem = *LaraItem;
+		const auto& playerItem = *LaraItem;
 
 		// Fall toward player.
 		if (item.Animation.IsAirborne)
@@ -58,7 +58,7 @@ namespace TEN::Entities::Traps
 			item.Animation.Velocity.y += (item.Animation.Velocity.y < DAMOCLES_SWORD_VELOCITY_MAX) ? g_GameFlow->GetSettings()->Physics.Gravity : 1.0f;
 
 			// Translate sword.
-			short headingAngle = Geometry::GetOrientToPoint(item.Pose.Position.ToVector3(), laraItem.Pose.Position.ToVector3()).y;
+			short headingAngle = Geometry::GetOrientToPoint(item.Pose.Position.ToVector3(), playerItem.Pose.Position.ToVector3()).y;
 			TranslateItem(&item, headingAngle, item.ItemFlags[1], item.Animation.Velocity.y);
 
 			int vPos = item.Pose.Position.y;
@@ -68,8 +68,8 @@ namespace TEN::Entities::Traps
 			if ((pointColl.GetFloorHeight() - vPos) <= DAMOCLES_SWORD_IMPALE_DEPTH)
 			{
 				SoundEffect(SFX_TR1_DAMOCLES_ROOM_SWORD, &item.Pose);
-				float distance = Vector3::Distance(item.Pose.Position.ToVector3(), Camera.pos.ToVector3());
-				Camera.bounce = -((BLOCK(7.0f / 2) - distance) * abs(item.Animation.Velocity.y)) / BLOCK(7.0f / 2);
+				float dist = Vector3::Distance(item.Pose.Position.ToVector3(), Camera.pos.ToVector3());
+				Camera.bounce = -((BLOCK(7.0f / 2) - dist) * abs(item.Animation.Velocity.y)) / BLOCK(7.0f / 2);
 
 				item.Animation.IsAirborne = false;
 				item.Status = ItemStatus::ITEM_DEACTIVATED;
@@ -81,31 +81,31 @@ namespace TEN::Entities::Traps
 			return;
 		}
 		
-		// Scan for player.
-		if (item.Pose.Position.y < GetPointCollision(item).GetFloorHeight())
+		// Test for player nearby.
+		if (TestNeighborRooms(item.RoomNumber, playerItem.RoomNumber) && item.Pose.Position.y < GetPointCollision(item).GetFloorHeight())
 		{
 			item.Pose.Orientation.y += item.ItemFlags[0];
 
 			// Check vertical position to player.
-			if (item.Pose.Position.y >= laraItem.Pose.Position.y)
+			if (item.Pose.Position.y >= playerItem.Pose.Position.y)
 				return;
 
 			// Check vertical distance.
-			float distanceV = laraItem.Pose.Position.y - item.Pose.Position.y;
-			if (distanceV > DAMOCLES_SWORD_ACTIVATE_RANGE_VERTICAL)
+			float distV = playerItem.Pose.Position.y - item.Pose.Position.y;
+			if (distV > DAMOCLES_SWORD_ACTIVATE_RANGE_VERTICAL)
 				return;
 
 			// Check 2D distance.
-			float distance2D = Vector2i::Distance(
+			float dist2D = Vector2i::Distance(
 				Vector2i(item.Pose.Position.x, item.Pose.Position.z),
-				Vector2i(laraItem.Pose.Position.x, laraItem.Pose.Position.z));
-			if (distance2D > DAMOCLES_SWORD_ACTIVATE_RANGE_2D)
+				Vector2i(playerItem.Pose.Position.x, playerItem.Pose.Position.z));
+			if (dist2D > DAMOCLES_SWORD_ACTIVATE_RANGE_2D)
 				return;
 
 			// Drop sword.
 			// TODO: Have 2D velocity also take vertical distance into account.
 			item.Animation.IsAirborne = true;
-			item.ItemFlags[1] = distance2D / 32;
+			item.ItemFlags[1] = dist2D / 32;
 			return;
 		}
 	}


### PR DESCRIPTION
## Checklist

- [x] I have added a changelog entry to CHANGELOG.md file on the branch/fork (if it is an internal change then it is not needed) 
- [x] Pull request meets the Coding Conventions standards: https://github.com/MontyTRC89/TombEngine/blob/master/CONTRIBUTING.md#coding-conventions

## Links to issue(s) this pull request concerns (if applicable)
n/a

## Description of pull request
Adds `TestNeighborRooms()` function as discussed on Discord. This can be used to check if two moveables are in neighbouring rooms and can logically interact. In this PR, I have applied it to the Damocles sword to prevent it from falling if the player comes near it in an overlapping room.