### PR TITLE
Optimization of the `Type` module

### DIFF
--- a/Scripts/Engine/Type.lua
+++ b/Scripts/Engine/Type.lua
@@ -140,7 +140,7 @@ end
 --      end
 --  end
 Type.IsColor = function (variable)
-    return type(variable) == "userdata" and getmetatable(variable) == getmetatable(COLOR)
+    return getmetatable(variable) == getmetatable(COLOR)
 end
 
 --- Check if the variable is a @{Rotation}.
@@ -154,7 +154,7 @@ end
 --      end
 --  end
 Type.IsRotation = function (variable)
-    return type(variable) == "userdata" and getmetatable(variable) == getmetatable(ROTATION)
+    return getmetatable(variable) == getmetatable(ROTATION)
 end
 
 --- Check if the variable is a @{Vec2}.
@@ -168,7 +168,7 @@ end
 --      end
 --  end
 Type.IsVec2 = function (variable)
-    return type(variable) == "userdata" and getmetatable(variable) == getmetatable(VEC2)
+    return getmetatable(variable) == getmetatable(VEC2)
 end
 
 --- Check if the variable is a @{Vec3}.
@@ -182,7 +182,7 @@ end
 --      end
 --	end
 Type.IsVec3 = function (variable)
-    return type(variable) == "userdata" and getmetatable(variable) == getmetatable(VEC3)
+    return getmetatable(variable) == getmetatable(VEC3)
 end
 
 --- Check if the variable is a @{Time} object.
@@ -196,7 +196,7 @@ end
 --      end
 --	end
 Type.IsTime = function (variable)
-    return type(variable) == "userdata" and getmetatable(variable) == getmetatable(TIME)
+    return getmetatable(variable) == getmetatable(TIME)
 end
 
 --- Check if the variable is a LevelFunc.
@@ -210,7 +210,7 @@ end
 --      end
 --  end
 Type.IsLevelFunc = function (variable)
-    return type(variable) == "userdata" and getmetatable(variable) == getmetatable(LevelFuncs.Engine.TYPE_CONTROL_LEVELFUNC)
+    return getmetatable(variable) == getmetatable(LevelFuncs.Engine.TYPE_CONTROL_LEVELFUNC)
 end
 
 --- Check if the variable is an enum value.


### PR DESCRIPTION
## Checklist

- [x] I have added a changelog entry to CHANGELOG.md file on the branch/fork (if it is an internal change then it is not needed) 
- [x] Pull request meets the Coding Conventions standards: https://github.com/MontyTRC89/TombEngine/blob/master/CONTRIBUTING.md#coding-conventions

## Links to issue(s) this pull request concerns (if applicable)

n/a

## Description of pull request 

This pull request refactors the way primitive TEN type constants and internal sentinels are defined and used in `Scripts/Engine/Type.lua`. The main goal is to standardize naming conventions, reduce exposure of internal sentinels, and improve code clarity and maintainability.

**Refactoring of primitive type constants:**

* Replaced local lowercase variables (`color`, `rotation`, `time`, `vec2`, `vec3`) with uppercase constants (`COLOR`, `ROTATION`, `TIME`, `VEC2`, `VEC3`) for primitive TEN types to follow a clearer naming convention.
* Updated all type-checking functions (`Type.IsColor`, `Type.IsRotation`, `Type.IsVec2`, `Type.IsVec3`, `Type.IsTime`) to use the new uppercase constants instead of the old lowercase variables.

**Internal sentinel improvements:**

* Renamed the internal sentinel for LevelFunc type checks from `LevelFuncs.Engine.TypeControlLevelFunc` to `LevelFuncs.Engine.TYPE_CONTROL_LEVELFUNC` to match the uppercase constant naming convention and clarified its purpose in comments.
* Updated `Type.IsLevelFunc` to use the new sentinel name.