### PR TITLE
Use internal numerical ID instead of name for DisplayItem class

### DIFF
--- a/TombEngine/Game/Hud/DrawItems/DisplayItem.cpp
+++ b/TombEngine/Game/Hud/DrawItems/DisplayItem.cpp
@@ -11,9 +11,9 @@ using namespace TEN::Math;
 
 namespace TEN::Hud
 {
-	DisplayItem::DisplayItem(const std::string& name, GAME_OBJECT_ID objectID, const Vector3& pos, const EulerAngles& orient, const Vector3& scale)
+	DisplayItem::DisplayItem(unsigned int id, GAME_OBJECT_ID objectID, const Vector3& pos, const EulerAngles& orient, const Vector3& scale)
 	{
-		_itemName = name;
+		_id = id;
 		_objectID = objectID;
 		_position = pos;
 		_orientation = orient;
@@ -23,9 +23,9 @@ namespace TEN::Hud
 		_prevScale = scale;
 	}
 
-	const std::string& DisplayItem::GetName() const
+	unsigned int DisplayItem::GetID() const
 	{
-		return _itemName;
+		return _id;
 	}
 
 	GAME_OBJECT_ID DisplayItem::GetObjectID() const
@@ -135,11 +135,6 @@ namespace TEN::Hud
 		return EulerAngles::Lerp(prevIt->second, it->second, alpha);
 	}
 
-	void DisplayItem::SetName(const std::string& name)
-	{
-		_itemName = name;
-	}
-
 	void DisplayItem::SetObjectID(GAME_OBJECT_ID objectID)
 	{
 		_objectID = objectID;
@@ -149,7 +144,7 @@ namespace TEN::Hud
 	{
 		constexpr auto DELTA_TOLERANCE = 100.0f;
 
-		if (disableInterpolation || Vector3::Distance(pos, _position) > DELTA_TOLERANCE)
+		if (!_wasInterpolated || disableInterpolation || Vector3::Distance(pos, _position) > DELTA_TOLERANCE)
 			_prevPosition = pos;
 
 		_position = pos;
@@ -159,7 +154,7 @@ namespace TEN::Hud
 	{
 		constexpr auto DELTA_TOLERANCE = ANGLE(45);
 
-		if (disableInterpolation || !EulerAngles::Compare(orient, _orientation, DELTA_TOLERANCE))
+		if (!_wasInterpolated || disableInterpolation || !EulerAngles::Compare(orient, _orientation, DELTA_TOLERANCE))
 			_prevOrientation = orient;
 
 		_orientation = orient;
@@ -167,7 +162,7 @@ namespace TEN::Hud
 
 	void DisplayItem::SetScale(const Vector3& scale, bool disableInterpolation)
 	{
-		if (disableInterpolation)
+		if (!_wasInterpolated || disableInterpolation)
 			_prevScale = scale;
 
 		_scale = scale;
@@ -175,7 +170,7 @@ namespace TEN::Hud
 
 	void DisplayItem::SetColor(Color& color, bool disableInterpolation)
 	{
-		if (disableInterpolation)
+		if (!_wasInterpolated || disableInterpolation)
 			_prevColor = color;
 
 		_color = color;
@@ -278,5 +273,6 @@ namespace TEN::Hud
 		_prevColor = _color;
 		_prevMeshOrientations = _meshOrientations;
 		_prevFrameNumber = _frameNumber;
+		_wasInterpolated = true;
 	}
 }

--- a/TombEngine/Game/Hud/DrawItems/DisplayItem.h
+++ b/TombEngine/Game/Hud/DrawItems/DisplayItem.h
@@ -15,11 +15,12 @@ namespace TEN::Hud
 	private:
 		// Fields
 
-		std::string    _itemName = {};
+		unsigned int _id = 0;
 		GAME_OBJECT_ID _objectID = GAME_OBJECT_ID::ID_NO_OBJECT;
 
 		bool _visible = false;
 		bool _disposing = false;
+		bool _wasInterpolated = false;
 
 		Vector3                              _position         = Vector3::Zero;
 		EulerAngles                          _orientation      = EulerAngles::Identity;
@@ -42,11 +43,11 @@ namespace TEN::Hud
 		// Constructors
 
 		DisplayItem() = default;
-		DisplayItem(const std::string& name, GAME_OBJECT_ID objectID, const Vector3& pos, const EulerAngles& orient, const Vector3& scale);
+		DisplayItem(unsigned int id, GAME_OBJECT_ID objectID, const Vector3& pos, const EulerAngles& orient, const Vector3& scale);
 
 		// Getters
 
-		const std::string&                         GetName() const;
+		unsigned int                               GetID() const;
 		GAME_OBJECT_ID                             GetObjectID() const;
 		const Vector3&                             GetPosition() const;
 		std::optional<std::pair<Vector2, Vector2>> GetBounds() const;
@@ -74,7 +75,6 @@ namespace TEN::Hud
 
 		// Setters
 
-		void SetName(const std::string& name);
 		void SetObjectID(GAME_OBJECT_ID objectID);
 		void SetPosition(const Vector3& pos, bool disableInterpolation);
 		void SetOrientation(const EulerAngles& orient, bool disableInterpolation);

--- a/TombEngine/Game/Hud/DrawItems/DrawItems.cpp
+++ b/TombEngine/Game/Hud/DrawItems/DrawItems.cpp
@@ -13,11 +13,11 @@ namespace TEN::Hud
 {
 	DrawItemsController g_DrawItems = {};
 
-	DisplayItem* DrawItemsController::GetItemByName(const std::string& name)
+	DisplayItem* DrawItemsController::GetItemByID(unsigned int id)
 	{
 		for (auto& item : _displayItems)
 		{
-			if (item.GetName() == name)
+			if (item.GetID() == id)
 				return &item;
 		}
 
@@ -107,11 +107,11 @@ namespace TEN::Hud
 		return _displayItems.empty();
 	}
 
-	bool DrawItemsController::TestItemExists(const std::string& name)
+	bool DrawItemsController::TestItemExists(unsigned int id)
 	{
 		for (auto& item : _displayItems)
 		{
-			if (item.GetName() == name)
+			if (item.GetID() == id)
 			{
 				return true;
 			}
@@ -133,38 +133,30 @@ namespace TEN::Hud
 		return false;
 	}
 
-	void DrawItemsController::AddItem(const std::string& name, GAME_OBJECT_ID objectID, const Vector3& pos, const EulerAngles& orient, const Vector3& scale, int meshBits)
+	unsigned int DrawItemsController::AddItem(GAME_OBJECT_ID objectID, const Vector3& pos, const EulerAngles& orient, const Vector3& scale, int meshBits)
 	{
-		// Check if item already exists.
-		for (auto& item : _displayItems)
-		{
-			if (item.GetName() == name)
-			{
-				// Update existing item.
-				item.SetObjectID(objectID);
-				item.SetPosition(pos, true);
-				item.SetOrientation(orient, true);
-				item.SetScale(scale, true);
-				item.SetMeshBits(meshBits);
-				return;
-			}
-		}
-
 		// If at capacity, don’t add new item.
 		if (_displayItems.size() >= DRAW_ITEM_COUNT_MAX)
-			return;
+			return 0;
 
-		auto newItem = DisplayItem(name, objectID, pos, orient, scale);
+		if (_lastID == UINT_MAX)
+			_lastID = 0;
+
+		_lastID++;
+
+		auto newItem = DisplayItem(_lastID, objectID, pos, orient, scale);
 		newItem.SetMeshBits(meshBits);
 		_displayItems.push_back(newItem);
+
+		return _lastID;
 	}
 
-	void DrawItemsController::RemoveItem(const std::string& name)
+	void DrawItemsController::RemoveItem(unsigned int id)
 	{
 		auto item = std::find_if(_displayItems.begin(), _displayItems.end(),
 		[&](const DisplayItem& item)
 		{
-			return item.GetName() == name;
+			return item.GetID() == id;
 		});
 
 		if (item != _displayItems.end())

--- a/TombEngine/Game/Hud/DrawItems/DrawItems.h
+++ b/TombEngine/Game/Hud/DrawItems/DrawItems.h
@@ -28,10 +28,12 @@ namespace TEN::Hud
 		Vector3 _prevCameraPosition = _cameraPosition;
 		Vector3 _prevTargetPosition = _targetPosition;
 
+		unsigned int _lastID = 0;
+
 	public:
 		// Getters
 
-		DisplayItem*			  GetItemByName(const std::string& name);
+		DisplayItem*			  GetItemByID(unsigned int id);
 		std::vector<DisplayItem>& GetItems();
 		Vector3					  GetCameraPosition() const;
 		Vector3					  GetCameraTargetPosition() const;
@@ -51,13 +53,13 @@ namespace TEN::Hud
 		// Inquirers
 
 		bool IsEmpty();
-		bool TestItemExists(const std::string& name);
+		bool TestItemExists(unsigned int id);
 		bool TestObjectIDExists(GAME_OBJECT_ID objectID);
 
 		// Utilities
 
-		void AddItem(const std::string& name, GAME_OBJECT_ID objectID, const Vector3& origin, const EulerAngles& orient, const Vector3& scale, int meshBits);
-		void RemoveItem(const std::string& name);
+		unsigned int AddItem(GAME_OBJECT_ID objectID, const Vector3& origin, const EulerAngles& orient, const Vector3& scale, int meshBits);
+		void RemoveItem(unsigned int id);
 
 		void Prepare();
 		void Update();

--- a/TombEngine/Scripting/Internal/TEN/View/DisplayItem/ScriptDisplayItem.cpp
+++ b/TombEngine/Scripting/Internal/TEN/View/DisplayItem/ScriptDisplayItem.cpp
@@ -29,11 +29,11 @@ namespace TEN::Scripting::DisplayItem
 	void ScriptDisplayItem::Register(sol::state& state, sol::table& parent)
 	{
 		using ctors = sol::constructors<
-			ScriptDisplayItem(std::string, GAME_OBJECT_ID, const Vec3&, const Rotation&, const Vec3&, int),
-			ScriptDisplayItem(std::string, GAME_OBJECT_ID, const Vec3&, const Rotation&, const Vec3&),
-			ScriptDisplayItem(std::string, GAME_OBJECT_ID, const Vec3&, const Rotation&),
-			ScriptDisplayItem(std::string, GAME_OBJECT_ID, const Vec3&),
-			ScriptDisplayItem(std::string, GAME_OBJECT_ID)>;
+			ScriptDisplayItem(GAME_OBJECT_ID, const Vec3&, const Rotation&, const Vec3&, int),
+			ScriptDisplayItem(GAME_OBJECT_ID, const Vec3&, const Rotation&, const Vec3&),
+			ScriptDisplayItem(GAME_OBJECT_ID, const Vec3&, const Rotation&),
+			ScriptDisplayItem(GAME_OBJECT_ID, const Vec3&),
+			ScriptDisplayItem(GAME_OBJECT_ID)>;
 
 		// Register type.
 		parent.new_usertype<ScriptDisplayItem>(
@@ -79,16 +79,10 @@ namespace TEN::Scripting::DisplayItem
 
 	const TEN::Hud::DisplayItem* ScriptDisplayItem::TryGetItem() const
 	{
-		if (_name.empty())
-		{
-			TENLog("DisplayItem operation failed: name is empty.", LogLevel::Warning);
-			return nullptr;
-		}
-
-		auto* item = g_DrawItems.GetItemByName(_name);
+		auto* item = g_DrawItems.GetItemByID(_id);
 		if (item == nullptr)
 		{
-			TENLog("DisplayItem operation failed: item '" + _name + "' does not exist.", LogLevel::Warning);
+			TENLog(fmt::format("DisplayItem operation failed: item {} does not exist.", _id), LogLevel::Warning);
 			return nullptr;
 		}
 
@@ -201,11 +195,9 @@ namespace TEN::Scripting::DisplayItem
 	/// Class
 	// @section Class
 	// Methods for DisplayItem instances.
-	
 
 	/// Create a DisplayItem object.
 	// @function DisplayItem
-	// @tparam string name Lua name of the display item.
 	// @tparam Objects.ObjID objectID Slot object ID.
 	// @tparam[opt=Vec3(0&#44; 0&#44; 0)] Vec3 pos Position in 3D display space.
 	// @tparam[opt=Rotation(0&#44; 0&#44; 0)] Rotation rot Rotation on the XYZ axes.
@@ -213,36 +205,36 @@ namespace TEN::Scripting::DisplayItem
 	// @tparam[opt] int meshBits Packed meshbits.
 	// @treturn DisplayItem A new DisplayItem object.
 	// @usage
-	// local item = TEN.View.DisplayItem("My name", -- name
-	//	TEN.Objects.ObjID.PISTOLS_ITEM, -- object ID) 
+	// local item = TEN.View.DisplayItem(TEN.Objects.ObjID.PISTOLS_ITEM)
 
-	ScriptDisplayItem::ScriptDisplayItem(const std::string& name, GAME_OBJECT_ID objectID, const Vec3& pos, const Rotation& rot, const Vec3& scale, int meshBits)
+	ScriptDisplayItem::ScriptDisplayItem(GAME_OBJECT_ID objectID, const Vec3& pos, const Rotation& rot, const Vec3& scale, int meshBits)
 	{
-		_name = name;
-		g_DrawItems.AddItem(name, objectID, pos, rot.ToEulerAngles(), scale, meshBits);
+		auto potentialID = g_DrawItems.AddItem(objectID, pos, rot.ToEulerAngles(), scale, meshBits);
+		ScriptAssertTerminateF(potentialID, "Creation of display item failed. Possibly too many display items already active?");
+		_id = potentialID;
 	}
 
-	ScriptDisplayItem::ScriptDisplayItem(const std::string& name, GAME_OBJECT_ID objectID, const Vec3& pos, const Rotation& rot, const Vec3& scale) :
-		ScriptDisplayItem(name, objectID, pos, rot, scale, ALL_JOINT_BITS) { }
+	ScriptDisplayItem::ScriptDisplayItem(GAME_OBJECT_ID objectID, const Vec3& pos, const Rotation& rot, const Vec3& scale) :
+		ScriptDisplayItem(objectID, pos, rot, scale, ALL_JOINT_BITS) { }
 
-	ScriptDisplayItem::ScriptDisplayItem(const std::string& name, GAME_OBJECT_ID objectID, const Vec3& pos, const Rotation& rot) :
-		ScriptDisplayItem(name, objectID, pos, rot, Vector3::One, ALL_JOINT_BITS) { }
+	ScriptDisplayItem::ScriptDisplayItem(GAME_OBJECT_ID objectID, const Vec3& pos, const Rotation& rot) :
+		ScriptDisplayItem(objectID, pos, rot, Vector3::One, ALL_JOINT_BITS) { }
 
-	ScriptDisplayItem::ScriptDisplayItem(const std::string& name, GAME_OBJECT_ID objectID, const Vec3& pos) :
-		ScriptDisplayItem(name, objectID, pos, EulerAngles::Identity, Vector3::One, ALL_JOINT_BITS) { }
+	ScriptDisplayItem::ScriptDisplayItem(GAME_OBJECT_ID objectID, const Vec3& pos) :
+		ScriptDisplayItem(objectID, pos, EulerAngles::Identity, Vector3::One, ALL_JOINT_BITS) { }
 
-	ScriptDisplayItem::ScriptDisplayItem(const std::string& name, GAME_OBJECT_ID objectID) :
-		ScriptDisplayItem(name, objectID, Vector3::Zero, EulerAngles::Identity, Vector3::One, ALL_JOINT_BITS) { }
+	ScriptDisplayItem::ScriptDisplayItem(GAME_OBJECT_ID objectID) :
+		ScriptDisplayItem(objectID, Vector3::Zero, EulerAngles::Identity, Vector3::One, ALL_JOINT_BITS) { }
 
 	ScriptDisplayItem::~ScriptDisplayItem()
 	{
-		if (_name.empty() || !g_DrawItems.TestItemExists(_name))
+		if (!g_DrawItems.TestItemExists(_id))
 		{
-			TENLog("Attempt to remove display item with invalid name.", LogLevel::Warning);
+			TENLog(fmt::format("Attempt to remove display item with invalid ID {}.", _id), LogLevel::Warning);
 			return;
 		}
 
-		g_DrawItems.RemoveItem(_name);
+		g_DrawItems.RemoveItem(_id);
 	}
 
 	/// Change the display item's object ID. 
@@ -374,8 +366,7 @@ namespace TEN::Scripting::DisplayItem
 	// local objectID = item:GetObjectID()
 	GAME_OBJECT_ID ScriptDisplayItem::GetObjectID() const
 	{
-		auto* item = g_DrawItems.GetItemByName(_name);
-		if (item != nullptr)
+		if (auto* item = TryGetItem())
 			return item->GetObjectID();
 
 		return ID_NO_OBJECT;
@@ -552,7 +543,7 @@ namespace TEN::Scripting::DisplayItem
 	/// Draw the display item in display space for the current frame.
 	// @function DisplayItem:Draw
 	// @usage
-	// local endFrame = item:Draw()
+	// item:Draw()
 	void ScriptDisplayItem::Draw()
 	{
 		if (auto* item = TryGetItem())

--- a/TombEngine/Scripting/Internal/TEN/View/DisplayItem/ScriptDisplayItem.h
+++ b/TombEngine/Scripting/Internal/TEN/View/DisplayItem/ScriptDisplayItem.h
@@ -21,7 +21,7 @@ namespace TEN::Scripting::DisplayItem
 	private:
 		// Fields
 
-		std::string _name = {};
+		unsigned int _id = 0;
 
 		// Methods
 
@@ -31,11 +31,11 @@ namespace TEN::Scripting::DisplayItem
 	public:
 		// Constructors
 
-		ScriptDisplayItem(const std::string& name, GAME_OBJECT_ID objectID, const Vec3& pos, const Rotation& rot, const Vec3& scale, int meshBits);
-		ScriptDisplayItem(const std::string& name, GAME_OBJECT_ID objectID, const Vec3& pos, const Rotation& rot, const Vec3& scale);
-		ScriptDisplayItem(const std::string& name, GAME_OBJECT_ID objectID, const Vec3& pos, const Rotation& rot);
-		ScriptDisplayItem(const std::string& name, GAME_OBJECT_ID objectID, const Vec3& pos);
-		ScriptDisplayItem(const std::string& name, GAME_OBJECT_ID objectID);
+		ScriptDisplayItem(GAME_OBJECT_ID objectID, const Vec3& pos, const Rotation& rot, const Vec3& scale, int meshBits);
+		ScriptDisplayItem(GAME_OBJECT_ID objectID, const Vec3& pos, const Rotation& rot, const Vec3& scale);
+		ScriptDisplayItem(GAME_OBJECT_ID objectID, const Vec3& pos, const Rotation& rot);
+		ScriptDisplayItem(GAME_OBJECT_ID objectID, const Vec3& pos);
+		ScriptDisplayItem(GAME_OBJECT_ID objectID);
 		~ScriptDisplayItem();
 
 		// Setters


### PR DESCRIPTION
Replaces name with internal ID, as name is not necessary if construction and destruction of DisplayItems is now handled automatically.

To be reviewed by Copilot.