### PR TITLE
Fix optional Settings fields not generated correctly in XML output

### DIFF
--- a/Documentation/settings_class_post_process.ps1
+++ b/Documentation/settings_class_post_process.ps1
@@ -81,11 +81,11 @@ function Get-FieldDocumentation {
                 $description = $matches[3]
 
                 # Parse optional/default value from modifiers (e.g. "opt=true", "opt")
-                if ($optModifiers) {
+                if ($optModifiers -match '(?:^|,)\s*opt(?:=([^,]*))?') {
                     $optional = $true
 
-                    if ($optModifiers -match 'opt=(.+)') {
-                        $defaultValue = $matches[1] -replace '&#44;', ','
+                    if ($matches[1] -ne $null) {
+                        $defaultValue = $matches[1].Trim() -replace '&#44;', ','
                     }
                 }
             } elseif ($line.StartsWith('///')) {


### PR DESCRIPTION
## Checklist

- [ ] I have added a changelog entry to CHANGELOG.md file on the branch/fork (if it is an internal change then it is not needed) 
- [x] Pull request meets the Coding Conventions standards: https://github.com/MontyTRC89/TombEngine/blob/master/CONTRIBUTING.md#coding-conventions

## Links to issue(s) this pull request concerns (if applicable)

n/a

## Description of pull request 

This pull request updates the `settings_class_post_process.ps1` script to enhance how field documentation is parsed and represented, especially regarding type information and optional/default value metadata. The changes improve the extraction, storage, and XML output of field properties, making the generated documentation more informative and structured.

**Improvements to field metadata extraction and storage:**

* Enhanced the `Get-FieldDocumentation` function to parse and store type, optionality, and default value information from `@tfield` comment lines, including support for optional modifiers and default values.
* Updated the return object of `Get-FieldDocumentation` to include new fields: `Type`, `Optional`, and `DefaultValue`.
* Modified `Parse-SettingsFromCpp` to propagate the new field metadata (`Type`, `Optional`, `DefaultValue`) when collecting field information.

**Improvements to XML documentation output:**

* Updated `New-XmlFieldElement` to include a `<type>` element for fields when type information is available.
* Added `<optional>` and `<defaultValue>` elements to the XML output for fields marked as optional, including their default values if specified.