### PR TITLE
Fix for flying creatures (PredictTargetPosition Issue)

### DIFF
--- a/TombEngine/Game/control/box.cpp
+++ b/TombEngine/Game/control/box.cpp
@@ -2643,8 +2643,12 @@ void CreatureMood(ItemInfo* item, AI_INFO* AI, bool isViolent)
 
 	case MoodType::Attack:
 	{
-	// Flying creatures target enemy's upper body when on land.
-	auto targetOffset = (LOT->Zone == ZoneType::Flyer && Lara.Control.WaterStatus == WaterStatus::Dry)
+	// Flying creatures target enemy's upper body when enemy is not in water.
+	bool isEnemyOnLand = enemy->IsLara()
+		? (GetLaraInfo(*enemy).Control.WaterStatus == WaterStatus::Dry)		 // Lara.
+		: !TestEnvironment(RoomEnvFlags::ENV_FLAG_WATER, enemy->RoomNumber); // Other Creatures.
+
+	auto targetOffset = (LOT->Zone == ZoneType::Flyer && isEnemyOnLand)
 		? Vector3i(0, GetClosestKeyframe(*enemy).BoundingBox.Y1, 0) : Vector3i(0, 0, 0);
 
 	LOT->Target = PredictTargetPosition(*item, *enemy, targetOffset);

--- a/TombEngine/Game/control/box.cpp
+++ b/TombEngine/Game/control/box.cpp
@@ -2644,10 +2644,10 @@ void CreatureMood(ItemInfo* item, AI_INFO* AI, bool isViolent)
 	case MoodType::Attack:
 	{
 	// Flying creatures target enemy's upper body when on land.
-	int headOffset = (LOT->Zone == ZoneType::Flyer && Lara.Control.WaterStatus == WaterStatus::Dry)
-		? GetClosestKeyframe(*enemy).BoundingBox.Y1 : 0;
+	auto targetOffset = (LOT->Zone == ZoneType::Flyer && Lara.Control.WaterStatus == WaterStatus::Dry)
+		? Vector3i(0, GetClosestKeyframe(*enemy).BoundingBox.Y1, 0) : Vector3i(0, 0, 0);
 
-	LOT->Target = PredictTargetPosition(*item, *enemy, headOffset);
+	LOT->Target = PredictTargetPosition(*item, *enemy, targetOffset);
 	LOT->RequiredBox = enemy->BoxNumber;
 
 	break;
@@ -2897,7 +2897,7 @@ void GetCreatureMood(ItemInfo* item, AI_INFO* AI, bool isViolent)
 	}
 }
 
-Vector3i PredictTargetPosition(ItemInfo& sourceItem, ItemInfo& targetItem, int targetYOffset)
+Vector3i PredictTargetPosition(ItemInfo& sourceItem, ItemInfo& targetItem, Vector3i targetOffset)
 {
 	constexpr float PREDICTION_MIN_DISTANCE = BLOCK(0.5f);
 	constexpr float PREDICTION_MAX_DISTANCE = BLOCK(6);
@@ -2906,7 +2906,7 @@ Vector3i PredictTargetPosition(ItemInfo& sourceItem, ItemInfo& targetItem, int t
 
 	auto sourcePos = sourceItem.Pose.Position;
 	auto targetPos = targetItem.Pose.Position;
-	targetPos.y += targetYOffset;
+	targetPos += targetOffset;
 
 	auto predictionFactor = g_GameFlow->GetSettings()->Pathfinding.PredictionFactor;
 

--- a/TombEngine/Game/control/box.cpp
+++ b/TombEngine/Game/control/box.cpp
@@ -2642,18 +2642,16 @@ void CreatureMood(ItemInfo* item, AI_INFO* AI, bool isViolent)
 		break;
 
 	case MoodType::Attack:
-		// ATTACK: Go directly to enemy's position.
-		LOT->Target = PredictTargetPosition(*item, *enemy);
-		LOT->RequiredBox = enemy->BoxNumber;
+	{
+	// Flying creatures target enemy's upper body when on land.
+	int headOffset = (LOT->Zone == ZoneType::Flyer && Lara.Control.WaterStatus == WaterStatus::Dry)
+		? GetClosestKeyframe(*enemy).BoundingBox.Y1 : 0;
 
-		// Flying creatures target enemy's upper body when on land.
-		if (LOT->Zone == ZoneType::Flyer && Lara.Control.WaterStatus == WaterStatus::Dry)
-		{
-			auto& bounds = GetClosestKeyframe(*enemy).BoundingBox;
-			LOT->Target.y = enemy->Pose.Position.y + bounds.Y1;
-		}
+	LOT->Target = PredictTargetPosition(*item, *enemy, headOffset);
+	LOT->RequiredBox = enemy->BoxNumber;
 
-		break;
+	break;
+	}
 
 	case MoodType::Escape:
 		// ESCAPE: Find boxes far from and away from enemy.
@@ -2899,7 +2897,7 @@ void GetCreatureMood(ItemInfo* item, AI_INFO* AI, bool isViolent)
 	}
 }
 
-Vector3i PredictTargetPosition(ItemInfo& sourceItem, ItemInfo& targetItem)
+Vector3i PredictTargetPosition(ItemInfo& sourceItem, ItemInfo& targetItem, int targetYOffset)
 {
 	constexpr float PREDICTION_MIN_DISTANCE = BLOCK(0.5f);
 	constexpr float PREDICTION_MAX_DISTANCE = BLOCK(6);
@@ -2908,6 +2906,7 @@ Vector3i PredictTargetPosition(ItemInfo& sourceItem, ItemInfo& targetItem)
 
 	auto sourcePos = sourceItem.Pose.Position;
 	auto targetPos = targetItem.Pose.Position;
+	targetPos.y += targetYOffset;
 
 	auto predictionFactor = g_GameFlow->GetSettings()->Pathfinding.PredictionFactor;
 

--- a/TombEngine/Game/control/box.cpp
+++ b/TombEngine/Game/control/box.cpp
@@ -2650,7 +2650,7 @@ void CreatureMood(ItemInfo* item, AI_INFO* AI, bool isViolent)
 		if (LOT->Zone == ZoneType::Flyer && Lara.Control.WaterStatus == WaterStatus::Dry)
 		{
 			auto& bounds = GetClosestKeyframe(*enemy).BoundingBox;
-			LOT->Target.y += bounds.Y1;
+			LOT->Target.y = enemy->Pose.Position.y + bounds.Y1;
 		}
 
 		break;

--- a/TombEngine/Game/control/box.h
+++ b/TombEngine/Game/control/box.h
@@ -147,7 +147,7 @@ bool CreatureActive(short itemNumber);
 void InitializeCreature(short itemNumber);
 bool StalkBox(ItemInfo* item, ItemInfo* enemy, int boxNumber);
 void CreatureAIInfo(ItemInfo* item, AI_INFO* AI);
-Vector3i PredictTargetPosition(ItemInfo& sourceItem, ItemInfo& targetItem, int targetYOffset = 0);
+Vector3i PredictTargetPosition(ItemInfo& sourceItem, ItemInfo& targetItem, Vector3i targetOffset = Vector3i(0, 0, 0));
 TARGET_TYPE CalculateTarget(Vector3i* target, ItemInfo* item, LOTInfo* LOT);
 bool CreatureAnimation(short itemNumber, short headingAngle, short tiltAngle);
 void CreatureHealth(ItemInfo* item);

--- a/TombEngine/Game/control/box.h
+++ b/TombEngine/Game/control/box.h
@@ -147,7 +147,7 @@ bool CreatureActive(short itemNumber);
 void InitializeCreature(short itemNumber);
 bool StalkBox(ItemInfo* item, ItemInfo* enemy, int boxNumber);
 void CreatureAIInfo(ItemInfo* item, AI_INFO* AI);
-Vector3i PredictTargetPosition(ItemInfo& sourceItem, ItemInfo& targetItem);
+Vector3i PredictTargetPosition(ItemInfo& sourceItem, ItemInfo& targetItem, int targetYOffset = 0);
 TARGET_TYPE CalculateTarget(Vector3i* target, ItemInfo* item, LOTInfo* LOT);
 bool CreatureAnimation(short itemNumber, short headingAngle, short tiltAngle);
 void CreatureHealth(ItemInfo* item);


### PR DESCRIPTION
The issue is in CreatureMood::Attack. When PredictTargetPosition() is called, it uses LOT->Target (from the previous frame) as the smoothing base for interpolation. But LOT->Target.y from the last frame already had Y1 added to it. Then Y1 gets added again via LOT->Target.y += bounds.Y1, causing a double-application that accumulates each frame and pushes the target Y higher and higher — making flying creatures hover one block (or more) above Lara instead of at her level. In 1.10, the code was simply LOT->Target = enemy->Pose.Position, setting Y directly without any smoothing interference, then adding Y1 once. The fix is to override the Y directly instead of doing += bounds.Y1 through a smoothed position/
