### PR TITLE
Fix blood effect for spiky traps

### DIFF
--- a/TombEngine/Objects/TR4/Trap/SpikyCeiling.cpp
+++ b/TombEngine/Objects/TR4/Trap/SpikyCeiling.cpp
@@ -93,7 +93,7 @@ namespace TEN::Entities::Traps
 		if (TestBoundsCollide(&item, playerItem, coll->Setup.Radius))
 		{
 			DoDamage(playerItem, SPIKY_CEILING_HARM_DAMAGE);
-			DoLotsOfBlood(playerItem->Pose.Position.x, playerItem->Pose.Position.y + CLICK(3), playerItem->Pose.Position.z, 4, playerItem->Pose.Orientation.y, playerItem->RoomNumber, 3);
+			DoLotsOfBlood(playerItem->Pose.Position.x, playerItem->Pose.Position.y - CLICK(3), playerItem->Pose.Position.z, 4, playerItem->Pose.Orientation.y, playerItem->RoomNumber, 3);
 			playerItem->TouchBits.ClearAll();
 
 			SoundEffect(SFX_TR4_LARA_GRABFEET, &playerItem->Pose);

--- a/TombEngine/Objects/TR4/Trap/SpikyWall.cpp
+++ b/TombEngine/Objects/TR4/Trap/SpikyWall.cpp
@@ -143,7 +143,7 @@ namespace TEN::Entities::Traps
 		if (TestBoundsCollide(&item, playerItem, coll->Setup.Radius))
 		{
 			DoDamage(playerItem, SPIKY_WALL_HARM_DAMAGE);
-			DoLotsOfBlood(playerItem->Pose.Position.x, playerItem->Pose.Position.y + CLICK(2), playerItem->Pose.Position.z, 4, playerItem->Pose.Orientation.y, playerItem->RoomNumber, 3);
+			DoLotsOfBlood(playerItem->Pose.Position.x, playerItem->Pose.Position.y - CLICK(2), playerItem->Pose.Position.z, 4, playerItem->Pose.Orientation.y, playerItem->RoomNumber, 3);
 			playerItem->TouchBits.ClearAll();
 
 			SoundEffect(SFX_TR4_LARA_GRABFEET, &playerItem->Pose);


### PR DESCRIPTION
There is no blood effect when taking damage from a spiky wall\ceiling. The reason is blood spawns always underground.
Solution:
invert the math symbols in SpikyCeiling.cpp line 96
and SpikyWall.cpp line 146
