### PR TITLE
WIP: Wading Grass

### DIFF
--- a/TombEngine/Renderer/ConstantBuffers/GrassBuffer.h
+++ b/TombEngine/Renderer/ConstantBuffers/GrassBuffer.h
@@ -1,0 +1,63 @@
+#pragma once
+#include <SimpleMath.h>
+
+namespace TEN::Renderer::ConstantBuffers
+{
+	using namespace DirectX::SimpleMath;
+
+	constexpr int GRASS_INSTANCE_BUCKET_SIZE = 256;
+	constexpr int MAX_GRASS_INFLUENCE_SPHERES = 8;
+
+	struct alignas(16) GrassInfluenceSphere
+	{
+		Vector3 Position;
+		float Radius;
+		//--
+		float Intensity;
+		float Timestamp;
+		float Padding0;
+		float Padding1;
+	};
+
+	struct alignas(16) GrassInstance
+	{
+		Vector3 Position;
+		float Scale;
+		//--
+		Vector3 Normal;
+		float Seed;
+		//--
+		Vector4 Color;
+		//--
+		Vector2 UVOffset;
+		Vector2 UVScale;
+	};
+
+	struct alignas(16) CGrassSettingsBuffer
+	{
+		float MaxDrawDistance;
+		float FadeStartDistance;
+		float WindStrength;
+		float WindFrequency;
+		//--
+		Vector3 WindDirection;
+		float Time;
+		//--
+		float BendRiseSpeed;
+		float BendDecaySpeed;
+		float BendMaxAngle;
+		int NumInfluences;
+		//--
+		float BladeWidth;
+		float BladeHeight;
+		int DebugMode;
+		float Padding0;
+		//--
+		GrassInfluenceSphere Influences[MAX_GRASS_INFLUENCE_SPHERES];
+	};
+
+	struct alignas(16) CGrassInstanceBuffer
+	{
+		GrassInstance Instances[GRASS_INSTANCE_BUCKET_SIZE];
+	};
+}

--- a/TombEngine/Renderer/ConstantBuffers/GrassBuffer.h
+++ b/TombEngine/Renderer/ConstantBuffers/GrassBuffer.h
@@ -14,8 +14,8 @@ namespace TEN::Renderer::ConstantBuffers
 		float Radius;
 		//--
 		float Intensity;
-		float Timestamp;
-		float Padding0;
+		float Timestamp;       // Last refresh time (used for decay).
+		float BirthTimestamp;  // Creation time (used for rise).
 		float Padding1;
 	};
 
@@ -31,6 +31,15 @@ namespace TEN::Renderer::ConstantBuffers
 		//--
 		Vector2 UVOffset;
 		Vector2 UVScale;
+		//--
+		Vector3 AmbientLight;
+		float WindEnabled; // 1.0 = blade in outdoor (skybox) room; 0.0 = indoors, no wind.
+		//--
+		Vector3 SunDirection;
+		float SunIntensity;
+		//--
+		Vector3 SunColor;
+		float SunPad0;
 	};
 
 	struct alignas(16) CGrassSettingsBuffer

--- a/TombEngine/Renderer/Grass/GrassSystem.cpp
+++ b/TombEngine/Renderer/Grass/GrassSystem.cpp
@@ -1,0 +1,438 @@
+#include "framework.h"
+#include "Renderer/Grass/GrassSystem.h"
+
+#include <random>
+#include <algorithm>
+#include <map>
+
+#include "Game/collision/floordata.h"
+#include "Game/room.h"
+#include "Specific/level.h"
+#include "Math/Constants.h"
+#include "Renderer/RenderView.h"
+#include "Renderer/ConstantBuffers/ConstantBuffer.h"
+#include "Renderer/ConstantBuffers/GrassBuffer.h"
+
+using namespace TEN::Collision::Floordata;
+
+namespace TEN::Renderer::Grass
+{
+	// Tile dimension in world units (4 blocks = 4096).
+	static constexpr float TILE_SIZE = 4096.0f;
+
+	// Hash-based PRNG for deterministic placement.
+	static uint32_t HashPosition(int x, int z, uint32_t seed)
+	{
+		uint32_t h = seed;
+		h ^= (uint32_t)x + 0x9e3779b9 + (h << 6) + (h >> 2);
+		h ^= (uint32_t)z + 0x9e3779b9 + (h << 6) + (h >> 2);
+		return h;
+	}
+
+	static float HashToFloat01(uint32_t h)
+	{
+		return (float)(h & 0xFFFFFF) / (float)0xFFFFFF;
+	}
+
+	void GrassSystem::Initialize(ID3D11Device* device)
+	{
+		_initialized = true;
+		Clear();
+	}
+
+	void GrassSystem::Clear()
+	{
+		_allBlades.clear();
+		_tiles.clear();
+		_nextInfluenceSlot = 0;
+		_currentTime = 0.0f;
+		_lastVisibleTileCount = 0;
+		_lastVisibleBladeCount = 0;
+		_lastDrawCallCount = 0;
+
+		for (auto& inf : _influences)
+			inf.Active = false;
+	}
+
+	void GrassSystem::GenerateForLevel()
+	{
+		Clear();
+
+		for (int roomNum = 0; roomNum < (int)g_Level.Rooms.size(); roomNum++)
+		{
+			GenerateGrassForRoom(roomNum);
+		}
+
+		BuildTiles();
+	}
+
+	void GrassSystem::GenerateGrassForRoom(int roomNumber)
+	{
+		auto& room = g_Level.Rooms[roomNumber];
+
+		// Skip underwater rooms.
+		if (room.flags & ENV_FLAG_WATER)
+			return;
+
+		for (int gridX = 0; gridX < room.XSize; gridX++)
+		{
+			for (int gridZ = 0; gridZ < room.ZSize; gridZ++)
+			{
+				auto& sector = GetFloor(roomNumber, Vector2i(gridX, gridZ));
+
+				// Skip walls.
+				if (sector.IsWall(0) && sector.IsWall(1))
+					continue;
+
+				int worldX = room.Position.x + gridX * BLOCK_UNIT;
+				int worldZ = room.Position.z + gridZ * BLOCK_UNIT;
+
+				// Check both triangles of the floor for grass material.
+				for (int tri = 0; tri < 2; tri++)
+				{
+					auto& triData = sector.FloorSurface.Triangles[tri];
+
+					if (triData.Material != MaterialType::Grass)
+						continue;
+
+					// Get floor height at sector center for this triangle.
+					int sampleX = worldX + BLOCK_UNIT / 2;
+					int sampleZ = worldZ + BLOCK_UNIT / 2;
+					int floorHeight = sector.GetSurfaceHeight(sampleX, sampleZ, true);
+
+					if (floorHeight == NO_HEIGHT)
+						continue;
+
+					Vector3 normal = sector.GetSurfaceNormal(tri, true);
+
+					// Skip steep slopes (TEN uses inverted Y: flat floor normal.y = -1).
+					if (normal.y > -0.5f)
+						continue;
+
+					GenerateBladesForSector(
+						roomNumber, worldX, worldZ, floorHeight, normal, triData.Material);
+
+					break; // Only generate once per sector (both triangles share the space).
+				}
+			}
+		}
+	}
+
+	void GrassSystem::GenerateBladesForSector(
+		int roomNumber, int worldX, int worldZ,
+		int floorHeight, const Vector3& normal, MaterialType material)
+	{
+		float density = _config.Density;
+		float cellSize = BLOCK_UNIT / density;
+		int cellsPerAxis = (int)density;
+
+		uint32_t sectorSeed = HashPosition(worldX, worldZ, 0xDEAD);
+
+		for (int cx = 0; cx < cellsPerAxis; cx++)
+		{
+			for (int cz = 0; cz < cellsPerAxis; cz++)
+			{
+				uint32_t cellHash = HashPosition(cx + worldX * 137, cz + worldZ * 251, sectorSeed);
+				float rng0 = HashToFloat01(cellHash);
+				float rng1 = HashToFloat01(cellHash * 2654435761u);
+				float rng2 = HashToFloat01(cellHash * 340573321u);
+				float rng3 = HashToFloat01(cellHash * 1664525u + 1013904223u);
+
+				// Jittered position within cell.
+				float jitterX = (rng0 - 0.5f) * _config.JitterAmount;
+				float jitterZ = (rng1 - 0.5f) * _config.JitterAmount;
+
+				float localX = (cx + 0.5f + jitterX) * cellSize;
+				float localZ = (cz + 0.5f + jitterZ) * cellSize;
+
+				float finalX = worldX + localX;
+				float finalZ = worldZ + localZ;
+
+				// Clamp to sector bounds.
+				finalX = std::clamp(finalX, (float)worldX + 1.0f, (float)(worldX + BLOCK_UNIT) - 1.0f);
+				finalZ = std::clamp(finalZ, (float)worldZ + 1.0f, (float)(worldZ + BLOCK_UNIT) - 1.0f);
+
+				// Get the actual floor height at this exact position.
+				auto& room = g_Level.Rooms[roomNumber];
+				auto& sector = GetFloor(roomNumber, (int)finalX, (int)finalZ);
+
+				if (sector.IsWall((int)finalX, (int)finalZ))
+					continue;
+
+				int height = sector.GetSurfaceHeight((int)finalX, (int)finalZ, true);
+				if (height == NO_HEIGHT)
+					continue;
+
+				Vector3 localNormal = sector.GetSurfaceNormal((int)finalX, (int)finalZ, true);
+				if (localNormal.y > -0.5f)
+					continue;
+
+				GrassBlade blade;
+				blade.Position = Vector3(finalX, (float)height, finalZ);
+				blade.Normal = localNormal;
+				blade.Scale = _config.MinScale + rng2 * (_config.MaxScale - _config.MinScale);
+				blade.Seed = rng3; // Use independent hash for rotation to decorrelate from position jitter.
+				blade.Color = Vector4(0.75f + rng1 * 0.25f, 0.8f + rng2 * 0.2f, 0.65f + rng0 * 0.2f, 1.0f);
+
+				// Select a sprite variant from the atlas.
+				int totalSprites = _config.AtlasColumns * _config.AtlasRows;
+				blade.SpriteIdx = (int)(rng2 * totalSprites) % totalSprites;
+
+				_allBlades.push_back(blade);
+			}
+		}
+	}
+
+	void GrassSystem::BuildTiles()
+	{
+		if (_allBlades.empty())
+			return;
+
+		// Sort blades into spatial tiles based on XZ position.
+		struct TileKey
+		{
+			int tx, tz;
+			bool operator<(const TileKey& other) const
+			{
+				return (tx < other.tx) || (tx == other.tx && tz < other.tz);
+			}
+		};
+
+		std::map<TileKey, std::vector<int>> tileBladeIndices;
+
+		for (int i = 0; i < (int)_allBlades.size(); i++)
+		{
+			auto& blade = _allBlades[i];
+			int tx = (int)std::floor(blade.Position.x / TILE_SIZE);
+			int tz = (int)std::floor(blade.Position.z / TILE_SIZE);
+			tileBladeIndices[{tx, tz}].push_back(i);
+		}
+
+		// Rebuild the blade array sorted by tile, and create tile descriptors.
+		std::vector<GrassBlade> sortedBlades;
+		sortedBlades.reserve(_allBlades.size());
+
+		for (auto& [key, indices] : tileBladeIndices)
+		{
+			GrassTile tile;
+			tile.StartIndex = (int)sortedBlades.size();
+			tile.BladeCount = (int)indices.size();
+
+			Vector3 bmin(FLT_MAX, FLT_MAX, FLT_MAX);
+			Vector3 bmax(-FLT_MAX, -FLT_MAX, -FLT_MAX);
+
+			for (int idx : indices)
+			{
+				auto& blade = _allBlades[idx];
+				sortedBlades.push_back(blade);
+
+				bmin = Vector3::Min(bmin, blade.Position - Vector3(0, _config.BladeHeight, 0));
+				bmax = Vector3::Max(bmax, blade.Position + Vector3(0, _config.BladeHeight * 1.5f, 0));
+			}
+
+			// Expand the bounding box slightly for wind sway.
+			bmin -= Vector3(_config.BladeWidth, 0, _config.BladeWidth);
+			bmax += Vector3(_config.BladeWidth, 0, _config.BladeWidth);
+
+			tile.Bounds = BoundingBox(
+				(bmin + bmax) * 0.5f,
+				(bmax - bmin) * 0.5f);
+
+			_tiles.push_back(tile);
+		}
+
+		_allBlades = std::move(sortedBlades);
+	}
+
+	void GrassSystem::Update(float time)
+	{
+		_currentTime = time;
+	}
+
+	void GrassSystem::AddInfluence(const Vector3& position, float radius, float intensity)
+	{
+		// Try to find an existing influence at a similar position to update.
+		for (auto& inf : _influences)
+		{
+			if (inf.Active)
+			{
+				float dist = Vector3::Distance(inf.Position, position);
+				if (dist < radius * 0.5f)
+				{
+					// Update existing.
+					inf.Position = position;
+					inf.Radius = radius;
+					inf.Intensity = intensity;
+					inf.Timestamp = _currentTime;
+					return;
+				}
+			}
+		}
+
+		// Allocate a new slot (ring buffer with oldest eviction).
+		auto& slot = _influences[_nextInfluenceSlot];
+		slot.Position = position;
+		slot.Radius = radius;
+		slot.Intensity = intensity;
+		slot.Timestamp = _currentTime;
+		slot.Active = true;
+
+		_nextInfluenceSlot = (_nextInfluenceSlot + 1) % MAX_INFLUENCES;
+	}
+
+	void GrassSystem::Draw(
+		ID3D11DeviceContext* context,
+		const RenderView& view,
+		ConstantBuffer<CGrassSettingsBuffer>& cbSettings,
+		ConstantBuffer<CGrassInstanceBuffer>& cbInstances,
+		float time)
+	{
+		if (!_enabled || _allBlades.empty() || _tiles.empty())
+			return;
+
+		// Fill the settings constant buffer.
+		CGrassSettingsBuffer settings = {};
+		settings.MaxDrawDistance = _config.MaxDrawDistance;
+		settings.FadeStartDistance = _config.FadeStartDistance;
+		settings.WindStrength = _config.WindStrength;
+		settings.WindFrequency = _config.WindFrequency;
+		settings.WindDirection = _config.WindDirection;
+		settings.WindDirection.Normalize();
+		settings.Time = time;
+		settings.BendRiseSpeed = _config.BendRiseSpeed;
+		settings.BendDecaySpeed = _config.BendDecaySpeed;
+		settings.BendMaxAngle = _config.BendMaxAngle;
+		settings.BladeWidth = _config.BladeWidth;
+		settings.BladeHeight = _config.BladeHeight;
+		settings.DebugMode = _debugMode ? 1 : 0;
+
+		// Pack influence spheres.
+		int numInfluences = 0;
+		for (int i = 0; i < MAX_INFLUENCES; i++)
+		{
+			if (_influences[i].Active)
+			{
+				// Expire old influences.
+				float age = time - _influences[i].Timestamp;
+				if (age > 5.0f) // 5 seconds max lifetime.
+				{
+					_influences[i].Active = false;
+					continue;
+				}
+
+				auto& dst = settings.Influences[numInfluences];
+				dst.Position = _influences[i].Position;
+				dst.Radius = _influences[i].Radius;
+				dst.Intensity = _influences[i].Intensity;
+				dst.Timestamp = _influences[i].Timestamp;
+				numInfluences++;
+
+				if (numInfluences >= MAX_GRASS_INFLUENCE_SPHERES)
+					break;
+			}
+		}
+		settings.NumInfluences = numInfluences;
+
+		cbSettings.UpdateData(settings, context);
+
+		// Frustum cull tiles and draw visible ones in batches.
+		const auto& frustum = view.Camera.Frustum;
+		const Vector3 camPos = view.Camera.WorldPosition;
+
+		_lastVisibleTileCount = 0;
+		_lastVisibleBladeCount = 0;
+		_lastDrawCallCount = 0;
+
+		CGrassInstanceBuffer instanceBuffer = {};
+		int batchCount = 0;
+
+		auto flushBatch = [&]()
+		{
+			if (batchCount == 0)
+				return;
+
+			cbInstances.UpdateData(instanceBuffer, context);
+			context->DrawInstanced(6, batchCount, 0, 0);
+			_lastDrawCallCount++;
+			batchCount = 0;
+		};
+
+		for (auto& tile : _tiles)
+		{
+			// Frustum culling.
+			Vector3 tileMin(
+				tile.Bounds.Center.x - tile.Bounds.Extents.x,
+				tile.Bounds.Center.y - tile.Bounds.Extents.y,
+				tile.Bounds.Center.z - tile.Bounds.Extents.z);
+			Vector3 tileMax(
+				tile.Bounds.Center.x + tile.Bounds.Extents.x,
+				tile.Bounds.Center.y + tile.Bounds.Extents.y,
+				tile.Bounds.Center.z + tile.Bounds.Extents.z);
+
+			if (!frustum.AABBInFrustum(tileMin, tileMax))
+				continue;
+
+			// Distance culling: check tile center vs max draw distance.
+			Vector3 tileCenter(tile.Bounds.Center.x, tile.Bounds.Center.y, tile.Bounds.Center.z);
+			float tileDist = Vector3::Distance(camPos, tileCenter);
+
+			if (tileDist > _config.MaxDrawDistance + TILE_SIZE)
+				continue;
+
+			_lastVisibleTileCount++;
+
+			// Process blades in this tile.
+			int end = tile.StartIndex + tile.BladeCount;
+			for (int i = tile.StartIndex; i < end; i++)
+			{
+				auto& blade = _allBlades[i];
+
+				// Per-blade distance culling.
+				float bladeDist = Vector3::Distance(camPos, blade.Position);
+				if (bladeDist > _config.MaxDrawDistance)
+					continue;
+
+				// LOD: reduce density at distance.
+				if (bladeDist > _config.FadeStartDistance)
+				{
+					float lodFactor = (bladeDist - _config.FadeStartDistance) /
+						(_config.MaxDrawDistance - _config.FadeStartDistance);
+					// Probabilistic LOD: skip some blades at distance.
+					if (blade.Seed < lodFactor * 0.6f)
+						continue;
+				}
+
+				// Disable bending for distant blades (performance).
+				// Bending is computed in the shader only for blades
+				// within the influence sphere radii anyway.
+
+				// Fill instance data.
+				auto& inst = instanceBuffer.Instances[batchCount];
+				inst.Position = blade.Position;
+				inst.Scale = blade.Scale;
+				inst.Normal = blade.Normal;
+				inst.Seed = blade.Seed;
+				inst.Color = blade.Color;
+
+				// Calculate UV offset for sprite atlas variant.
+				int col = blade.SpriteIdx % _config.AtlasColumns;
+				int row = blade.SpriteIdx / _config.AtlasColumns;
+				inst.UVScale = Vector2(
+					1.0f / _config.AtlasColumns,
+					1.0f / _config.AtlasRows);
+				inst.UVOffset = Vector2(
+					col * inst.UVScale.x,
+					row * inst.UVScale.y);
+
+				batchCount++;
+				_lastVisibleBladeCount++;
+
+				if (batchCount >= GRASS_INSTANCE_BUCKET_SIZE)
+					flushBatch();
+			}
+		}
+
+		// Flush remaining.
+		flushBatch();
+	}
+}

--- a/TombEngine/Renderer/Grass/GrassSystem.cpp
+++ b/TombEngine/Renderer/Grass/GrassSystem.cpp
@@ -1,7 +1,6 @@
 #include "framework.h"
 #include "Renderer/Grass/GrassSystem.h"
 
-#include <random>
 #include <algorithm>
 #include <map>
 
@@ -44,7 +43,6 @@ namespace TEN::Renderer::Grass
 	{
 		_allBlades.clear();
 		_tiles.clear();
-		_nextInfluenceSlot = 0;
 		_currentTime = 0.0f;
 		_lastVisibleTileCount = 0;
 		_lastVisibleBladeCount = 0;
@@ -59,9 +57,7 @@ namespace TEN::Renderer::Grass
 		Clear();
 
 		for (int roomNum = 0; roomNum < (int)g_Level.Rooms.size(); roomNum++)
-		{
 			GenerateGrassForRoom(roomNum);
-		}
 
 		BuildTiles();
 	}
@@ -153,17 +149,18 @@ namespace TEN::Renderer::Grass
 				finalZ = std::clamp(finalZ, (float)worldZ + 1.0f, (float)(worldZ + BLOCK_UNIT) - 1.0f);
 
 				// Get the actual floor height at this exact position.
-				auto& room = g_Level.Rooms[roomNumber];
 				auto& sector = GetFloor(roomNumber, (int)finalX, (int)finalZ);
 
 				if (sector.IsWall((int)finalX, (int)finalZ))
 					continue;
 
 				int height = sector.GetSurfaceHeight((int)finalX, (int)finalZ, true);
+
 				if (height == NO_HEIGHT)
 					continue;
 
 				Vector3 localNormal = sector.GetSurfaceNormal((int)finalX, (int)finalZ, true);
+
 				if (localNormal.y > -0.5f)
 					continue;
 
@@ -177,6 +174,8 @@ namespace TEN::Renderer::Grass
 				// Select a sprite variant from the atlas.
 				int totalSprites = _config.AtlasColumns * _config.AtlasRows;
 				blade.SpriteIdx = (int)(rng2 * totalSprites) % totalSprites;
+				blade.RoomNumber = roomNumber;
+				blade.WindEnabled = (g_Level.Rooms[roomNumber].flags & ENV_FLAG_SKYBOX) != 0;
 
 				_allBlades.push_back(blade);
 			}
@@ -192,6 +191,7 @@ namespace TEN::Renderer::Grass
 		struct TileKey
 		{
 			int tx, tz;
+
 			bool operator<(const TileKey& other) const
 			{
 				return (tx < other.tx) || (tx == other.tx && tz < other.tz);
@@ -226,13 +226,15 @@ namespace TEN::Renderer::Grass
 				auto& blade = _allBlades[idx];
 				sortedBlades.push_back(blade);
 
-				bmin = Vector3::Min(bmin, blade.Position - Vector3(0, _config.BladeHeight, 0));
-				bmax = Vector3::Max(bmax, blade.Position + Vector3(0, _config.BladeHeight * 1.5f, 0));
+				// TEN uses inverted Y (up = -Y), so blades grow toward negative Y.
+				bmin = Vector3::Min(bmin, blade.Position - Vector3(0, _config.BladeHeight * 1.5f, 0));
+				bmax = Vector3::Max(bmax, blade.Position + Vector3(0, _config.BladeHeight, 0));
 			}
 
-			// Expand the bounding box slightly for wind sway.
-			bmin -= Vector3(_config.BladeWidth, 0, _config.BladeWidth);
-			bmax += Vector3(_config.BladeWidth, 0, _config.BladeWidth);
+			// Expand bounding box for blade half-width + wind displacement.
+			float xzPad = _config.BladeWidth * _config.MaxScale * 0.5f + _config.WindStrength * 1.5f;
+			bmin -= Vector3(xzPad, 0, xzPad);
+			bmax += Vector3(xzPad, 0, xzPad);
 
 			tile.Bounds = BoundingBox(
 				(bmin + bmax) * 0.5f,
@@ -257,6 +259,7 @@ namespace TEN::Renderer::Grass
 			if (inf.Active)
 			{
 				float dist = Vector3::Distance(inf.Position, position);
+
 				if (dist < radius * 0.5f)
 				{
 					// Update existing.
@@ -269,15 +272,38 @@ namespace TEN::Renderer::Grass
 			}
 		}
 
-		// Allocate a new slot (ring buffer with oldest eviction).
-		auto& slot = _influences[_nextInfluenceSlot];
-		slot.Position = position;
-		slot.Radius = radius;
-		slot.Intensity = intensity;
-		slot.Timestamp = _currentTime;
-		slot.Active = true;
+		// Allocate a new slot: prefer inactive slots, then the most-decayed active one.
+		int bestSlot = -1;
+		float bestAge = -1.0f;
 
-		_nextInfluenceSlot = (_nextInfluenceSlot + 1) % MAX_INFLUENCES;
+		for (int i = 0; i < MAX_INFLUENCES; i++)
+		{
+			if (!_influences[i].Active)
+			{
+				bestSlot = i;
+				break;
+			}
+
+			// Evict the influence that has decayed the most (largest age since last refresh).
+			float age = _currentTime - _influences[i].Timestamp;
+
+			if (age > bestAge)
+			{
+				bestAge = age;
+				bestSlot = i;
+			}
+		}
+
+		if (bestSlot < 0)
+			bestSlot = 0;
+
+		auto& slot          = _influences[bestSlot];
+		slot.Position       = position;
+		slot.Radius         = radius;
+		slot.Intensity      = intensity;
+		slot.Timestamp      = _currentTime;
+		slot.BirthTimestamp = _currentTime;
+		slot.Active         = true;
 	}
 
 	void GrassSystem::Draw(
@@ -285,6 +311,9 @@ namespace TEN::Renderer::Grass
 		const RenderView& view,
 		ConstantBuffer<CGrassSettingsBuffer>& cbSettings,
 		ConstantBuffer<CGrassInstanceBuffer>& cbInstances,
+		const Vector4* roomAmbients,
+		const RoomSunData* roomSuns,
+		int numRooms,
 		float time)
 	{
 		if (!_enabled || _allBlades.empty() || _tiles.empty())
@@ -297,7 +326,12 @@ namespace TEN::Renderer::Grass
 		settings.WindStrength = _config.WindStrength;
 		settings.WindFrequency = _config.WindFrequency;
 		settings.WindDirection = _config.WindDirection;
-		settings.WindDirection.Normalize();
+
+		if (settings.WindDirection.LengthSquared() > 0.0001f)
+			settings.WindDirection.Normalize();
+		else
+			settings.WindDirection = Vector3(1.0f, 0.0f, 0.0f);
+
 		settings.Time = time;
 		settings.BendRiseSpeed = _config.BendRiseSpeed;
 		settings.BendDecaySpeed = _config.BendDecaySpeed;
@@ -308,23 +342,29 @@ namespace TEN::Renderer::Grass
 
 		// Pack influence spheres.
 		int numInfluences = 0;
+
 		for (int i = 0; i < MAX_INFLUENCES; i++)
 		{
 			if (_influences[i].Active)
 			{
-				// Expire old influences.
+				// Expire old influences when the computed bend factor drops below 1%.
 				float age = time - _influences[i].Timestamp;
-				if (age > 5.0f) // 5 seconds max lifetime.
+				float activeWindow = 0.2f;
+				float decayTime = std::max(age - activeWindow, 0.0f);
+				float bendFactor = std::exp(-decayTime * _config.BendDecaySpeed);
+
+				if (bendFactor < 0.01f)
 				{
 					_influences[i].Active = false;
 					continue;
 				}
 
-				auto& dst = settings.Influences[numInfluences];
-				dst.Position = _influences[i].Position;
-				dst.Radius = _influences[i].Radius;
-				dst.Intensity = _influences[i].Intensity;
-				dst.Timestamp = _influences[i].Timestamp;
+				auto& dst          = settings.Influences[numInfluences];
+				dst.Position       = _influences[i].Position;
+				dst.Radius         = _influences[i].Radius;
+				dst.Intensity      = _influences[i].Intensity;
+				dst.Timestamp      = _influences[i].Timestamp;
+				dst.BirthTimestamp = _influences[i].BirthTimestamp;
 				numInfluences++;
 
 				if (numInfluences >= MAX_GRASS_INFLUENCE_SPHERES)
@@ -335,6 +375,13 @@ namespace TEN::Renderer::Grass
 
 		cbSettings.UpdateData(settings, context);
 
+		// Precompute squared distances for culling.
+		float maxDrawDistSq = _config.MaxDrawDistance * _config.MaxDrawDistance;
+		float fadeStartDistSq = _config.FadeStartDistance * _config.FadeStartDistance;
+		float tileMaxDist = _config.MaxDrawDistance + TILE_SIZE;
+		float tileMaxDistSq = tileMaxDist * tileMaxDist;
+		float fadeRange = _config.MaxDrawDistance - _config.FadeStartDistance;
+
 		// Frustum cull tiles and draw visible ones in batches.
 		const auto& frustum = view.Camera.Frustum;
 		const Vector3 camPos = view.Camera.WorldPosition;
@@ -342,6 +389,11 @@ namespace TEN::Renderer::Grass
 		_lastVisibleTileCount = 0;
 		_lastVisibleBladeCount = 0;
 		_lastDrawCallCount = 0;
+
+		// Precompute atlas UV scale (constant for all blades).
+		Vector2 uvScale(
+			1.0f / _config.AtlasColumns,
+			1.0f / _config.AtlasRows);
 
 		CGrassInstanceBuffer instanceBuffer = {};
 		int batchCount = 0;
@@ -364,6 +416,7 @@ namespace TEN::Renderer::Grass
 				tile.Bounds.Center.x - tile.Bounds.Extents.x,
 				tile.Bounds.Center.y - tile.Bounds.Extents.y,
 				tile.Bounds.Center.z - tile.Bounds.Extents.z);
+
 			Vector3 tileMax(
 				tile.Bounds.Center.x + tile.Bounds.Extents.x,
 				tile.Bounds.Center.y + tile.Bounds.Extents.y,
@@ -372,31 +425,36 @@ namespace TEN::Renderer::Grass
 			if (!frustum.AABBInFrustum(tileMin, tileMax))
 				continue;
 
-			// Distance culling: check tile center vs max draw distance.
+			// Distance culling: check tile center vs max draw distance (squared).
 			Vector3 tileCenter(tile.Bounds.Center.x, tile.Bounds.Center.y, tile.Bounds.Center.z);
-			float tileDist = Vector3::Distance(camPos, tileCenter);
+			float tileDistSq = Vector3::DistanceSquared(camPos, tileCenter);
 
-			if (tileDist > _config.MaxDrawDistance + TILE_SIZE)
+			if (tileDistSq > tileMaxDistSq)
 				continue;
 
 			_lastVisibleTileCount++;
 
 			// Process blades in this tile.
 			int end = tile.StartIndex + tile.BladeCount;
+
 			for (int i = tile.StartIndex; i < end; i++)
 			{
 				auto& blade = _allBlades[i];
 
-				// Per-blade distance culling.
-				float bladeDist = Vector3::Distance(camPos, blade.Position);
-				if (bladeDist > _config.MaxDrawDistance)
+				// Per-blade distance culling (squared to avoid sqrt).
+				float bladeDistSq = Vector3::DistanceSquared(camPos, blade.Position);
+
+				if (bladeDistSq > maxDrawDistSq)
 					continue;
 
 				// LOD: reduce density at distance.
-				if (bladeDist > _config.FadeStartDistance)
+				if (bladeDistSq > fadeStartDistSq)
 				{
-					float lodFactor = (bladeDist - _config.FadeStartDistance) /
-						(_config.MaxDrawDistance - _config.FadeStartDistance);
+					float bladeDist = std::sqrt(bladeDistSq);
+					float lodFactor = (fadeRange > 0.001f)
+						? (bladeDist - _config.FadeStartDistance) / fadeRange
+						: 1.0f;
+
 					// Probabilistic LOD: skip some blades at distance.
 					if (blade.Seed < lodFactor * 0.6f)
 						continue;
@@ -414,15 +472,36 @@ namespace TEN::Renderer::Grass
 				inst.Seed = blade.Seed;
 				inst.Color = blade.Color;
 
+				// Look up room ambient light for this blade.
+				inst.AmbientLight = (blade.RoomNumber >= 0 && blade.RoomNumber < numRooms)
+					? Vector3(roomAmbients[blade.RoomNumber])
+					: Vector3(0.5f, 0.5f, 0.5f);
+
+				// Wind is baked at generation time from the room's skybox flag.
+				inst.WindEnabled = blade.WindEnabled ? 1.0f : 0.0f;
+
+				// Per-room sun bulb lighting (direction pre-normalized in DrawGrass).
+				if (blade.RoomNumber >= 0 && blade.RoomNumber < numRooms && roomSuns[blade.RoomNumber].Intensity > 0.0f)
+				{
+					const auto& sun = roomSuns[blade.RoomNumber];
+					inst.SunDirection = sun.Direction;
+					inst.SunColor = sun.Color;
+					inst.SunIntensity = sun.Intensity;
+				}
+				else
+				{
+					inst.SunDirection = Vector3::Zero;
+					inst.SunColor = Vector3::Zero;
+					inst.SunIntensity = 0.0f;
+				}
+
 				// Calculate UV offset for sprite atlas variant.
 				int col = blade.SpriteIdx % _config.AtlasColumns;
 				int row = blade.SpriteIdx / _config.AtlasColumns;
-				inst.UVScale = Vector2(
-					1.0f / _config.AtlasColumns,
-					1.0f / _config.AtlasRows);
+				inst.UVScale = uvScale;
 				inst.UVOffset = Vector2(
-					col * inst.UVScale.x,
-					row * inst.UVScale.y);
+					col * uvScale.x,
+					row * uvScale.y);
 
 				batchCount++;
 				_lastVisibleBladeCount++;

--- a/TombEngine/Renderer/Grass/GrassSystem.h
+++ b/TombEngine/Renderer/Grass/GrassSystem.h
@@ -1,0 +1,156 @@
+#pragma once
+
+#include <array>
+#include <vector>
+#include <SimpleMath.h>
+#include <DirectXCollision.h>
+#include <d3d11.h>
+#include <wrl/client.h>
+
+#include "Renderer/ConstantBuffers/GrassBuffer.h"
+
+using namespace DirectX::SimpleMath;
+using namespace DirectX;
+using Microsoft::WRL::ComPtr;
+
+enum class MaterialType;
+
+namespace TEN::Renderer
+{
+	struct RenderView;
+
+	namespace ConstantBuffers
+	{
+		template <typename CBuff> class ConstantBuffer;
+	}
+}
+
+namespace TEN::Renderer::Grass
+{
+	using namespace TEN::Renderer::ConstantBuffers;
+
+	// A single grass blade instance (CPU side).
+	struct GrassBlade
+	{
+		Vector3 Position  = Vector3::Zero;
+		Vector3 Normal    = Vector3::UnitY;
+		float   Scale     = 1.0f;
+		float   Seed      = 0.0f;
+		Vector4 Color     = Vector4::One;
+		int     SpriteIdx = 0; // Index into grass atlas sprite variants.
+	};
+
+	// A spatial tile containing grass blades for culling.
+	struct GrassTile
+	{
+		BoundingBox    Bounds;
+		int            RoomNumber  = 0;
+		int            StartIndex  = 0;  // Into the owning GrassGrid's blade array.
+		int            BladeCount  = 0;
+	};
+
+	// Influence sphere for bending effect (e.g., player walking through grass).
+	struct GrassInfluence
+	{
+		Vector3 Position   = Vector3::Zero;
+		float   Radius     = 0.0f;
+		float   Intensity  = 0.0f;
+		float   Timestamp  = 0.0f;
+		bool    Active     = false;
+	};
+
+	// Configuration for the grass system.
+	struct GrassConfig
+	{
+		// Placement.
+		float Density           = 16.0f;  // Blades per BLOCK(1) unit on each axis.
+		float MinScale          = 0.6f;
+		float MaxScale          = 1.5f;
+		float JitterAmount      = 1.0f;   // 0 = grid, 1 = full jitter within cell.
+
+		// Rendering.
+		float BladeWidth        = 56.0f;  // World units.
+		float BladeHeight       = 350.0f; // World units (~1/3 block).
+		float MaxDrawDistance    = 16384.0f;  // ~16 blocks.
+		float FadeStartDistance = 12288.0f;  // ~12 blocks.
+
+		// Wind.
+		float   WindStrength    = 25.0f;
+		float   WindFrequency   = 1.5f;
+		Vector3 WindDirection   = Vector3(1.0f, 0.0f, 0.3f);
+
+		// Bending.
+		float BendRiseSpeed     = 10.0f;
+		float BendDecaySpeed    = 1.5f;
+		float BendMaxAngle      = 250.0f; // World units of displacement at full bend.
+		float PlayerBendRadius  = 512.0f; // ~2 clicks.
+		float PlayerBendIntensity = 1.0f;
+
+		// Atlas layout (assuming a simple grid of sprite variants in one texture).
+		int   AtlasColumns      = 4;
+		int   AtlasRows         = 1;
+	};
+
+	class GrassSystem
+	{
+	public:
+		GrassSystem() = default;
+
+		void Initialize(ID3D11Device* device);
+		void GenerateForLevel();
+		void Clear();
+
+		// Per-frame update: updates influence spheres.
+		void Update(float time);
+
+		// Renders all visible grass tiles.
+		void Draw(
+			ID3D11DeviceContext* context,
+			const RenderView& view,
+			ConstantBuffer<CGrassSettingsBuffer>& cbSettings,
+			ConstantBuffer<CGrassInstanceBuffer>& cbInstances,
+			float time);
+
+		// Add a bending influence (call each frame for active influences).
+		void AddInfluence(const Vector3& position, float radius, float intensity);
+
+		bool IsEnabled() const { return _enabled && !_allBlades.empty(); }
+		void SetEnabled(bool enabled) { _enabled = enabled; }
+		void SetDebugMode(bool debug) { _debugMode = debug; }
+
+		// Debug info.
+		int GetTotalBladeCount() const { return (int)_allBlades.size(); }
+		int GetVisibleTileCount() const { return _lastVisibleTileCount; }
+		int GetVisibleBladeCount() const { return _lastVisibleBladeCount; }
+		int GetDrawCallCount() const { return _lastDrawCallCount; }
+
+		GrassConfig& GetConfig() { return _config; }
+
+	private:
+		void GenerateGrassForRoom(int roomNumber);
+		void GenerateBladesForSector(int roomNumber, int worldX, int worldZ, int floorHeight, const Vector3& normal, MaterialType material);
+		void BuildTiles();
+
+		bool _enabled       = true;
+		bool _debugMode     = false;
+		bool _initialized   = false;
+		GrassConfig _config;
+
+		// All blades across the entire level, sorted by tile.
+		std::vector<GrassBlade> _allBlades;
+
+		// Spatial tiles for frustum culling.
+		std::vector<GrassTile> _tiles;
+
+		// Active influence spheres (ring buffer).
+		static constexpr int MAX_INFLUENCES = MAX_GRASS_INFLUENCE_SPHERES;
+		std::array<GrassInfluence, MAX_GRASS_INFLUENCE_SPHERES> _influences = {};
+		int _nextInfluenceSlot = 0;
+		float _currentTime = 0.0f;
+
+		// Debug counters.
+		int _lastVisibleTileCount  = 0;
+		int _lastVisibleBladeCount = 0;
+		int _lastDrawCallCount     = 0;
+	};
+}

--- a/TombEngine/Renderer/Grass/GrassSystem.h
+++ b/TombEngine/Renderer/Grass/GrassSystem.h
@@ -32,63 +32,110 @@ namespace TEN::Renderer::Grass
 	// A single grass blade instance (CPU side).
 	struct GrassBlade
 	{
-		Vector3 Position  = Vector3::Zero;
-		Vector3 Normal    = Vector3::UnitY;
-		float   Scale     = 1.0f;
-		float   Seed      = 0.0f;
-		Vector4 Color     = Vector4::One;
-		int     SpriteIdx = 0; // Index into grass atlas sprite variants.
+		Vector3 Position     = Vector3::Zero;
+		Vector3 Normal       = Vector3::UnitY;
+		float   Scale        = 1.0f;
+		float   Seed         = 0.0f;
+		Vector4 Color        = Vector4::One;
+		int     SpriteIdx    = 0; // Index into grass atlas sprite variants.
+		int     RoomNumber   = 0; // Room this blade belongs to (for ambient lookup).
+		bool    WindEnabled  = false; // True if blade is in an outdoor (skybox) room.
 	};
 
 	// A spatial tile containing grass blades for culling.
 	struct GrassTile
 	{
 		BoundingBox    Bounds;
-		int            RoomNumber  = 0;
-		int            StartIndex  = 0;  // Into the owning GrassGrid's blade array.
+		int            StartIndex  = 0; // Into the owning GrassGrid's blade array.
 		int            BladeCount  = 0;
 	};
 
 	// Influence sphere for bending effect (e.g., player walking through grass).
 	struct GrassInfluence
 	{
-		Vector3 Position   = Vector3::Zero;
-		float   Radius     = 0.0f;
-		float   Intensity  = 0.0f;
-		float   Timestamp  = 0.0f;
-		bool    Active     = false;
+		Vector3 Position       = Vector3::Zero;
+		float   Radius         = 0.0f;
+		float   Intensity      = 0.0f;
+		float   Timestamp      = 0.0f; // Last refresh time (used for decay).
+		float   BirthTimestamp = 0.0f; // Creation time (used for rise).
+		bool    Active         = false;
 	};
 
 	// Configuration for the grass system.
 	struct GrassConfig
 	{
-		// Placement.
-		float Density           = 16.0f;  // Blades per BLOCK(1) unit on each axis.
+		// -- Placement --
+		// Number of grass blades placed per BLOCK unit on each axis within a sector.
+		// E.g. 16 = 256 blades per sector (16x16 grid before jitter).
+		float Density           = 16.0f;
+
+		// Minimum and maximum random scale multiplier applied to each blade.
 		float MinScale          = 0.6f;
 		float MaxScale          = 1.5f;
-		float JitterAmount      = 1.0f;   // 0 = grid, 1 = full jitter within cell.
 
-		// Rendering.
-		float BladeWidth        = 56.0f;  // World units.
-		float BladeHeight       = 350.0f; // World units (~1/3 block).
-		float MaxDrawDistance    = 16384.0f;  // ~16 blocks.
-		float FadeStartDistance = 12288.0f;  // ~12 blocks.
+		// Controls how much each blade is randomly offset from its grid cell centre.
+		// 0.0 = perfectly uniform grid (no randomness).
+		// 1.0 = blade can appear anywhere within its cell (fully random).
+		float JitterAmount      = 1.0f;
 
-		// Wind.
-		float   WindStrength    = 25.0f;
-		float   WindFrequency   = 1.5f;
+		// -- Rendering --
+		// Width and height of each grass quad in world units.
+		float BladeWidth        = 64.0f;
+		float BladeHeight       = 256.0f;
+
+		// Maximum distance from the camera at which grass is drawn at all.
+		// Blades beyond this distance are skipped entirely. Reducing this improves performance.
+		float MaxDrawDistance   = 16384.0f;
+
+		// Distance at which grass begins to fade out (alpha fades to 0 at MaxDrawDistance).
+		float FadeStartDistance = 12288.0f;
+
+		// -- Wind --
+		// Maximum world-unit displacement of a blade tip caused by wind at full swing.
+		// Higher values = more dramatic swaying. Too high can look unnatural.
+		float WindStrength      = 128.0f;
+
+		// How many full wind oscillation cycles occur per second.
+		// Higher values = faster flickering; lower values = slow, rolling waves.
+		float WindFrequency     = 1.5f;
+
+		// The primary direction the wind blows.
 		Vector3 WindDirection   = Vector3(1.0f, 0.0f, 0.3f);
 
-		// Bending.
+		// -- Bending (player interaction) --
+		// How fast grass blades bend down when Lara first steps into them.
+		// This is a linear ramp: full bend is reached after (1.0 / BendRiseSpeed) seconds.
+		// E.g. 10.0 = full bend in ~0.1s (snappy). 2.0 = full bend in ~0.5s (slow lean).
 		float BendRiseSpeed     = 10.0f;
-		float BendDecaySpeed    = 1.5f;
-		float BendMaxAngle      = 250.0f; // World units of displacement at full bend.
-		float PlayerBendRadius  = 512.0f; // ~2 clicks.
+
+		// How fast bent blades spring back up after Lara leaves.
+		// This is an exponential decay: bend halves every (ln2 / BendDecaySpeed) seconds.
+		// E.g. 2.5 = blades mostly upright in ~2s. 0.1 = blades stay flat for ~45s.
+		float BendDecaySpeed    = 2.5f;
+
+		// Maximum world-unit displacement applied to a blade tip at full bend.
+		// This should be roughly equal to BladeHeight for a convincing flat collapse.
+		// Too low = blades barely react; too high = blades stretch past the floor.
+		float BendMaxAngle      = 256.0f;
+
+		// Radius around Lara (in world units) within which grass blades are bent each frame.
+		float PlayerBendRadius  = 512.0f;
+
+		// Multiplier on the overall bending strength. 1.0 = normal full bend.
+		// Reduce below 1.0 for subtler interaction; raise above 1.0 to exaggerate.
 		float PlayerBendIntensity = 1.0f;
 
 		// Atlas layout (assuming a simple grid of sprite variants in one texture).
 		int   AtlasColumns      = 4;
 		int   AtlasRows         = 1;
+	};
+
+	// Per-room sun bulb data (one entry per room, built each frame).
+	struct RoomSunData
+	{
+		Vector3 Direction = Vector3::Zero;
+		Vector3 Color     = Vector3::Zero;
+		float   Intensity = 0.0f;
 	};
 
 	class GrassSystem
@@ -109,6 +156,9 @@ namespace TEN::Renderer::Grass
 			const RenderView& view,
 			ConstantBuffer<CGrassSettingsBuffer>& cbSettings,
 			ConstantBuffer<CGrassInstanceBuffer>& cbInstances,
+			const Vector4* roomAmbients,
+			const RoomSunData* roomSuns,
+			int numRooms,
 			float time);
 
 		// Add a bending influence (call each frame for active influences).
@@ -142,10 +192,9 @@ namespace TEN::Renderer::Grass
 		// Spatial tiles for frustum culling.
 		std::vector<GrassTile> _tiles;
 
-		// Active influence spheres (ring buffer).
+		// Active influence spheres.
 		static constexpr int MAX_INFLUENCES = MAX_GRASS_INFLUENCE_SPHERES;
 		std::array<GrassInfluence, MAX_GRASS_INFLUENCE_SPHERES> _influences = {};
-		int _nextInfluenceSlot = 0;
 		float _currentTime = 0.0f;
 
 		// Debug counters.

--- a/TombEngine/Renderer/Renderer.cpp
+++ b/TombEngine/Renderer/Renderer.cpp
@@ -55,6 +55,8 @@ namespace TEN::Renderer
 		for (auto& mesh : _meshes)
 			delete mesh;
 		_meshes.resize(0);
+
+		_grassSystem.Clear();
 	}
 
 	void Renderer::Lock()

--- a/TombEngine/Renderer/Renderer.h
+++ b/TombEngine/Renderer/Renderer.h
@@ -196,11 +196,13 @@ namespace TEN::Renderer
 		// Grass system
 
 		Grass::GrassSystem _grassSystem;
-		CGrassSettingsBuffer _stGrassSettings;
 		ConstantBuffer<CGrassSettingsBuffer> _cbGrassSettings;
-		CGrassInstanceBuffer _stGrassInstances;
 		ConstantBuffer<CGrassInstanceBuffer> _cbGrassInstances;
 		Texture2D _grassAtlasTexture;
+
+		// Per-room grass lighting (rebuilt each frame, persistent to avoid per-frame heap alloc).
+		std::vector<Vector4> _grassRoomAmbients;
+		std::vector<Grass::RoomSunData> _grassRoomSuns;
 
 		// Primitive batches
 

--- a/TombEngine/Renderer/Renderer.h
+++ b/TombEngine/Renderer/Renderer.h
@@ -40,6 +40,7 @@
 #include "Renderer/ConstantBuffers/PostProcessBuffer.h"
 #include "Renderer/ConstantBuffers/SMAABuffer.h"
 #include "Renderer/ConstantBuffers/SkyBuffer.h"
+#include "Renderer/ConstantBuffers/GrassBuffer.h"
 #include "Renderer/Structures/RendererBone.h"
 #include "Renderer/Structures/RendererDoor.h"
 #include "Renderer/Structures/RendererStringToDraw.h"
@@ -68,6 +69,7 @@
 #include "Renderer/Structures/RendererObject.h"
 #include "Renderer/Structures/RendererStar.h"
 #include "Structures/RendererShader.h"
+#include "Renderer/Grass/GrassSystem.h"
 
 using namespace TEN::Animation;
 
@@ -191,6 +193,15 @@ namespace TEN::Renderer
 		CMaterialBuffer _stMaterial;
 		ConstantBuffer<CMaterialBuffer> _cbMaterial;
 
+		// Grass system
+
+		Grass::GrassSystem _grassSystem;
+		CGrassSettingsBuffer _stGrassSettings;
+		ConstantBuffer<CGrassSettingsBuffer> _cbGrassSettings;
+		CGrassInstanceBuffer _stGrassInstances;
+		ConstantBuffer<CGrassInstanceBuffer> _cbGrassInstances;
+		Texture2D _grassAtlasTexture;
+
 		// Primitive batches
 
 		std::unique_ptr<SpriteBatch> _spriteBatch;
@@ -300,6 +311,7 @@ namespace TEN::Renderer
 		int _numShadowMapDrawCalls = 0;
 		int _numDebrisDrawCalls = 0;
 		int _numEffectsDrawCalls = 0;
+		int _numGrassDrawCalls = 0;
 
 		int _numDotProducts = 0;
 		int _numCheckPortalCalls = 0;
@@ -441,6 +453,7 @@ namespace TEN::Renderer
 		void DrawWaterfalls(RendererItem* item, RenderView& view, float speed, RendererPass rendererPass);
 		void DrawBaddyGunflashes(RenderView& view);
 		void DrawStatics(RenderView& view, RendererPass rendererPass);
+		void DrawGrass(RenderView& view, RendererPass rendererPass);
 		void DrawLara(RenderView& view, RendererPass rendererPass);
 		void PrepareFires(RenderView& view);
 		void PrepareParticles(RenderView& view);

--- a/TombEngine/Renderer/RendererCompatibility.cpp
+++ b/TombEngine/Renderer/RendererCompatibility.cpp
@@ -1070,6 +1070,11 @@ namespace TEN::Renderer
 			}
 		}
 
+		// Generate grass instances from level floor materials.
+		TENLog("Generating grass instances...", LogLevel::Info);
+		_grassSystem.GenerateForLevel();
+		TENLog("Generated " + std::to_string(_grassSystem.GetTotalBladeCount()) + " grass blades.", LogLevel::Info);
+
 		return true;
 	}
 

--- a/TombEngine/Renderer/RendererDraw.cpp
+++ b/TombEngine/Renderer/RendererDraw.cpp
@@ -1861,6 +1861,8 @@ namespace TEN::Renderer
 		BindConstantBufferVS(ConstantBufferRegister::InstancedSprites, _cbInstancedSpriteBuffer.get());
 		BindConstantBufferVS(ConstantBufferRegister::PostProcess, _cbPostProcessBuffer.get());
 		BindConstantBufferVS(ConstantBufferRegister::Sky, _cbSky.get());
+		BindConstantBufferVS(ConstantBufferRegister::GrassSettings, _cbGrassSettings.get());
+		BindConstantBufferVS(ConstantBufferRegister::GrassInstances, _cbGrassInstances.get());
 
 		BindConstantBufferPS(ConstantBufferRegister::Camera, _cbCameraMatrices.get());
 		BindConstantBufferPS(ConstantBufferRegister::Material, _cbMaterial.get());
@@ -1873,6 +1875,8 @@ namespace TEN::Renderer
 		BindConstantBufferPS(ConstantBufferRegister::InstancedSprites, _cbInstancedSpriteBuffer.get());
 		BindConstantBufferPS(ConstantBufferRegister::PostProcess, _cbPostProcessBuffer.get());
 		BindConstantBufferPS(ConstantBufferRegister::Sky, _cbSky.get());
+		BindConstantBufferPS(ConstantBufferRegister::GrassSettings, _cbGrassSettings.get());
+		BindConstantBufferPS(ConstantBufferRegister::GrassInstances, _cbGrassInstances.get());
 
 		// Reset GPU state.
 		SetBlendMode(BlendMode::Opaque, true);
@@ -2402,6 +2406,10 @@ namespace TEN::Renderer
 				DrawStatics(view, pass);
 				DrawDebris(view, pass); // Debris mostly originate from shatter statics.
 			}
+
+			// Draw grass after statics, before sprites.
+			if (statics && pass == RendererPass::Opaque)
+				DrawGrass(view, pass);
 
 			// Sorted sprites already collected at beginning of frame.
 			if (sprites && pass != RendererPass::CollectTransparentFaces)
@@ -4247,5 +4255,60 @@ namespace TEN::Renderer
 		BindTexture(TextureRegister::NormalMap, &std::get<1>(atlas), SamplerStateRegister::AnisotropicClamp);
 		BindTexture(TextureRegister::ORSHMap, &std::get<2>(atlas), SamplerStateRegister::AnisotropicClamp);
 		BindTexture(TextureRegister::EmissiveMap, &std::get<3>(atlas), SamplerStateRegister::AnisotropicClamp);
+	}
+
+	void Renderer::DrawGrass(RenderView& view, RendererPass rendererPass)
+	{
+		if (!_grassSystem.IsEnabled())
+			return;
+
+		// Update the player influence sphere each frame.
+		if (LaraItem != nullptr)
+		{
+			auto& config = _grassSystem.GetConfig();
+			Vector3 playerPos = LaraItem->Pose.Position.ToVector3();
+			_grassSystem.AddInfluence(playerPos, config.PlayerBendRadius, config.PlayerBendIntensity);
+		}
+
+		// Bind grass shader.
+		_shaders.Bind(Shader::Grass);
+
+		// Bind grass constant buffers.
+		BindConstantBufferVS(ConstantBufferRegister::GrassSettings, _cbGrassSettings.get());
+		BindConstantBufferPS(ConstantBufferRegister::GrassSettings, _cbGrassSettings.get());
+		BindConstantBufferVS(ConstantBufferRegister::GrassInstances, _cbGrassInstances.get());
+		BindConstantBufferPS(ConstantBufferRegister::GrassInstances, _cbGrassInstances.get());
+
+		// Bind grass atlas texture.
+		BindTexture(TextureRegister::GrassAtlas, &_grassAtlasTexture, SamplerStateRegister::AnisotropicClamp);
+
+		// Set render state for alpha-cutout grass.
+		SetBlendMode(BlendMode::AlphaTest);
+		SetCullMode(CullMode::None); // Grass quads are visible from both sides.
+		SetDepthState(DepthState::Write);
+
+		// Use the null vertex buffer - vertices are generated from InstanceID + VertexID in VS.
+		_context->IASetInputLayout(nullptr);
+		_context->IASetVertexBuffers(0, 0, nullptr, nullptr, nullptr);
+		_context->IASetIndexBuffer(nullptr, DXGI_FORMAT_R32_UINT, 0);
+		_context->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+
+		// Get time for wind/bending animation.
+		float time = (float)GlobalCounter * 0.03333f + GetInterpolationFactor() * 0.03333f;
+		_grassSystem.Update(time);
+
+		// Draw all visible grass tiles.
+		_grassSystem.Draw(_context.Get(), view, _cbGrassSettings, _cbGrassInstances, time);
+		_numGrassDrawCalls = _grassSystem.GetDrawCallCount();
+
+		// Restore state.
+		SetCullMode(CullMode::CounterClockwise);
+
+		// Restore input layout and vertex/index buffers for subsequent draw calls.
+		_context->IASetInputLayout(_inputLayout.Get());
+		unsigned int stride = sizeof(Vertex);
+		unsigned int offset = 0;
+		_context->IASetVertexBuffers(0, 1, _staticsVertexBuffer.Buffer.GetAddressOf(), &stride, &offset);
+		_context->IASetIndexBuffer(_staticsIndexBuffer.Buffer.Get(), DXGI_FORMAT_R32_UINT, 0);
 	}
 }

--- a/TombEngine/Renderer/RendererDraw.cpp
+++ b/TombEngine/Renderer/RendererDraw.cpp
@@ -4297,8 +4297,43 @@ namespace TEN::Renderer
 		float time = (float)GlobalCounter * 0.03333f + GetInterpolationFactor() * 0.03333f;
 		_grassSystem.Update(time);
 
+		// Update room ambient lookup for grass lighting (reuse persistent vector).
+		_grassRoomAmbients.resize(_rooms.size());
+		for (size_t i = 0; i < _rooms.size(); i++)
+			_grassRoomAmbients[i] = _rooms[i].AmbientLight;
+
+		// Build per-room sun bulb cache (pick the brightest sun in each room).
+		_grassRoomSuns.resize(_rooms.size());
+		for (size_t i = 0; i < _rooms.size(); i++)
+		{
+			Grass::RoomSunData best = {};
+			for (auto& light : _rooms[i].Lights)
+			{
+				if (light.Type == LightType::Sun && light.Intensity > best.Intensity)
+				{
+					best.Direction = light.Direction;
+					best.Color = light.Color;
+					best.Intensity = light.Intensity;
+				}
+			}
+
+			// Pre-normalize sun direction so Draw() doesn't have to per-blade.
+			if (best.Intensity > 0.0f)
+			{
+				float lenSq = best.Direction.LengthSquared();
+
+				if (lenSq > 0.0001f)
+					best.Direction.Normalize();
+				else
+					best.Direction = Vector3(0.0f, 1.0f, 0.0f);
+			}
+
+			_grassRoomSuns[i] = best;
+		}
+
 		// Draw all visible grass tiles.
-		_grassSystem.Draw(_context.Get(), view, _cbGrassSettings, _cbGrassInstances, time);
+		_grassSystem.Draw(_context.Get(), view, _cbGrassSettings, _cbGrassInstances,
+			_grassRoomAmbients.data(), _grassRoomSuns.data(), (int)_grassRoomAmbients.size(), time);
 		_numGrassDrawCalls = _grassSystem.GetDrawCallCount();
 
 		// Restore state.

--- a/TombEngine/Renderer/RendererDrawMenu.cpp
+++ b/TombEngine/Renderer/RendererDrawMenu.cpp
@@ -1787,11 +1787,11 @@ namespace TEN::Renderer
 		case RendererDebugPage::GrassStats:
 			PrintDebugMessage("GRASS STATS");
 			PrintDebugMessage(" ");
-			PrintDebugMessage("Total blades: %d", _grassSystem.GetTotalBladeCount());
-			PrintDebugMessage("Visible tiles: %d", _grassSystem.GetVisibleTileCount());
-			PrintDebugMessage("Visible blades: %d", _grassSystem.GetVisibleBladeCount());
-			PrintDebugMessage("Draw calls: %d", _numGrassDrawCalls);
-			PrintDebugMessage("Grass enabled: %s", _grassSystem.IsEnabled() ? "Yes" : "No");
+			PrintDebugMessage(("Total blades: " + std::to_string(_grassSystem.GetTotalBladeCount())).c_str());
+			PrintDebugMessage(("Visible tiles: " + std::to_string(_grassSystem.GetVisibleTileCount())).c_str());
+			PrintDebugMessage(("Visible blades: " + std::to_string(_grassSystem.GetVisibleBladeCount())).c_str());
+			PrintDebugMessage(("Draw calls: " + std::to_string(_numGrassDrawCalls)).c_str());
+			PrintDebugMessage(_grassSystem.IsEnabled() ? "Grass enabled: Yes" : "Grass enabled: No");
 			break;
 
 		case RendererDebugPage::WireframeMode:

--- a/TombEngine/Renderer/RendererDrawMenu.cpp
+++ b/TombEngine/Renderer/RendererDrawMenu.cpp
@@ -1784,6 +1784,16 @@ namespace TEN::Renderer
 			PrintDebugMessage("    Dot products: %d", _numDotProducts);
 			break;
 
+		case RendererDebugPage::GrassStats:
+			PrintDebugMessage("GRASS STATS");
+			PrintDebugMessage(" ");
+			PrintDebugMessage("Total blades: %d", _grassSystem.GetTotalBladeCount());
+			PrintDebugMessage("Visible tiles: %d", _grassSystem.GetVisibleTileCount());
+			PrintDebugMessage("Visible blades: %d", _grassSystem.GetVisibleBladeCount());
+			PrintDebugMessage("Draw calls: %d", _numGrassDrawCalls);
+			PrintDebugMessage("Grass enabled: %s", _grassSystem.IsEnabled() ? "Yes" : "No");
+			break;
+
 		case RendererDebugPage::WireframeMode:
 			PrintDebugMessage("WIREFRAME MODE");
 			break;

--- a/TombEngine/Renderer/RendererEnums.h
+++ b/TombEngine/Renderer/RendererEnums.h
@@ -170,6 +170,7 @@ enum class RendererDebugPage
 	CollisionMeshStats,
 	PortalStats,
 	PathfindingStats,
+	GrassStats,
 	WireframeMode,
 
 	Count
@@ -199,7 +200,8 @@ enum class TextureRegister
 	ORSHMap = 10,
 	EmissiveMap = 11,
 	LegacyEnvironmentReflections = 12,
-	SkyboxEnvironmentReflections = 13
+	SkyboxEnvironmentReflections = 13,
+	GrassAtlas = 14
 };
 
 enum class SamplerStateRegister
@@ -224,10 +226,12 @@ enum class ConstantBufferRegister
 	AnimatedTextures = 6,
 	PostProcess = 7,
 	Sky = 8,
+	GrassSettings = 9,
 	Hud = 10,
 	HudBar = 11,
 	Blending = 12,
-	InstancedSprites = 13
+	InstancedSprites = 13,
+	GrassInstances = 13  // Shares slot with InstancedSprites (never active during grass draw).
 };
 
 enum class AlphaTestMode

--- a/TombEngine/Renderer/RendererInit.cpp
+++ b/TombEngine/Renderer/RendererInit.cpp
@@ -73,6 +73,11 @@ namespace TEN::Renderer
 		_cbSMAABuffer = CreateConstantBuffer<CSMAABuffer>();
 		_cbMaterial = CreateConstantBuffer<CMaterialBuffer>();
 
+		// Initialize grass constant buffers.
+		_cbGrassSettings = CreateConstantBuffer<CGrassSettingsBuffer>();
+		_cbGrassInstances = CreateConstantBuffer<CGrassInstanceBuffer>();
+		_grassSystem.Initialize(_device.Get());
+
 		// Prepare HUD Constant buffer.
 		_cbHUDBar = CreateConstantBuffer<CHUDBarBuffer>();
 		_cbHUD = CreateConstantBuffer<CHUDBuffer>();
@@ -553,6 +558,9 @@ namespace TEN::Renderer
 		SetTextureOrDefault(_loadingBarBorder, GetAssetPath(L"Textures/LoadingBarBorder.png"));
 		SetTextureOrDefault(_loadingBarInner, GetAssetPath(L"Textures/LoadingBarInner.png"));
 		SetTextureOrDefault(_whiteTexture, GetAssetPath(L"Textures/WhiteSprite.png"));
+
+		// Initialize grass atlas texture.
+		SetTextureOrDefault(_grassAtlasTexture, GetAssetPath(L"Textures/GrassAtlas.png"));
 
 		_context->Flush();
 

--- a/TombEngine/Renderer/ShaderManager/ShaderManager.cpp
+++ b/TombEngine/Renderer/ShaderManager/ShaderManager.cpp
@@ -116,6 +116,8 @@ namespace TEN::Renderer::Utils
 		Load(Shader::InstancedStatics, "InstancedStatics", "", ShaderType::PixelAndVertex);
 		Load(Shader::InstancedSprites, "InstancedSprites", "", ShaderType::PixelAndVertex);
 
+		Load(Shader::Grass, "Grass", "", ShaderType::PixelAndVertex);
+
 		Load(Shader::GBuffer, "GBuffer", "", ShaderType::Pixel);
 		Load(Shader::GBufferRooms, "GBuffer", "Rooms", ShaderType::Vertex);
 		Load(Shader::GBufferItems, "GBuffer", "Items", ShaderType::Vertex);

--- a/TombEngine/Renderer/ShaderManager/ShaderManager.h
+++ b/TombEngine/Renderer/ShaderManager/ShaderManager.h
@@ -68,6 +68,10 @@ namespace TEN::Renderer::Utils
 		Downscale,
 		GlowCombine,
 
+		// Grass
+
+		Grass,
+
 		Count
 	};
 

--- a/TombEngine/Shaders/CBGrass.hlsli
+++ b/TombEngine/Shaders/CBGrass.hlsli
@@ -10,8 +10,8 @@ struct GrassInfluenceSphere
 	float Radius;
 	//--
 	float Intensity;
-	float Timestamp;
-	float Padding0;
+	float Timestamp;       // Last refresh time (used for decay).
+	float BirthTimestamp;  // Creation time (used for rise).
 	float Padding1;
 };
 
@@ -27,6 +27,15 @@ struct GrassInstanceData
 	//--
 	float2 UVOffset;
 	float2 UVScale;
+	//--
+	float3 AmbientLight;
+	float WindEnabled;
+	//--
+	float3 SunDirection;
+	float SunIntensity;
+	//--
+	float3 SunColor;
+	float SunPad0;
 };
 
 cbuffer GrassSettingsBuffer : register(b9)

--- a/TombEngine/Shaders/CBGrass.hlsli
+++ b/TombEngine/Shaders/CBGrass.hlsli
@@ -1,0 +1,60 @@
+#ifndef CBGRASS_HLSLI
+#define CBGRASS_HLSLI
+
+#define MAX_GRASS_INSTANCES 256
+#define MAX_GRASS_INFLUENCES 8
+
+struct GrassInfluenceSphere
+{
+	float3 Position;
+	float Radius;
+	//--
+	float Intensity;
+	float Timestamp;
+	float Padding0;
+	float Padding1;
+};
+
+struct GrassInstanceData
+{
+	float3 Position;
+	float Scale;
+	//--
+	float3 Normal;
+	float Seed;
+	//--
+	float4 Color;
+	//--
+	float2 UVOffset;
+	float2 UVScale;
+};
+
+cbuffer GrassSettingsBuffer : register(b9)
+{
+	float MaxDrawDistance;
+	float FadeStartDistance;
+	float WindStrength;
+	float WindFrequency;
+	//--
+	float3 WindDirection;
+	float Time;
+	//--
+	float BendRiseSpeed;
+	float BendDecaySpeed;
+	float BendMaxAngle;
+	int NumInfluences;
+	//--
+	float BladeWidth;
+	float BladeHeight;
+	int DebugMode;
+	float GrassSettingsPad0;
+	//--
+	GrassInfluenceSphere Influences[MAX_GRASS_INFLUENCES];
+};
+
+cbuffer GrassInstanceBuffer : register(b13)
+{
+	GrassInstanceData GrassInstances[MAX_GRASS_INSTANCES];
+};
+
+#endif

--- a/TombEngine/Shaders/Grass.hlsl
+++ b/TombEngine/Shaders/Grass.hlsl
@@ -1,0 +1,225 @@
+// Grass.hlsl - Instanced grass blade rendering with influence-based bending.
+// Each grass blade is a vertical quad (2 triangles, 6 vertices) positioned and
+// oriented per-instance. The vertex shader generates quad vertices from InstanceID 
+// and VertexID, applies wind animation, and bends blades based on nearby influence 
+// spheres (e.g. the player walking through).
+
+#include "./Math.hlsli"
+#include "./CBCamera.hlsli"
+#include "./CBGrass.hlsli"
+#include "./ShaderLight.hlsli"
+#include "./Blending.hlsli"
+
+struct PixelShaderInput
+{
+	float4 Position     : SV_POSITION;
+	float3 WorldPosition: POSITION0;
+	float3 Normal       : NORMAL;
+	float2 UV           : TEXCOORD0;
+	float4 Color        : COLOR;
+	float4 PositionCopy : TEXCOORD1;
+	float4 FogBulbs     : TEXCOORD2;
+	float  DistanceFog  : FOG;
+	float  FadeFactor   : TEXCOORD3;
+};
+
+struct PixelShaderOutput
+{
+	float4 Color : SV_TARGET0;
+};
+
+Texture2D GrassTexture : register(t14);
+SamplerState GrassSampler : register(s14);
+
+// ---------- Vertex generation ----------
+// Generates a vertical quad from VertexID (0..5 for two triangles).
+// Returns local-space position: X = [-0.5, 0.5], Y = [0, 1], Z = 0.
+
+static const float2 QuadPos[6] =
+{
+	float2(-0.5f, 0.0f), // BL
+	float2( 0.5f, 0.0f), // BR
+	float2( 0.5f, 1.0f), // TR
+	float2(-0.5f, 0.0f), // BL
+	float2( 0.5f, 1.0f), // TR
+	float2(-0.5f, 1.0f)  // TL
+};
+
+static const float2 QuadUV[6] =
+{
+	float2(0.0f, 1.0f),
+	float2(1.0f, 1.0f),
+	float2(1.0f, 0.0f),
+	float2(0.0f, 1.0f),
+	float2(1.0f, 0.0f),
+	float2(0.0f, 0.0f)
+};
+
+// ---------- Wind animation ----------
+float3 ComputeWind(float3 worldPos, float seed, float heightFrac)
+{
+	// Wind only affects upper portion of blade.
+	float windMask = saturate(heightFrac * heightFrac);
+
+	// Use fractal noise for organic variation.
+	float windPhase = Time * WindFrequency + seed * 6.283f;
+	float noiseVal = sin(windPhase + worldPos.x * 0.01f + worldPos.z * 0.013f) *
+	                 cos(windPhase * 0.7f + worldPos.z * 0.009f);
+
+	float3 windOffset = WindDirection * noiseVal * WindStrength * windMask;
+	return windOffset;
+}
+
+// ---------- Influence bending ----------
+float3 ComputeInfluenceBend(float3 worldPos, float seed, float heightFrac)
+{
+	float3 totalBend = float3(0.0f, 0.0f, 0.0f);
+
+	// Only bend upper portion of blade.
+	float bendMask = saturate(heightFrac * heightFrac);
+
+	for (int i = 0; i < NumInfluences; i++)
+	{
+		float3 toGrass = worldPos - Influences[i].Position;
+		float dist = length(toGrass);
+		float radius = Influences[i].Radius;
+
+		if (dist > radius || dist < 0.001f)
+			continue;
+
+		// Distance falloff: strongest at center, zero at edge.
+		float falloff = 1.0f - saturate(dist / radius);
+		falloff = falloff * falloff; // Quadratic falloff.
+
+		// Time-based rise/decay: how long since the influence was active.
+		float timeSinceActive = Time - Influences[i].Timestamp;
+		float decay = exp(-timeSinceActive * BendDecaySpeed);
+		float rise = saturate(timeSinceActive * BendRiseSpeed);
+		float timeFactor = rise * decay;
+
+		// Per-instance variation using seed.
+		float variation = 0.8f + 0.4f * frac(seed * 127.1f);
+
+		// Bend direction: push grass away from influence center, biased downward.
+		float3 bendDir = SafeNormalize(toGrass);
+		bendDir.y = 0.5f; // Push blades downward (positive Y = down in TEN).
+		bendDir = SafeNormalize(bendDir);
+
+		float bendStrength = Influences[i].Intensity * falloff * timeFactor * variation * BendMaxAngle;
+		totalBend += bendDir * bendStrength * bendMask;
+	}
+
+	return totalBend;
+}
+
+// ---------- Vertex Shader ----------
+PixelShaderInput VS(uint VertexID : SV_VertexID, uint InstanceID : SV_InstanceID)
+{
+	PixelShaderInput output;
+
+	GrassInstanceData inst = GrassInstances[InstanceID];
+
+	// Generate quad vertex from VertexID.
+	float2 localPos = QuadPos[VertexID % 6];
+	float2 uv = QuadUV[VertexID % 6];
+	float heightFrac = localPos.y; // 0 at base, 1 at tip.
+
+	// Scale the quad.
+	float3 bladeLocal;
+	bladeLocal.x = localPos.x * BladeWidth * inst.Scale;
+	bladeLocal.y = localPos.y * BladeHeight * inst.Scale;
+	bladeLocal.z = 0.0f;
+
+	// Create a rotation matrix so the blade faces the camera (Y-axis billboard). 
+	// The blade rotates around its up vector to face the camera, but stays upright.
+	float3 up = inst.Normal;
+	float3 toCamera = CamPositionWS.xyz - inst.Position;
+	toCamera.y = 0.0f; // Keep upright.
+	float camDist = length(toCamera);
+	
+	float3 forward;
+	if (camDist > 0.01f)
+		forward = toCamera / camDist;
+	else
+		forward = float3(0.0f, 0.0f, 1.0f);
+
+	// Per-instance random rotation to break uniformity. 
+	// Use seed to add a fixed rotation offset so blades aren't all aligned.
+	float rotAngle = inst.Seed * 6.283f;
+	float cosR = cos(rotAngle);
+	float sinR = sin(rotAngle);
+	float3 rotatedForward = float3(
+		forward.x * cosR - forward.z * sinR,
+		0.0f,
+		forward.x * sinR + forward.z * cosR
+	);
+	rotatedForward = SafeNormalize(rotatedForward);
+	
+	float3 right = cross(up, rotatedForward);
+	right = SafeNormalize(right);
+	float3 adjustedForward = cross(right, up);
+
+	// Local to world: right = X, up = Y, forward = Z.
+	float3 worldPos = inst.Position
+		+ right * bladeLocal.x
+		+ up * bladeLocal.y
+		+ adjustedForward * bladeLocal.z;
+
+	// Apply wind animation.
+	float3 wind = ComputeWind(worldPos, inst.Seed, heightFrac);
+	worldPos += wind;
+
+	// Apply influence bending.
+	float3 bend = ComputeInfluenceBend(inst.Position, inst.Seed, heightFrac);
+	worldPos += bend;
+
+	// LOD: fade based on distance from camera.
+	float distToCamera = length(CamPositionWS.xyz - inst.Position);
+	float fadeFactor = 1.0f - saturate((distToCamera - FadeStartDistance) / max(MaxDrawDistance - FadeStartDistance, 1.0f));
+
+	output.Position = mul(float4(worldPos, 1.0f), ViewProjection);
+	output.WorldPosition = worldPos;
+	output.Normal = up;
+	output.UV = uv * inst.UVScale + inst.UVOffset;
+	output.Color = inst.Color;
+	output.PositionCopy = output.Position;
+	output.FadeFactor = fadeFactor;
+
+	output.FogBulbs = DoFogBulbsForVertex(worldPos);
+	output.DistanceFog = DoDistanceFogForVertex(worldPos);
+
+	return output;
+}
+
+// ---------- Pixel Shader ----------
+PixelShaderOutput PS(PixelShaderInput input)
+{
+	PixelShaderOutput output;
+
+	float4 tex = GrassTexture.Sample(GrassSampler, input.UV);
+
+	// Alpha cutout.
+	clip(tex.a - 0.5f);
+
+	// Simple hemispherical ambient lighting (TEN uses inverted Y: up = -Y).
+	float NdotUp = dot(input.Normal, float3(0.0f, -1.0f, 0.0f)) * 0.5f + 0.5f;
+	float3 ambient = lerp(float3(0.3f, 0.25f, 0.2f), float3(0.7f, 0.75f, 0.65f), NdotUp);
+
+	// Gradient: darker at base, lighter at tip.
+	// UV.y=0 is top, UV.y=1 is bottom - darken at bottom.
+	float baseGradient = lerp(0.5f, 1.0f, 1.0f - input.UV.y);
+
+	float3 color = tex.rgb * input.Color.rgb * ambient * baseGradient;
+
+	// Apply distance fade.
+	float alpha = tex.a * input.FadeFactor;
+	clip(alpha - 0.1f);
+
+	output.Color = float4(color, alpha);
+
+	// Apply fog.
+	output.Color = DoFogBulbsForPixel(output.Color, float4(input.FogBulbs.xyz, 1.0f));
+	output.Color = DoDistanceFogForPixel(output.Color, FogColor, input.DistanceFog);
+
+	return output;
+}

--- a/TombEngine/Shaders/Grass.hlsl
+++ b/TombEngine/Shaders/Grass.hlsl
@@ -1,7 +1,7 @@
 // Grass.hlsl - Instanced grass blade rendering with influence-based bending.
 // Each grass blade is a vertical quad (2 triangles, 6 vertices) positioned and
-// oriented per-instance. The vertex shader generates quad vertices from InstanceID 
-// and VertexID, applies wind animation, and bends blades based on nearby influence 
+// oriented per-instance. The vertex shader generates quad vertices from InstanceID
+// and VertexID, applies wind animation, and bends blades based on nearby influence
 // spheres (e.g. the player walking through).
 
 #include "./Math.hlsli"
@@ -12,15 +12,18 @@
 
 struct PixelShaderInput
 {
-	float4 Position     : SV_POSITION;
-	float3 WorldPosition: POSITION0;
-	float3 Normal       : NORMAL;
-	float2 UV           : TEXCOORD0;
-	float4 Color        : COLOR;
-	float4 PositionCopy : TEXCOORD1;
-	float4 FogBulbs     : TEXCOORD2;
-	float  DistanceFog  : FOG;
-	float  FadeFactor   : TEXCOORD3;
+	float4 Position      : SV_POSITION;
+	float3 WorldPosition : POSITION0;
+	float3 Normal        : NORMAL;
+	float2 UV            : TEXCOORD0;
+	float4 Color         : COLOR;
+	float4 FogBulbs      : TEXCOORD2;
+	float  DistanceFog   : FOG;
+	float  FadeFactor    : TEXCOORD3;
+	nointerpolation float3 AmbientLight  : TEXCOORD1;
+	nointerpolation float3 SunDirection  : TEXCOORD4;
+	nointerpolation float  SunIntensity  : TEXCOORD5;
+	nointerpolation float3 SunColor      : TEXCOORD6;
 };
 
 struct PixelShaderOutput
@@ -56,31 +59,59 @@ static const float2 QuadUV[6] =
 };
 
 // ---------- Wind animation ----------
-float3 ComputeWind(float3 worldPos, float seed, float heightFrac)
+// Produces organic traveling-wave displacement along and across the wind direction.
+// Wave crests propagate in the wind direction; multiple harmonics add variation.
+// windEnabled: 1.0 = outdoor room (waving on); 0.0 = indoor (no wind).
+float3 ComputeWind(float3 worldPos, float seed, float heightFrac, float windEnabled)
 {
-	// Wind only affects upper portion of blade.
+	// Only wave in outdoor (sky-visible) rooms.
+	if (windEnabled < 0.5f)
+		return float3(0.0f, 0.0f, 0.0f);
+
+	// Wind only affects upper portion of blade — squared mask for stiffer natural base.
 	float windMask = saturate(heightFrac * heightFrac);
 
-	// Use fractal noise for organic variation.
-	float windPhase = Time * WindFrequency + seed * 6.283f;
-	float noiseVal = sin(windPhase + worldPos.x * 0.01f + worldPos.z * 0.013f) *
-	                 cos(windPhase * 0.7f + worldPos.z * 0.009f);
+	// 2D wind direction (XZ-plane); guaranteed normalized on the CPU side.
+	float2 windDir2D  = float2(WindDirection.x, WindDirection.z);
+	float2 windPerp2D = float2(-windDir2D.y, windDir2D.x); // Perpendicular in XZ.
 
-	float3 windOffset = WindDirection * noiseVal * WindStrength * windMask;
+	// Traveling-wave spatial phases: crests propagate along / across wind direction.
+	// 0.008 ≈ 785 world-unit wavelength; 0.005 ≈ 1257 wu cross-wavelength.
+	float forwardPhase = dot(worldPos.xz, windDir2D ) * 0.008f;
+	float crossPhase   = dot(worldPos.xz, windPerp2D) * 0.005f;
+
+	// Per-blade seed shifts phase so blades don't all peak simultaneously.
+	float seedOff = seed * PI2;
+
+	float t = Time * WindFrequency;
+
+	// Primary wave: strong, slow rolling sway in the wind direction.
+	float wave1 = sin(t        - forwardPhase          + seedOff);
+	// Second harmonic: faster, smaller — adds ripple on top of the primary sway.
+	float wave2 = sin(t * 1.7f - forwardPhase * 1.3f   + seedOff * 0.6f)  * 0.4f;
+	// Cross ripple: subtle sideways wobble perpendicular to the wind.
+	float side  = cos(t * 0.8f - crossPhase            + seedOff * 1.4f)  * 0.25f;
+
+	// Forward displacement (in wind direction) + sideways ripple.
+	float3 windOffset =
+		float3(windDir2D.x,  0.0f, windDir2D.y)  * (wave1 + wave2) * WindStrength        * windMask +
+		float3(windPerp2D.x, 0.0f, windPerp2D.y) * side            * WindStrength * 0.3f * windMask;
+
 	return windOffset;
 }
 
 // ---------- Influence bending ----------
-float3 ComputeInfluenceBend(float3 worldPos, float seed, float heightFrac)
+float3 ComputeInfluenceBend(float3 bladeBase, float seed, float heightFrac)
 {
 	float3 totalBend = float3(0.0f, 0.0f, 0.0f);
 
-	// Only bend upper portion of blade.
-	float bendMask = saturate(heightFrac * heightFrac);
+	// Bend mask: anchored at base, full bend from ~40% height upward.
+	// smoothstep gives a more natural bowing look than heightFrac^2.
+	float bendMask = smoothstep(0.0f, 0.4f, heightFrac);
 
 	for (int i = 0; i < NumInfluences; i++)
 	{
-		float3 toGrass = worldPos - Influences[i].Position;
+		float3 toGrass = bladeBase - Influences[i].Position;
 		float dist = length(toGrass);
 		float radius = Influences[i].Radius;
 
@@ -91,18 +122,28 @@ float3 ComputeInfluenceBend(float3 worldPos, float seed, float heightFrac)
 		float falloff = 1.0f - saturate(dist / radius);
 		falloff = falloff * falloff; // Quadratic falloff.
 
-		// Time-based rise/decay: how long since the influence was active.
+		// Rise: ramps from 0 to 1 based on time since first contact.
+		// BendRiseSpeed controls how fast blades initially bend (lower = slower).
+		float timeSinceBorn   = Time - Influences[i].BirthTimestamp;
+		float rise            = saturate(timeSinceBorn * BendRiseSpeed);
+
+		// Decay: full strength while actively refreshed; exponential falloff after.
+		// A small active window accounts for per-frame timestamp refresh lag.
 		float timeSinceActive = Time - Influences[i].Timestamp;
-		float decay = exp(-timeSinceActive * BendDecaySpeed);
-		float rise = saturate(timeSinceActive * BendRiseSpeed);
-		float timeFactor = rise * decay;
+		float activeWindow    = 0.2f;
+		float decayTime       = max(timeSinceActive - activeWindow, 0.0f);
+		float timeFactor      = rise * exp(-decayTime * BendDecaySpeed);
 
 		// Per-instance variation using seed.
 		float variation = 0.8f + 0.4f * frac(seed * 127.1f);
 
-		// Bend direction: push grass away from influence center, biased downward.
-		float3 bendDir = SafeNormalize(toGrass);
-		bendDir.y = 0.5f; // Push blades downward (positive Y = down in TEN).
+		// Bend direction: push grass away from influence center.
+		float3 bendDir = toGrass / dist;
+
+		// When directly underfoot (close to center), collapse more vertically.
+		// When farther from center, push more horizontally outward.
+		float closeness = 1.0f - saturate(dist / (radius * 0.4f));
+		bendDir.y = lerp(0.3f, 1.5f, closeness); // Positive Y = downward in TEN.
 		bendDir = SafeNormalize(bendDir);
 
 		float bendStrength = Influences[i].Intensity * falloff * timeFactor * variation * BendMaxAngle;
@@ -130,31 +171,35 @@ PixelShaderInput VS(uint VertexID : SV_VertexID, uint InstanceID : SV_InstanceID
 	bladeLocal.y = localPos.y * BladeHeight * inst.Scale;
 	bladeLocal.z = 0.0f;
 
-	// Create a rotation matrix so the blade faces the camera (Y-axis billboard). 
+	// Create a rotation matrix so the blade faces the camera (Y-axis billboard).
 	// The blade rotates around its up vector to face the camera, but stays upright.
 	float3 up = inst.Normal;
 	float3 toCamera = CamPositionWS.xyz - inst.Position;
+
 	toCamera.y = 0.0f; // Keep upright.
+
 	float camDist = length(toCamera);
-	
 	float3 forward;
+
 	if (camDist > 0.01f)
 		forward = toCamera / camDist;
 	else
 		forward = float3(0.0f, 0.0f, 1.0f);
 
-	// Per-instance random rotation to break uniformity. 
+	// Per-instance random rotation to break uniformity.
 	// Use seed to add a fixed rotation offset so blades aren't all aligned.
 	float rotAngle = inst.Seed * 6.283f;
 	float cosR = cos(rotAngle);
 	float sinR = sin(rotAngle);
+
 	float3 rotatedForward = float3(
 		forward.x * cosR - forward.z * sinR,
 		0.0f,
 		forward.x * sinR + forward.z * cosR
 	);
+
 	rotatedForward = SafeNormalize(rotatedForward);
-	
+
 	float3 right = cross(up, rotatedForward);
 	right = SafeNormalize(right);
 	float3 adjustedForward = cross(right, up);
@@ -165,8 +210,8 @@ PixelShaderInput VS(uint VertexID : SV_VertexID, uint InstanceID : SV_InstanceID
 		+ up * bladeLocal.y
 		+ adjustedForward * bladeLocal.z;
 
-	// Apply wind animation.
-	float3 wind = ComputeWind(worldPos, inst.Seed, heightFrac);
+	// Apply wind animation (traveling waves; only in outdoor rooms).
+	float3 wind = ComputeWind(worldPos, inst.Seed, heightFrac, inst.WindEnabled);
 	worldPos += wind;
 
 	// Apply influence bending.
@@ -182,8 +227,13 @@ PixelShaderInput VS(uint VertexID : SV_VertexID, uint InstanceID : SV_InstanceID
 	output.Normal = up;
 	output.UV = uv * inst.UVScale + inst.UVOffset;
 	output.Color = inst.Color;
-	output.PositionCopy = output.Position;
+	output.AmbientLight = inst.AmbientLight;
 	output.FadeFactor = fadeFactor;
+
+	// Pass per-instance sun data to pixel shader.
+	output.SunDirection = inst.SunDirection;
+	output.SunIntensity = inst.SunIntensity;
+	output.SunColor = inst.SunColor;
 
 	output.FogBulbs = DoFogBulbsForVertex(worldPos);
 	output.DistanceFog = DoDistanceFogForVertex(worldPos);
@@ -198,18 +248,37 @@ PixelShaderOutput PS(PixelShaderInput input)
 
 	float4 tex = GrassTexture.Sample(GrassSampler, input.UV);
 
-	// Alpha cutout.
+	// Hard alpha cutout for solid, opaque grass appearance.
 	clip(tex.a - 0.5f);
 
-	// Simple hemispherical ambient lighting (TEN uses inverted Y: up = -Y).
+	// Room ambient lighting (from per-instance data).
+	// Modulate with a hemispherical gradient for natural variation.
 	float NdotUp = dot(input.Normal, float3(0.0f, -1.0f, 0.0f)) * 0.5f + 0.5f;
-	float3 ambient = lerp(float3(0.3f, 0.25f, 0.2f), float3(0.7f, 0.75f, 0.65f), NdotUp);
+	float hemiBlend = lerp(0.7f, 1.0f, NdotUp);
+	float3 ambient = input.AmbientLight * hemiBlend;
 
 	// Gradient: darker at base, lighter at tip.
 	// UV.y=0 is top, UV.y=1 is bottom - darken at bottom.
 	float baseGradient = lerp(0.5f, 1.0f, 1.0f - input.UV.y);
 
-	float3 color = tex.rgb * input.Color.rgb * ambient * baseGradient;
+	// Sun bulb directional lighting (per-room, from instance data).
+	float3 sunLighting = float3(0.0f, 0.0f, 0.0f);
+
+	if (input.SunIntensity > 0.0f)
+	{
+		// TEN uses inverted Y (up = -Y), so the sun direction points "down" in world space.
+		// NdotL uses the blade's up normal against the negated sun direction.
+		float NdotL = saturate(dot(input.Normal, -input.SunDirection));
+
+		// Wrap lighting: soften the NdotL falloff so grass doesn't go fully black
+		// on faces pointing away from the sun. wrap=0.5 gives a half-lambert look.
+		float wrap = 0.5f;
+		float wrappedNdotL = saturate((NdotL + wrap) / (1.0f + wrap));
+
+		sunLighting = input.SunColor * input.SunIntensity * wrappedNdotL;
+	}
+
+	float3 color = tex.rgb * input.Color.rgb * (ambient + sunLighting) * baseGradient;
 
 	// Apply distance fade.
 	float alpha = tex.a * input.FadeFactor;

--- a/TombEngine/TombEngine.vcxproj
+++ b/TombEngine/TombEngine.vcxproj
@@ -205,7 +205,7 @@ if not exist "%ScriptsDir%\Strings.lua" xcopy /Y "$(SolutionDir)Scripts\Strings.
       </Command>
     </PostBuildEvent>
     <PreBuildEvent>
-      <Command>powershell -ExecutionPolicy Bypass -File "$(SolutionDir)\Documentation\generate_objectlist.ps1"
+      <Command>powershell -ExecutionPolicy Bypass -File "$(SolutionDir)Documentation\generate_objectlist.ps1"
 powershell -ExecutionPolicy Bypass -File "$(ProjectDir)Specific\savegame\schema\generate_code.ps1"
 
 CD "$(ProjectDir)..\Documentation\"
@@ -778,6 +778,7 @@ if not exist "%ScriptsDir%\Strings.lua" xcopy /Y "$(SolutionDir)Scripts\Strings.
     <ClInclude Include="Renderer\ConstantBuffers\BlendingBuffer.h" />
     <ClInclude Include="Renderer\ConstantBuffers\CameraMatrixBuffer.h" />
     <ClInclude Include="Renderer\ConstantBuffers\ConstantBuffer.h" />
+    <ClInclude Include="Renderer\ConstantBuffers\GrassBuffer.h" />
     <ClInclude Include="Renderer\ConstantBuffers\HUDBarBuffer.h" />
     <ClInclude Include="Renderer\ConstantBuffers\HUDBuffer.h" />
     <ClInclude Include="Renderer\ConstantBuffers\InstancedSpriteBuffer.h" />
@@ -794,6 +795,7 @@ if not exist "%ScriptsDir%\Strings.lua" xcopy /Y "$(SolutionDir)Scripts\Strings.
     <ClInclude Include="Renderer\ConstantBuffers\SkyBuffer.h" />
     <ClInclude Include="Renderer\ConstantBuffers\SMAABuffer.h" />
     <ClInclude Include="Renderer\Frustum.h" />
+    <ClInclude Include="Renderer\Grass\GrassSystem.h" />
     <ClInclude Include="Renderer\Graphics\IndexBuffer.h" />
     <ClInclude Include="Renderer\Graphics\RenderTarget2D.h" />
     <ClInclude Include="Renderer\Graphics\RenderTargetCube.h" />
@@ -1337,6 +1339,7 @@ if not exist "%ScriptsDir%\Strings.lua" xcopy /Y "$(SolutionDir)Scripts\Strings.
     <ClCompile Include="Physics\Objects\CollisionMesh.cpp" />
     <ClCompile Include="Physics\Objects\CollisionMeshDesc.cpp" />
     <ClCompile Include="Renderer\Frustum.cpp" />
+    <ClCompile Include="Renderer\Grass\GrassSystem.cpp" />
     <ClCompile Include="Renderer\Renderer.cpp" />
     <ClCompile Include="Renderer\RendererAntialiasing.cpp" />
     <ClCompile Include="Renderer\RendererCompatibility.cpp" />


### PR DESCRIPTION
## Checklist

- [ ] I have added a changelog entry to CHANGELOG.md file on the branch/fork (if it is an internal change then it is not needed) 
- [ ] Pull request meets the Coding Conventions standards: https://github.com/MontyTRC89/TombEngine/blob/master/CONTRIBUTING.md#coding-conventions

## Links to issue(s) this pull request concerns (if applicable)

n/a

## Description of pull request 

This pull request introduces a new GPU-accelerated grass rendering system to the TombEngine renderer, enabling dynamic grass blade generation, wind, and player interaction effects. The changes span new data structures, constant buffers, rendering logic, shader integration, and debug tools. The most important changes are grouped below.

### Grass Rendering System Integration

* Added the new `GrassSystem` class (`Renderer/Grass/GrassSystem.h`) with CPU-side structures for grass blades, spatial tiles, influence spheres, and configuration, along with methods for initialization, grass generation, update, and rendering.
* Integrated grass system members into the renderer, including constant buffers (`CGrassSettingsBuffer`, `CGrassInstanceBuffer`), grass atlas texture, draw call counters, and system initialization/clearing. [[1]](diffhunk://#diff-a0a7bc90f86235a9ea4c306b16accfabb0f874da8217cbb3b49765b0d7cc2bb6R196-R204) [[2]](diffhunk://#diff-a0a7bc90f86235a9ea4c306b16accfabb0f874da8217cbb3b49765b0d7cc2bb6R314) [[3]](diffhunk://#diff-3e100bdd00cc2206451ce0249c1c70bf0d8cadc91e510cc0bcdc7b27d2739a1eR58-R59) [[4]](diffhunk://#diff-f6041268fb3f78762a464e9d22f1eb73f8361361d62c46a73a2bd414b4ebfd1fR76-R80) [[5]](diffhunk://#diff-f6041268fb3f78762a464e9d22f1eb73f8361361d62c46a73a2bd414b4ebfd1fR562-R564)
* Grass instances are generated from level floor materials at load time, with logging for blade counts.

### Rendering Pipeline and Shader Support

* Added grass rendering logic to the draw pipeline, including constant buffer and texture bindings, shader selection, render state setup, player influence sphere updates, and draw call restoration. [[1]](diffhunk://#diff-7b4d6ebaace99133aaa5de45c2edf2d0f80d0482e19728490f671206740d20d9R2410-R2413) [[2]](diffhunk://#diff-7b4d6ebaace99133aaa5de45c2edf2d0f80d0482e19728490f671206740d20d9R4259-R4313)
* Introduced new constant buffer and texture slots for grass settings and instances; updated enums for shader resource registration. [[1]](diffhunk://#diff-7627304cdcb79855496edf417ec9b3590a4dfc767d2366e2fbdddbf090a005e9L202-R204) [[2]](diffhunk://#diff-7627304cdcb79855496edf417ec9b3590a4dfc767d2366e2fbdddbf090a005e9R229-R234)
* Created `CBGrass.hlsli` for HLSL constant buffer definitions, matching CPU-side structures and enabling shader access to grass data.
* Registered the new `Grass` shader in the shader manager. [[1]](diffhunk://#diff-c8f077824441c9f911e77bc36ac8089638fb76126abc5937dc25c12c79a97ca8R119-R120) [[2]](diffhunk://#diff-a9b2664d454a2c97ed6cf3195235ccb5008b794f6dc03324398c23b811fcb06bR71-R74)

### Debug and Developer Tools

* Added a new debug page (`GrassStats`) to display grass statistics, including blade counts, visible tiles, draw calls, and enable state. [[1]](diffhunk://#diff-9c8d43bae2e8c8ff3a477eb5a25aa3146f74a7bef1dc33638bb158aac457f573R1787-R1796) [[2]](diffhunk://#diff-7627304cdcb79855496edf417ec9b3590a4dfc767d2366e2fbdddbf090a005e9R173)

### Supporting Infrastructure

* Added new header includes for grass buffers and system to renderer files to support compilation and integration. [[1]](diffhunk://#diff-a0a7bc90f86235a9ea4c306b16accfabb0f874da8217cbb3b49765b0d7cc2bb6R43) [[2]](diffhunk://#diff-a0a7bc90f86235a9ea4c306b16accfabb0f874da8217cbb3b49765b0d7cc2bb6R72)
* Bound grass constant buffers in both vertex and pixel shader stages during rendering. [[1]](diffhunk://#diff-7b4d6ebaace99133aaa5de45c2edf2d0f80d0482e19728490f671206740d20d9R1864-R1865) [[2]](diffhunk://#diff-7b4d6ebaace99133aaa5de45c2edf2d0f80d0482e19728490f671206740d20d9R1878-R1879)

---

**References:**  
[[1]](diffhunk://#diff-45a31d56e7a53ac4bda448d65b95cadfeef42f5c5a666f2ed705e9cc4814e236R1-R156) [[2]](diffhunk://#diff-a0a7bc90f86235a9ea4c306b16accfabb0f874da8217cbb3b49765b0d7cc2bb6R196-R204) [[3]](diffhunk://#diff-a0a7bc90f86235a9ea4c306b16accfabb0f874da8217cbb3b49765b0d7cc2bb6R314) [[4]](diffhunk://#diff-3e100bdd00cc2206451ce0249c1c70bf0d8cadc91e510cc0bcdc7b27d2739a1eR58-R59) [[5]](diffhunk://#diff-f6041268fb3f78762a464e9d22f1eb73f8361361d62c46a73a2bd414b4ebfd1fR76-R80) [[6]](diffhunk://#diff-f6041268fb3f78762a464e9d22f1eb73f8361361d62c46a73a2bd414b4ebfd1fR562-R564) [[7]](diffhunk://#diff-2c275d0f0ee10b8d69f4037ac594d3d2c0664de33c7880dbc38c9cea8405ec81R1073-R1077) [[8]](diffhunk://#diff-7b4d6ebaace99133aaa5de45c2edf2d0f80d0482e19728490f671206740d20d9R2410-R2413) [[9]](diffhunk://#diff-7b4d6ebaace99133aaa5de45c2edf2d0f80d0482e19728490f671206740d20d9R4259-R4313) [[10]](diffhunk://#diff-7627304cdcb79855496edf417ec9b3590a4dfc767d2366e2fbdddbf090a005e9L202-R204) [[11]](diffhunk://#diff-7627304cdcb79855496edf417ec9b3590a4dfc767d2366e2fbdddbf090a005e9R229-R234) [[12]](diffhunk://#diff-a9648774f5407ee304125314b6166a31558c9b733458824fd558facd6bc07d7bR1-R60) [[13]](diffhunk://#diff-c8f077824441c9f911e77bc36ac8089638fb76126abc5937dc25c12c79a97ca8R119-R120) [[14]](diffhunk://#diff-a9b2664d454a2c97ed6cf3195235ccb5008b794f6dc03324398c23b811fcb06bR71-R74) [[15]](diffhunk://#diff-9c8d43bae2e8c8ff3a477eb5a25aa3146f74a7bef1dc33638bb158aac457f573R1787-R1796) [[16]](diffhunk://#diff-7627304cdcb79855496edf417ec9b3590a4dfc767d2366e2fbdddbf090a005e9R173) [[17]](diffhunk://#diff-a0a7bc90f86235a9ea4c306b16accfabb0f874da8217cbb3b49765b0d7cc2bb6R43) [[18]](diffhunk://#diff-a0a7bc90f86235a9ea4c306b16accfabb0f874da8217cbb3b49765b0d7cc2bb6R72) [[19]](diffhunk://#diff-7b4d6ebaace99133aaa5de45c2edf2d0f80d0482e19728490f671206740d20d9R1864-R1865) [[20]](diffhunk://#diff-7b4d6ebaace99133aaa5de45c2edf2d0f80d0482e19728490f671206740d20d9R1878-R1879)