### PR TITLE
Fix winged mutant fly turning and target offset for some creatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ TombEngine releases are located in this repository (alongside with Tomb Editor):
 * Fixed linear inventory not fading ammo and combine selectors.
 * Fixed crashes on certain GPUs with dynamic memory allocation.
 * Fixed loading of level files bigger than 2 GB (only for 64-bit systems).
-
+* Fixed corrupted targeting at Lara in water rooms for some shooting creatures.
 ### Lua API changes
 * Added `Collision.Ray` class for raycasting to detect rooms, items, and static meshes.
 * Added `View.DisplayItem` class that can be used to render 3D items in 2D space.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ TombEngine releases are located in this repository (alongside with Tomb Editor):
 * Fixed crashes on certain GPUs with dynamic memory allocation.
 * Fixed loading of level files bigger than 2 GB (only for 64-bit systems).
 * Fixed corrupted targeting at Lara in water rooms for some shooting creatures.
+* Fixed WINGED_MUMMY BodyPartExplode effect, wich caused crash in some cases
 ### Lua API changes
 * Added `Collision.Ray` class for raycasting to detect rooms, items, and static meshes.
 * Added `View.DisplayItem` class that can be used to render 3D items in 2D space.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,9 @@ TombEngine releases are located in this repository (alongside with Tomb Editor):
 * Fixed occasional wrong LASER_BEAM collision.
 * Fixed several BADDY1/2 issues.
 * Fixed original issue with BADDY1/2 with rolling out animation ignoring player on a distance larger than 1 block.
-* Fixed OCB calculation for WINGED_MUMMY. 
+* Fixed explosion effect crash and OCB calculation for WINGED_MUMMY. 
   [For further information] (https://tombengine.com/asset/enemy/winged-mutant-mummy/)
+* Fixed corrupted targeting at Lara in water rooms for some shooting creatures.
 * Fixed teleporting upwards after corner shimmy when another ledge is above.
 * Fixed submerging into the floor when picking up items under low-placed static meshes.
 * Fixed asymmetrically placed plinth pickups (OCB 3 and 4) and allow plinth pickups without static mesh underneath.
@@ -50,8 +51,7 @@ TombEngine releases are located in this repository (alongside with Tomb Editor):
 * Fixed linear inventory not fading ammo and combine selectors.
 * Fixed crashes on certain GPUs with dynamic memory allocation.
 * Fixed loading of level files bigger than 2 GB (only for 64-bit systems).
-* Fixed corrupted targeting at Lara in water rooms for some shooting creatures.
-* Fixed WINGED_MUMMY BodyPartExplode effect, wich caused crash in some cases
+
 ### Lua API changes
 * Added `Collision.Ray` class for raycasting to detect rooms, items, and static meshes.
 * Added `View.DisplayItem` class that can be used to render 3D items in 2D space.

--- a/TombEngine/Game/missile.cpp
+++ b/TombEngine/Game/missile.cpp
@@ -44,10 +44,8 @@ void ShootAtEnemy(Vector3i target, ItemInfo* item, int index)
 		target = item->Pose.Position;
 
 	auto bounds = GameBoundingBox(item);
-	auto targetWithOffset = Vector3(
-		target.x,
-		item->Pose.Position.y + bounds.Y2 + (bounds.Y1 - bounds.Y2) * 0.75f,
-		target.z);
+	auto yOffset = bounds.Y2 - (bounds.GetHeight() * 0.75f);
+	auto targetWithOffset = Vector3(target.x, item->Pose.Position.y + yOffset, target.z);
 
 	// Apply slight random scatter.
 	auto randomOrient = EulerAngles(

--- a/TombEngine/Game/missile.cpp
+++ b/TombEngine/Game/missile.cpp
@@ -43,9 +43,10 @@ void ShootAtEnemy(Vector3i target, ItemInfo* item, int index)
 	if (Vector3i::Distance(item->Pose.Position, target) > TARGET_DEVIATION_THRESHOLD)
 		target = item->Pose.Position;
 
+	auto bounds = GameBoundingBox(item);
 	auto targetWithOffset = Vector3(
 		target.x,
-		target.y - (GameBoundingBox(item).GetHeight() * 0.75f),
+		item->Pose.Position.y + bounds.Y2 + (bounds.Y1 - bounds.Y2) * 0.75f,
 		target.z);
 
 	// Apply slight random scatter.

--- a/TombEngine/Objects/TR1/Entity/WingedMutant.cpp
+++ b/TombEngine/Objects/TR1/Entity/WingedMutant.cpp
@@ -556,17 +556,17 @@ namespace TEN::Entities::Creatures::TR1
 				break;
 
 			case WMUTANT_STATE_FLY:
-					creature.MaxTurn = WINGED_MUTANT_RUN_TURN_RATE_MAX;
+				creature.MaxTurn = WINGED_MUTANT_RUN_TURN_RATE_MAX;
 
-					// Override TargetOffset to OG point.
-					if (creature.Mood == MoodType::Attack && creature.Enemy != nullptr)
-						creature.Target.y = creature.Enemy->Pose.Position.y;
+				// Override TargetOffset to OG point.
+				if (creature.Mood == MoodType::Attack && creature.Enemy != nullptr)
+					creature.Target.y = creature.Enemy->Pose.Position.y;
 
-					if (creature.Mood != MoodType::Escape && isSameZoneInGroundMode && (item.Floor - item.Pose.Position.y) <= CLICK(2))
-					{
-						item.Animation.TargetState = WMUTANT_STATE_IDLE; // Switch to ground mode.
-						item.SetFlagField(WMUTANT_CONF_PATHFINDING_MODE, WMUTANT_PATH_GROUND);
-					}
+				if (creature.Mood != MoodType::Escape && isSameZoneInGroundMode && (item.Floor - item.Pose.Position.y) <= CLICK(2))
+				{
+					item.Animation.TargetState = WMUTANT_STATE_IDLE; // Switch to ground mode.
+					item.SetFlagField(WMUTANT_CONF_PATHFINDING_MODE, WMUTANT_PATH_GROUND);
+				}
 
 				break;
 			}

--- a/TombEngine/Objects/TR1/Entity/WingedMutant.cpp
+++ b/TombEngine/Objects/TR1/Entity/WingedMutant.cpp
@@ -326,13 +326,13 @@ namespace TEN::Entities::Creatures::TR1
 				{
 					item.Animation.TargetState = WMUTANT_STATE_SWIPE_ATTACK;
 				}
-				else if (ai.bite && ai.distance < WINGED_MUTANT_IDLE_JUMP_ATTACK_RANGE)
-				{
-					item.Animation.TargetState = WMUTANT_STATE_IDLE_JUMP_ATTACK;
-				}
 				else if (ai.bite && ai.distance < WINGED_MUTANT_SWIPE_ATTACK_RANGE)
 				{
 					item.Animation.TargetState = WMUTANT_STATE_SWIPE_ATTACK;
+				}
+				else if (ai.bite && ai.distance < WINGED_MUTANT_IDLE_JUMP_ATTACK_RANGE)
+				{
+					item.Animation.TargetState = WMUTANT_STATE_IDLE_JUMP_ATTACK;
 				}
 				else if (projectileType == WMUTANT_PROJ_SHARD)
 				{
@@ -556,13 +556,17 @@ namespace TEN::Entities::Creatures::TR1
 				break;
 
 			case WMUTANT_STATE_FLY:
-				creature.MaxTurn = WINGED_MUTANT_RUN_TURN_RATE_MAX;
-				if (creature.Mood != MoodType::Escape && isSameZoneInGroundMode)
-				{
-					item.Animation.TargetState = WMUTANT_STATE_IDLE; // Switch to ground mode.
-					item.Pose.Position.y = item.Floor;
-					item.SetFlagField(WMUTANT_CONF_PATHFINDING_MODE, WMUTANT_PATH_GROUND);
-				}
+					creature.MaxTurn = WINGED_MUTANT_RUN_TURN_RATE_MAX;
+
+					// Override TargetOffset to OG point.
+					if (creature.Mood == MoodType::Attack && creature.Enemy != nullptr)
+						creature.Target.y = creature.Enemy->Pose.Position.y;
+
+					if (creature.Mood != MoodType::Escape && isSameZoneInGroundMode && (item.Floor - item.Pose.Position.y) <= CLICK(2))
+					{
+						item.Animation.TargetState = WMUTANT_STATE_IDLE; // Switch to ground mode.
+						item.SetFlagField(WMUTANT_CONF_PATHFINDING_MODE, WMUTANT_PATH_GROUND);
+					}
 
 				break;
 			}

--- a/TombEngine/Objects/TR1/Entity/WingedMutant.cpp
+++ b/TombEngine/Objects/TR1/Entity/WingedMutant.cpp
@@ -556,6 +556,7 @@ namespace TEN::Entities::Creatures::TR1
 				break;
 
 			case WMUTANT_STATE_FLY:
+				creature.MaxTurn = WINGED_MUTANT_RUN_TURN_RATE_MAX;
 				if (creature.Mood != MoodType::Escape && isSameZoneInGroundMode)
 				{
 					item.Animation.TargetState = WMUTANT_STATE_IDLE; // Switch to ground mode.

--- a/TombEngine/Objects/TR5/Object/tr5_bodypart.cpp
+++ b/TombEngine/Objects/TR5/Object/tr5_bodypart.cpp
@@ -234,6 +234,7 @@ void ControlBodyPart(short fxNumber)
 			{
 				BodyPartExplode(*fx);
 				KillEffect(fxNumber);
+				return;
 			}
 		}
 


### PR DESCRIPTION
The Winged mutant has 3 bugs: 
1. No MaxTurn in FLY Case. 
2. Wrong TargetOffset formula for shooting attack.
3.  BodyPartExplode function do infinite loop if the body parts touch the water, it sometimes freeze or crash engine.

Wrong TargetOffset formula is epic bug, because it corrupted targeting at Lara in water rooms. These creatures use it: Centaur(TR1), Natla(TR1), WingedMutant(TR1), KnifeThrower(TR2), ScubaDiver(TR3)
