### PR TITLE
EventSequence: clarify Start/Restart semantics, harden Create validation, and avoid argument table mutation

### DIFF
--- a/Scripts/Engine/EventSequence.lua
+++ b/Scripts/Engine/EventSequence.lua
@@ -67,6 +67,7 @@ LevelFuncs.Engine.EventSequence.CallNext = function(sequenceName, nextTimerName,
 	if not thisES then
 		return
 	end
+	
 	if thisES.stopRequested then
 		thisES.stopRequested = false
 		return
@@ -216,7 +217,7 @@ EventSequence.Create = function (name, loop, timerFormat, ...)
 			local n = #funcAndArgs
 			func = funcAndArgs[1]
 			if n > 1 then
-				table.move(funcAndArgs, 2, n, 1, args) -- copy arguments
+				table.move(funcAndArgs, 2, n, 1, args) -- Copy arguments.
 			end
 		else
 			func = funcAndArgs
@@ -314,7 +315,7 @@ end
 -- end
 function EventSequence:Start()
 	local thisES = LevelVars.Engine.EventSequence.sequences[self.name]
-	thisES.stopRequested = false -- clear stale stop requests before a new run
+	thisES.stopRequested = false -- Clear stale stop requests before a new run.
 	Timer.Get(thisES.timers[thisES.currentTimer]):Start()
 end
 


### PR DESCRIPTION
## Checklist

- [x] I have added a changelog entry to CHANGELOG.md file on the branch/fork (if it is an internal change then it is not needed) 
- [x] Pull request meets the Coding Conventions standards: https://github.com/MontyTRC89/TombEngine/blob/master/CONTRIBUTING.md#coding-conventions

## Links to issue(s) this pull request concerns (if applicable)
n/a

## Description of pull request 
This PR improves EventSequence API clarity and runtime robustness by separating resume and restart behaviors, hardening Create input validation, and making function-argument handling non-mutating.

### Background
The previous Start behavior could be interpreted as a restart in some scenarios, which conflicted with the intended begin/unpause semantics.
Additionally, Create accepted edge-case vararg payloads that could produce malformed sequences, and table-based step arguments could be mutated in-place.

### What changed

1. API semantics clarified
    - Start now behaves as begin/unpause of the current step.
    - Restart explicitly performs a full restart from the first step.
    - Stop now clearly stops and resets sequence state to the first element.
2. Callback safety improved
    - CallNext re-reads sequence state after callback execution.
    - If sequence is stopped or deleted during callback, progression is aborted safely.
    - Next timer starts are guarded by existence checks.
3. Create validation hardened
    - Rejects empty vararg payloads.
    - Rejects odd vararg count (time/function pairs are required).
4. Non-mutating argument handling
    - For table-form steps {func, arg1, arg2, ...}, function and arguments are extracted without mutating caller-owned tables.
    - Arguments are copied to a dedicated args table before forwarding to Timer.Create.
    - This prevents side effects when callers reuse the same step table elsewhere.
5. Documentation aligned
    - Method intent is now clearer around Start, Restart, and Stop.
    - Stop behavior is documented as reset-to-first-element.
### Why this approach

- Keeps behavior intuitive for modders:
  - Start = resume/begin
  - Restart = restart from beginning
  - Stop = stop and reset state
- Prevents subtle side effects caused by in-place table mutation.
- Fails fast on malformed Create payloads.
### Behavioral impact

- More predictable control flow across pause/resume/restart scenarios.
- Safer behavior when callbacks modify sequence lifecycle.
- Invalid Create input is rejected early with explicit errors.

### About stopRequested
stopRequested is intentionally kept as a control-flow guard, not just as a stop state flag.
Its purpose is to prevent CallNext from advancing to the next step when Stop() is invoked inside a callback during the same update tick.
Without this guard, callback execution could stop timers but still allow CallNext to increment currentTimer and continue progression unexpectedly.
The flag is cleared on the next safe boundary (CallNext early-return path and on Start/Restart) to avoid stale state.
### Testing checklist

1. Create with zero varargs: must fail with error log.
    ```lua
    EventSequence.Create("test2", true, false)
    ```
    Passed ✓
2. Create with odd vararg count: must fail with error log.
    ```lua
    EventSequence.Create("test3", true, false, 1.0)
    ```
    Passed ✓
3. Pause then Start: must resume current timer (no forced reset). Passed ✓
4. Restart while active: must restart from first step. Passed ✓
5. Stop then Start: must start from reset first-element state. Passed ✓
6. Stop/Delete from callback: sequence must not advance unexpectedly. 
    ```lua
   LevelFuncs.Func1 = function (text, x, y)
         local pos = TEN.Vec2(TEN.Util.PercentToScreen(x, y))
         print("Function " .. text .. " called at position (" .. x .. ", " .. y .. ")")
         local str = TEN.Strings.DisplayString("Function " .. text .. "!", pos, 1)
         TEN.Strings.ShowString(str, 1)
         EventSequence.Delete("test1") -- Delete the sequence after the last function is called
   end
   EventSequence.Create(
   "test1", -- sequence's name
   true, -- loop
   {minutes = true, seconds = true, deciseconds = true}, -- time format
   2.3,
   {LevelFuncs.Func1, "1", 5, 10},
   3.1,
   {LevelFuncs.Func1, "2", 5, 15},
   4.8,
   {LevelFuncs.Func1, "3", 5, 20})
    ```
    Passed ✓
7. Reused step argument tables: must remain unchanged after Create.
    ```lua
    local testParamTable = {LevelFuncs.Func1, "1", 5, 10}
    
    EventSequence.Create(
          "test1", -- sequence's name
           true, -- loop
           {minutes = true, seconds = true, deciseconds = true}, -- time format
           2.3,
           testParamTable, -- parameters for the first function call
           3.1,
           {LevelFuncs.Func1, "2", 5, 15},
           4.8,
           {LevelFuncs.Func1, "3", 5, 20})
 
      EventSequence.Create(
            "test4", 
            false,
            {minutes = true, seconds = true, deciseconds = true},
            1.0,
            testParamTable)
      ```
    Passed ✓