### PR TITLE
Restore hit sound effect for TR1 creatures

### DIFF
--- a/TombEngine/Objects/TR1/Entity/SkateboardKid.cpp
+++ b/TombEngine/Objects/TR1/Entity/SkateboardKid.cpp
@@ -9,7 +9,7 @@
 #include "Game/Setup.h"
 #include "Math/Math.h"
 #include "Specific/trutils.h"
-#include <Sound/sound.h>
+#include "Sound/sound.h"
 
 using namespace TEN::Animation;
 using namespace TEN::Math;

--- a/TombEngine/Objects/TR1/Entity/SkateboardKid.cpp
+++ b/TombEngine/Objects/TR1/Entity/SkateboardKid.cpp
@@ -9,6 +9,7 @@
 #include "Game/Setup.h"
 #include "Math/Math.h"
 #include "Specific/trutils.h"
+#include <Sound/sound.h>
 
 using namespace TEN::Animation;
 using namespace TEN::Math;
@@ -163,6 +164,9 @@ namespace TEN::Entities::Creatures::TR1
 			CreatureMood(&item, &ai, false);
 
 			headingAngle = CreatureTurn(&item, creature.MaxTurn);
+
+			if (item.HitStatus)
+				SoundEffect(SFX_TR1_SKATEBOARDKID_HIT, &item.Pose);
 
 			switch (item.Animation.ActiveState)
 			{

--- a/TombEngine/Objects/TR1/Entity/tr1_bear.cpp
+++ b/TombEngine/Objects/TR1/Entity/tr1_bear.cpp
@@ -12,6 +12,7 @@
 #include "Game/misc.h"
 #include "Game/Setup.h"
 #include "Math/Math.h"
+#include "Sound/sound.h"
 #include "Specific/level.h"
 
 using namespace TEN::Collision::Point;
@@ -144,7 +145,10 @@ namespace TEN::Entities::Creatures::TR1
 			headingAngle = CreatureTurn(&item, creature.MaxTurn);
 
 			if (item.HitStatus)
+			{
+				SoundEffect(SFX_TR1_BEAR_HURT, &item.Pose);
 				creature.Flags = 1;
+			}
 
 			bool isPlayerDead = LaraItem->HitPoints <= 0;
 

--- a/TombEngine/Objects/TR1/Entity/tr1_big_rat.cpp
+++ b/TombEngine/Objects/TR1/Entity/tr1_big_rat.cpp
@@ -116,9 +116,6 @@ namespace TEN::Entities::Creatures::TR1
 		SetBigRatWater(item);
 		bool isOnWater = IsBigRatOnWater(item);
 
-		if (item->HitStatus)
-			SoundEffect(SFX_TR1_RAT_CHIRP, &item->Pose);
-
 		if (item->HitPoints <= 0)
 		{
 			bool doWaterDeath = isOnWater;
@@ -143,6 +140,9 @@ namespace TEN::Entities::Creatures::TR1
 			CreatureMood(item, &ai, isOnWater);
 			creature->MaxTurn = isOnWater ? BIG_RAT_SWIM_TURN_RATE_MAX : BIG_RAT_RUN_TURN_RATE_MAX;
 			angle = CreatureTurn(item, creature->MaxTurn);
+
+			if (item->HitStatus)
+				SoundEffect(SFX_TR1_RAT_CHIRP, &item->Pose);
 
 			switch (item->Animation.ActiveState)
 			{

--- a/TombEngine/Objects/TR1/Entity/tr1_giant_mutant.cpp
+++ b/TombEngine/Objects/TR1/Entity/tr1_giant_mutant.cpp
@@ -106,6 +106,9 @@ namespace TEN::Entities::Creatures::TR1
 
 			headingAngle = (short)phd_atan(creature->Target.z - item->Pose.Position.z, creature->Target.x - item->Pose.Position.x) - item->Pose.Orientation.y;
 
+			if (item->HitStatus)
+				SoundEffect(SFX_TR1_GIANT_MUTANT_HIT, &item->Pose);
+
 			if (item->TouchBits.TestAny())
 				DoDamage(creature->Enemy, MUTANT_CONTACT_DAMAGE);
 

--- a/TombEngine/Objects/TR1/Entity/tr1_wolf.cpp
+++ b/TombEngine/Objects/TR1/Entity/tr1_wolf.cpp
@@ -10,6 +10,7 @@
 #include "Game/misc.h"
 #include "Game/Setup.h"
 #include "Math/Math.h"
+#include "Sound/sound.h"
 #include "Specific/level.h"
 
 using namespace TEN::Math;
@@ -132,6 +133,9 @@ namespace TEN::Entities::Creatures::TR1
 
 			if (item.Animation.ActiveState != WOLF_STATE_SLEEP)
 				headingAngle = CreatureTurn(&item, creature.MaxTurn);
+
+			if (item.HitStatus)
+				SoundEffect(SFX_TR1_WOLF_HURT, &item.Pose);
 
 			switch (item.Animation.ActiveState)
 			{

--- a/TombEngine/Objects/TR5/Entity/tr5_lion.cpp
+++ b/TombEngine/Objects/TR5/Entity/tr5_lion.cpp
@@ -12,6 +12,7 @@
 #include "Game/misc.h"
 #include "Game/Setup.h"
 #include "Math/Math.h"
+#include "Sound/sound.h"
 #include "Specific/level.h"
 
 using namespace TEN::Math;
@@ -129,6 +130,9 @@ namespace TEN::Entities::Creatures::TR5
 
 			headingAngle = CreatureTurn(item, creature->MaxTurn);
 			joint0 = headingAngle * -16;
+
+			if (item->HitStatus)
+				SoundEffect(SFX_TR1_LION_HURT, &item->Pose);
 
 			switch (item->Animation.ActiveState)
 			{


### PR DESCRIPTION
Restore Hit SFX for TR1 creatures:
TR1_WOLF_HURT	
TR1_BEAR_HURT	
TR1_RAT_CHIRP	
TR1_LION_HURT
TR1_GIANT_MUTANT_HIT	
TR1_SKATEBOARDKID_HIT	


Depends on TombEngine/TombEditor#1155 