### PR TITLE
Update SetWeaponMode, GetWeaponMode

### DIFF
--- a/TombEngine/Renderer/RendererDrawMenu.cpp
+++ b/TombEngine/Renderer/RendererDrawMenu.cpp
@@ -979,7 +979,7 @@ namespace TEN::Renderer
 
 	void Renderer::DrawObjectIn3DSpace(const DisplayItem& item)
 	{
-		if (!item.GetVisible() || item.GetColor().A() == 0)
+		if (!item.GetVisible())
 			return;
 
 		float alpha = GetInterpolationFactor();
@@ -989,6 +989,11 @@ namespace TEN::Renderer
 		auto orient = item.GetInterpolatedOrientation(alpha);
 		auto scale = item.GetInterpolatedScale(alpha);
 		auto color = item.GetInterpolatedColor(alpha);
+
+		constexpr float ALPHA_EPSILON = 1e-5f;
+		if (color.w <= ALPHA_EPSILON)
+			return;
+
 		int meshBits = item.GetMeshBits();
 
 		unsigned int stride = sizeof(Vertex);

--- a/TombEngine/Renderer/RendererDrawMenu.cpp
+++ b/TombEngine/Renderer/RendererDrawMenu.cpp
@@ -979,7 +979,7 @@ namespace TEN::Renderer
 
 	void Renderer::DrawObjectIn3DSpace(const DisplayItem& item)
 	{
-		if (!item.GetVisible())
+		if (!item.GetVisible() || item.GetColor().A() == 0)
 			return;
 
 		float alpha = GetInterpolationFactor();

--- a/TombEngine/Renderer/RendererDrawMenu.cpp
+++ b/TombEngine/Renderer/RendererDrawMenu.cpp
@@ -983,17 +983,15 @@ namespace TEN::Renderer
 			return;
 
 		float alpha = GetInterpolationFactor();
+		auto color = item.GetInterpolatedColor(alpha);
+
+		if (color.A() <= EPSILON)
+			return;
 
 		auto objectNumber = item.GetObjectID();
 		auto pos = item.GetInterpolatedPosition(alpha);
 		auto orient = item.GetInterpolatedOrientation(alpha);
 		auto scale = item.GetInterpolatedScale(alpha);
-		auto color = item.GetInterpolatedColor(alpha);
-
-		constexpr float ALPHA_EPSILON = 1e-5f;
-		if (color.w <= ALPHA_EPSILON)
-			return;
-
 		int meshBits = item.GetMeshBits();
 
 		unsigned int stride = sizeof(Vertex);

--- a/TombEngine/Scripting/Internal/TEN/Objects/Lara/LaraObject.cpp
+++ b/TombEngine/Scripting/Internal/TEN/Objects/Lara/LaraObject.cpp
@@ -365,8 +365,8 @@ int LaraObject::GetAmmoType(TypeOrNil<LaraWeaponType> weaponType) const
 	const auto& player = GetLaraInfo(*_moveable);
 
 	auto weapon = ValueOr<LaraWeaponType>(weaponType, player.Control.Weapon.GunType);
-
 	auto ammoType = std::optional<PlayerAmmoType>(std::nullopt);
+
 	switch (weapon)
 	{
 		case::LaraWeaponType::Pistol:
@@ -519,7 +519,6 @@ int LaraObject::GetWeaponMode(TypeOrNil<LaraWeaponType> weaponType) const
 	const auto& player = GetLaraInfo(*_moveable);
 
 	auto weapon = ValueOr<LaraWeaponType>(weaponType, player.Control.Weapon.GunType);
-
 	auto weaponMode = std::optional<PlayerWeaponMode>(std::nullopt);
 
 	switch (weapon)
@@ -541,13 +540,14 @@ int LaraObject::GetWeaponMode(TypeOrNil<LaraWeaponType> weaponType) const
 			break;
 		}
 		break;
+
 	default:
 		break;
 	}
 
 	if (!weaponMode.has_value())
 	{
-		TENLog("GetWeaponMode() error; no weapon mode type.", LogLevel::Warning, LogConfig::All);
+		TENLog("GetWeaponMode: no weapon mode is available for specified weapon.", LogLevel::Warning, LogConfig::All);
 		weaponMode = PlayerWeaponMode::None;
 	}
 
@@ -580,12 +580,13 @@ void LaraObject::SetWeaponMode(LaraWeaponType weaponType, PlayerWeaponMode weapo
 			break;
 
 		default:
-			TENLog("SetWeaponMode() error; unsupported weapon mode for HK weapon type.", LogLevel::Warning, LogConfig::All);
+			TENLog("SetWeaponMode: unsupported weapon mode for HK weapon type.", LogLevel::Warning, LogConfig::All);
 			break;
 		}
 		break;
+
 	default:
-		TENLog("SetWeaponMode() error; no weapon mode supported for weapon type.", LogLevel::Warning, LogConfig::All);
+		TENLog("SetWeaponMode: no weapon mode supported for weapon type.", LogLevel::Warning, LogConfig::All);
 		break;
 	}
 }

--- a/TombEngine/Scripting/Internal/TEN/Objects/Lara/LaraObject.cpp
+++ b/TombEngine/Scripting/Internal/TEN/Objects/Lara/LaraObject.cpp
@@ -575,8 +575,12 @@ void LaraObject::SetWeaponMode(LaraWeaponType weaponType, PlayerWeaponMode weapo
 			player.Weapons[(int)LaraWeaponType::HK].WeaponMode = LaraWeaponTypeCarried::WTYPE_AMMO_2;
 			break;
 
-		default:
+		case PlayerWeaponMode::Sniper:
 			player.Weapons[(int)LaraWeaponType::HK].WeaponMode = LaraWeaponTypeCarried::WTYPE_AMMO_3;
+			break;
+
+		default:
+			TENLog("SetWeaponMode() error; unsupported weapon mode for HK weapon type.", LogLevel::Warning, LogConfig::All);
 			break;
 		}
 		break;

--- a/TombEngine/Scripting/Internal/TEN/Objects/Lara/LaraObject.cpp
+++ b/TombEngine/Scripting/Internal/TEN/Objects/Lara/LaraObject.cpp
@@ -510,30 +510,38 @@ int LaraObject::GetAmmoCount() const
 	return (ammo.HasInfinite()) ? -1 : (int)ammo.GetCount();
 }
 
-/// Get player HK weapon mode type.
+/// Get player weapon mode type.
 // @function LaraObject:GetWeaponMode
-// @treturn Objects.WeaponMode Player HK weapon mode type.
-int LaraObject::GetWeaponMode() const
+// @tparam[opt] Objects.WeaponType weaponType Weapon to retrieve weapon mode for. If omitted, the mode of the currently equipped weapon is returned. Only works for HK weapon currently.
+// @treturn Objects.WeaponMode Player weapon mode type.
+int LaraObject::GetWeaponMode(TypeOrNil<LaraWeaponType> weaponType) const
 {
 	const auto& player = GetLaraInfo(*_moveable);
 
+	auto weapon = ValueOr<LaraWeaponType>(weaponType, player.Control.Weapon.GunType);
+
 	auto weaponMode = std::optional<PlayerWeaponMode>(std::nullopt);
-	auto weapon = player.Weapons[(int)LaraWeaponType::HK].WeaponMode;
 
 	switch (weapon)
 	{
-	case::LaraWeaponTypeCarried::WTYPE_AMMO_1:
-	{
-		weaponMode = PlayerWeaponMode::Rapid;
+	case::LaraWeaponType::HK:
+		if (player.Weapons[(int)LaraWeaponType::HK].WeaponMode == LaraWeaponTypeCarried::WTYPE_AMMO_1)
+		{
+			weaponMode = PlayerWeaponMode::Rapid;
+			break;
+		}
+		else if (player.Weapons[(int)LaraWeaponType::HK].WeaponMode == LaraWeaponTypeCarried::WTYPE_AMMO_2)
+		{
+			weaponMode = PlayerWeaponMode::Burst;
+			break;
+		}
+		else if (player.Weapons[(int)LaraWeaponType::HK].WeaponMode == LaraWeaponTypeCarried::WTYPE_AMMO_3)
+		{
+			weaponMode = PlayerWeaponMode::Sniper;
+			break;
+		}
 		break;
-	}
-	case::LaraWeaponTypeCarried::WTYPE_AMMO_2:
-	{
-		weaponMode = PlayerWeaponMode::Burst;
-		break;
-	}
 	default:
-		weaponMode = PlayerWeaponMode::Sniper;
 		break;
 	}
 
@@ -546,28 +554,34 @@ int LaraObject::GetWeaponMode() const
 	return static_cast<int>(weaponMode.value());
 }
 
-/// Set player HK weapon mode type.
+/// Set player weapon mode type.
 // @function LaraObject:SetWeaponMode
-// @tparam Objects.WeaponMode weaponMode Player HK weapon mode type.
-void LaraObject::SetWeaponMode(PlayerWeaponMode weaponMode)
+// @tparam Objects.WeaponType weaponType Weapon to set weapon mode for. Only works for HK weapon currently.
+// @tparam Objects.WeaponMode weaponMode Player weapon mode type.
+void LaraObject::SetWeaponMode(LaraWeaponType weaponType, PlayerWeaponMode weaponMode)
 {
 	auto& player = GetLaraInfo(*_moveable);
 
-	switch (weaponMode)
+	switch (weaponType)
 	{
-	case PlayerWeaponMode::Rapid:
-		player.Weapons[(int)LaraWeaponType::HK].WeaponMode = LaraWeaponTypeCarried::WTYPE_AMMO_1;
-		break;
+	case::LaraWeaponType::HK:
+		switch (weaponMode)
+		{
+		case PlayerWeaponMode::Rapid:
+			player.Weapons[(int)LaraWeaponType::HK].WeaponMode = LaraWeaponTypeCarried::WTYPE_AMMO_1;
+			break;
 
-	case PlayerWeaponMode::Burst:
-		player.Weapons[(int)LaraWeaponType::HK].WeaponMode = LaraWeaponTypeCarried::WTYPE_AMMO_2;
-		break;
+		case PlayerWeaponMode::Burst:
+			player.Weapons[(int)LaraWeaponType::HK].WeaponMode = LaraWeaponTypeCarried::WTYPE_AMMO_2;
+			break;
 
-	case PlayerWeaponMode::Sniper:
-		player.Weapons[(int)LaraWeaponType::HK].WeaponMode = LaraWeaponTypeCarried::WTYPE_AMMO_3;
+		default:
+			player.Weapons[(int)LaraWeaponType::HK].WeaponMode = LaraWeaponTypeCarried::WTYPE_AMMO_3;
+			break;
+		}
 		break;
-
 	default:
+		TENLog("SetWeaponMode() error; no weapon mode supported for weapon type.", LogLevel::Warning, LogConfig::All);
 		break;
 	}
 }

--- a/TombEngine/Scripting/Internal/TEN/Objects/Lara/LaraObject.h
+++ b/TombEngine/Scripting/Internal/TEN/Objects/Lara/LaraObject.h
@@ -33,8 +33,8 @@ public:
 	int GetAmmoType(TypeOrNil<LaraWeaponType> weaponType) const;
 	void SetAmmoType(PlayerAmmoType ammoType);
 	int GetAmmoCount() const;
-	int GetWeaponMode() const;
-	void SetWeaponMode(PlayerWeaponMode weaponMode);
+	int GetWeaponMode(TypeOrNil<LaraWeaponType> weaponType) const;
+	void SetWeaponMode(LaraWeaponType weaponType, PlayerWeaponMode weaponMode);
 
 	void UndrawWeapon();
 	void DiscardTorch();


### PR DESCRIPTION
Disable drawing display items when Alpha is 0

## Checklist

- [ ] I have added a changelog entry to the `CHANGELOG.md` file on the branch/fork (if it is an internal change, this is not needed).
- [ ] This pull request meets the Coding Conventions standards: https://github.com/MontyTRC89/TombEngine/blob/master/CONTRIBUTING.md#coding-conventions

## Links to issue(s) this pull request concerns (if applicable)

N/A

## Pull request description
Disables drawing of  display items with alpha = 0
Updates GetWeaponMode and SetWeaponMode to use weaponType

local modeIndex = Lara:GetWeaponMode(TEN.Objects.WeaponType.HK)
print(modeIndex)

Lara:SetWeaponMode(TEN.Objects.WeaponType.HK, Objects.WeaponMode.RAPID)

Other enums are here

https://tombengine.github.io/5%20enums/Objects.WeaponMode.html
