### PR TITLE
Fixed draw key not always opening doors in fly mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ TombEngine releases are located in this repository (alongside with Tomb Editor):
 
 ## [Version 1.11.1]
 
+### Bug fixes
+* Fixed draw key not always opening doors in fly mode.
+
 ### Lua API changes
 * Fixed `Timer` class not working correctly with single frame intervals.
 

--- a/TombEngine/Game/Lara/lara.cpp
+++ b/TombEngine/Game/Lara/lara.cpp
@@ -5,6 +5,7 @@
 #include "Game/camera.h"
 #include "Game/collision/collide_item.h"
 #include "Game/collision/floordata.h"
+#include "Game/collision/Los.h"
 #include "Game/collision/Point.h"
 #include "Game/control/flipeffect.h"
 #include "Game/control/los.h"
@@ -44,6 +45,7 @@
 
 using namespace TEN::Animation;
 using namespace TEN::Collision::Floordata;
+using namespace TEN::Collision::Los;
 using namespace TEN::Collision::Point;
 using namespace TEN::Control::Volumes;
 using namespace TEN::Effects::Hair;
@@ -703,27 +705,18 @@ void LaraCheat(ItemInfo* item, CollisionInfo* coll)
 	// Open doors in front by pressing the Draw button.
 	if (IsClicked(In::Draw))
 	{
-		auto origin = item->Pose.Position;
-		auto target = Geometry::TranslatePoint(item->Pose.Position, item->Pose.Orientation, BLOCK(2));
-		auto gameOrigin = GameVector(origin, item->RoomNumber);
-		auto gameTarget = GameVector(target, FindRoomNumber(target, item->RoomNumber, true));
+		auto los = GetItemLosCollision(item->Pose.Position.ToVector3(), item->RoomNumber, item->Pose.Orientation.ToDirection(), BLOCK(2));
 
-		Vector3i vector = {};
-		bool inSight = !LOS(&gameOrigin, &gameTarget);
-		int itemNumber = ObjectOnLOS2(&gameOrigin, &gameTarget, &vector, nullptr);
-
-		if (inSight && itemNumber != NO_LOS_ITEM)
+		if (los.has_value() && los.value().Item)
 		{
-			auto distance = Vector3i::Distance(origin, vector);
-			auto objectName = GetObjectName(g_Level.Items[itemNumber].ObjectNumber);
+			auto objectName = GetObjectName(los.value().Item->ObjectNumber);
 
-			if (distance <= BLOCK(1.5f) && objectName.find("DOOR") != std::string::npos)
+			if (los.value().Distance <= BLOCK(1.5f) && objectName.find("DOOR") != std::string::npos)
 			{
-				g_Level.Items[itemNumber].Flags |= CODE_BITS;
-				Trigger(itemNumber);
+				los.value().Item->Flags |= CODE_BITS;
+				Trigger(los.value().Item->Index);
 			}
 		}
-
 	}
 }
 

--- a/TombEngine/Game/Lara/lara.cpp
+++ b/TombEngine/Game/Lara/lara.cpp
@@ -8,7 +8,6 @@
 #include "Game/collision/Los.h"
 #include "Game/collision/Point.h"
 #include "Game/control/flipeffect.h"
-#include "Game/control/los.h"
 #include "Game/control/volume.h"
 #include "Game/effects/Hair.h"
 #include "Game/effects/item_fx.h"
@@ -709,12 +708,13 @@ void LaraCheat(ItemInfo* item, CollisionInfo* coll)
 
 		if (los.has_value() && los.value().Item)
 		{
-			auto objectName = GetObjectName(los.value().Item->ObjectNumber);
+			auto& losValue = los.value();
+			auto objectName = GetObjectName(losValue.Item->ObjectNumber);
 
-			if (los.value().Distance <= BLOCK(1.5f) && objectName.find("DOOR") != std::string::npos)
+			if (losValue.Distance <= BLOCK(1.5f) && objectName.find("DOOR") != std::string::npos)
 			{
-				los.value().Item->Flags |= CODE_BITS;
-				Trigger(los.value().Item->Index);
+				losValue.Item->Flags |= CODE_BITS;
+				Trigger(losValue.Item->Index);
 			}
 		}
 	}


### PR DESCRIPTION
## Checklist

- [x] I have added a changelog entry to the `CHANGELOG.md` file on the branch/fork (if it is an internal change, this is not needed).
- [x] This pull request meets the Coding Conventions standards: https://github.com/MontyTRC89/TombEngine/blob/master/CONTRIBUTING.md#coding-conventions

## Links to issue(s) this pull request concerns (if applicable)

#1936 

## Pull request description

Fixes an issue with doors not always opening in fly mode by pushing DRAW key. Test with doors from both sides.