### PR TITLE
Fix damage to Lara from teeth spikes during flight cheat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ TombEngine releases are located in this repository (alongside with Tomb Editor):
 
 ### Bug fixes
 * Fixed draw key not always opening doors in fly mode.
+* Fixed TEETH_SPIKES with OCB 1 damaging player in fly mode.
 
 ### Lua API changes
 * Fixed `Timer` class not working correctly with single frame intervals.

--- a/TombEngine/Game/items.cpp
+++ b/TombEngine/Game/items.cpp
@@ -958,6 +958,9 @@ void DoDamage(ItemInfo* item, int damage, bool silent)
 	if (item->HitPoints <= 0)
 		return;
 
+	if (item->IsLara() && GetLaraInfo(*item).Control.WaterStatus == WaterStatus::FlyCheat)
+		return;
+
 	item->HitStatus = true;
 	item->HitPoints -= damage;
 

--- a/TombEngine/Objects/TR4/Trap/tr4_teethspike.cpp
+++ b/TombEngine/Objects/TR4/Trap/tr4_teethspike.cpp
@@ -81,7 +81,7 @@ namespace TEN::Entities::Traps
 			item.Status = ITEM_ACTIVE;
 
 			auto intersection = TestBoundsCollideTeethSpikes(&item, LaraItem);
-			
+
 			if (LaraItem->Animation.ActiveState != LS_DEATH && intersection != ContainmentType::DISJOINT)
 			{
 				// Calculate spike angle to horizon. If angle is upward, impale player.

--- a/TombEngine/Objects/TR4/Trap/tr4_teethspike.cpp
+++ b/TombEngine/Objects/TR4/Trap/tr4_teethspike.cpp
@@ -81,10 +81,7 @@ namespace TEN::Entities::Traps
 			item.Status = ITEM_ACTIVE;
 
 			auto intersection = TestBoundsCollideTeethSpikes(&item, LaraItem);
-
-			if (LaraItem->Animation.ActiveState != LS_DEATH &&
-				Lara.Control.WaterStatus != WaterStatus::FlyCheat &&
-				intersection != ContainmentType::DISJOINT)
+			if (LaraItem->Animation.ActiveState != LS_DEATH && intersection != ContainmentType::DISJOINT)
 			{
 				// Calculate spike angle to horizon. If angle is upward, impale player.
 				auto normal = Vector3::Transform(Vector3::UnitY, item.Pose.Orientation.ToRotationMatrix());
@@ -101,7 +98,7 @@ namespace TEN::Entities::Traps
 				{
 					if (LaraItem->Animation.Velocity.y > 6.0f || item.ItemFlags[0] > 1024)
 					{
-						LaraItem->HitPoints = -1;
+						DoDamage(LaraItem, INT_MAX);
 						bloodCount = 20;
 					}
 				}

--- a/TombEngine/Objects/TR4/Trap/tr4_teethspike.cpp
+++ b/TombEngine/Objects/TR4/Trap/tr4_teethspike.cpp
@@ -82,7 +82,9 @@ namespace TEN::Entities::Traps
 
 			auto intersection = TestBoundsCollideTeethSpikes(&item, LaraItem);
 
-			if (LaraItem->Animation.ActiveState != LS_DEATH && intersection != ContainmentType::DISJOINT)
+			if (LaraItem->Animation.ActiveState != LS_DEATH &&
+				Lara.Control.WaterStatus != WaterStatus::FlyCheat &&
+				intersection != ContainmentType::DISJOINT)
 			{
 				// Calculate spike angle to horizon. If angle is upward, impale player.
 				auto normal = Vector3::Transform(Vector3::UnitY, item.Pose.Orientation.ToRotationMatrix());

--- a/TombEngine/Objects/TR4/Trap/tr4_teethspike.cpp
+++ b/TombEngine/Objects/TR4/Trap/tr4_teethspike.cpp
@@ -81,6 +81,7 @@ namespace TEN::Entities::Traps
 			item.Status = ITEM_ACTIVE;
 
 			auto intersection = TestBoundsCollideTeethSpikes(&item, LaraItem);
+			
 			if (LaraItem->Animation.ActiveState != LS_DEATH && intersection != ContainmentType::DISJOINT)
 			{
 				// Calculate spike angle to horizon. If angle is upward, impale player.


### PR DESCRIPTION
This pull request introduces a gameplay change to ensure that Lara is immune to damage and trap interactions while using the "FlyCheat" water status. This prevents unintended deaths or damage when the cheat is active.

Gameplay logic updates:

* Updated the `DoDamage` function in `items.cpp` to prevent Lara from taking damage when her `WaterStatus` is set to `FlyCheat`.
* Modified the trap collision logic in `tr4_teethspike.cpp` to ensure that Lara is not affected by teeth spike traps when in `FlyCheat` mode.

* ## Checklist

- [x] I have added a changelog entry to the `CHANGELOG.md` file on the branch/fork (if it is an internal change, this is not needed).
- [ ] This pull request meets the Coding Conventions standards: https://github.com/MontyTRC89/TombEngine/blob/master/CONTRIBUTING.md#coding-conventions

## Links to issue(s) this pull request concerns (if applicable)

(Replace this sentence with links to issues this PR concerns. If not applicable, please write "N/A").

## Pull request description
