### PR TITLE
Fixed yeti kill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ TombEngine releases are located in this repository (alongside with Tomb Editor):
 
 ### Bug fixes
 * Fixed draw key not always opening doors in fly mode.
+* Fixed YETI misaligning with Lara during kill animation.
 
 ### Lua API changes
 * Fixed `Timer` class not working correctly with single frame intervals.

--- a/TombEngine/Objects/TR2/Entity/tr2_yeti.cpp
+++ b/TombEngine/Objects/TR2/Entity/tr2_yeti.cpp
@@ -260,7 +260,7 @@ namespace TEN::Entities::Creatures::TR2
 					creature->Flags = 1;
 
 					if (LaraItem->HitPoints <= 0)
-						CreatureKill(item, YETI_ANIM_KILL, LEA_YETI_DEATH, YETI_ANIM_DEATH, LS_DEATH);
+						CreatureKill(item, YETI_ANIM_KILL, LEA_YETI_DEATH, YETI_STATE_KILL, LS_DEATH);
 				}
 
 				break;
@@ -284,7 +284,7 @@ namespace TEN::Entities::Creatures::TR2
 					creature->Flags = 1;
 
 					if (LaraItem->HitPoints <= 0)
-						CreatureKill(item, YETI_ANIM_KILL, LEA_YETI_DEATH, YETI_ANIM_DEATH, LS_DEATH);
+						CreatureKill(item, YETI_ANIM_KILL, LEA_YETI_DEATH, YETI_STATE_KILL, LS_DEATH);
 				}
 
 				break;
@@ -306,7 +306,7 @@ namespace TEN::Entities::Creatures::TR2
 					creature->Flags = 1;
 
 					if (LaraItem->HitPoints <= 0)
-						CreatureKill(item, YETI_ANIM_KILL, LEA_YETI_DEATH, YETI_ANIM_DEATH, LS_DEATH);
+						CreatureKill(item, YETI_ANIM_KILL, LEA_YETI_DEATH, YETI_STATE_KILL, LS_DEATH);
 				}
 
 				break;


### PR DESCRIPTION
## Checklist

- [x] I have added a changelog entry to the `CHANGELOG.md` file on the branch/fork (if it is an internal change, this is not needed).
- [x] This pull request meets the Coding Conventions standards: https://github.com/MontyTRC89/TombEngine/blob/master/CONTRIBUTING.md#coding-conventions

## Links to issue(s) this pull request concerns (if applicable)

N/A

## Pull request description

Fixes state ID for yeti kill animation (it was a typo, and death anim number was used instead of kill state ID).