### PR TITLE
Fixed potential level statistics corruption in DoDamage

### DIFF
--- a/TombEngine/Game/items.cpp
+++ b/TombEngine/Game/items.cpp
@@ -961,7 +961,7 @@ void DoDamage(ItemInfo* item, int damage, bool silent)
 	if (item->IsLara() && GetLaraInfo(*item).Control.WaterStatus == WaterStatus::FlyCheat)
 		return;
 	
-	int damageDelta = item->HitPoints;
+	const int oldHitPoints = item->HitPoints;
 
 	item->HitStatus = true;
 	item->HitPoints -= damage;
@@ -977,8 +977,6 @@ void DoDamage(ItemInfo* item, int damage, bool silent)
 		}
 	}
 
-	damageDelta = damageDelta - item->HitPoints;
-
 	if (item->IsLara())
 	{
 		if (damage > 0)
@@ -989,6 +987,7 @@ void DoDamage(ItemInfo* item, int damage, bool silent)
 				Rumble(power, 0.15f);
 			}
 
+			int damageDelta = oldHitPoints - item->HitPoints;
 			SaveGame::Statistics.Game.DamageTaken += damageDelta;
 			SaveGame::Statistics.Level.DamageTaken += damageDelta;
 		}

--- a/TombEngine/Game/items.cpp
+++ b/TombEngine/Game/items.cpp
@@ -960,6 +960,8 @@ void DoDamage(ItemInfo* item, int damage, bool silent)
 
 	if (item->IsLara() && GetLaraInfo(*item).Control.WaterStatus == WaterStatus::FlyCheat)
 		return;
+	
+	int damageDelta = item->HitPoints;
 
 	item->HitStatus = true;
 	item->HitPoints -= damage;
@@ -975,6 +977,8 @@ void DoDamage(ItemInfo* item, int damage, bool silent)
 		}
 	}
 
+	damageDelta = damageDelta - item->HitPoints;
+
 	if (item->IsLara())
 	{
 		if (damage > 0)
@@ -985,8 +989,8 @@ void DoDamage(ItemInfo* item, int damage, bool silent)
 				Rumble(power, 0.15f);
 			}
 
-			SaveGame::Statistics.Game.DamageTaken += damage;
-			SaveGame::Statistics.Level.DamageTaken += damage;
+			SaveGame::Statistics.Game.DamageTaken += damageDelta;
+			SaveGame::Statistics.Level.DamageTaken += damageDelta;
 		}
 
 		if (!silent && (GlobalCounter - lastHurtTime) > (FPS * 2 + Random::GenerateInt(0, FPS)))

--- a/TombEngine/Game/items.cpp
+++ b/TombEngine/Game/items.cpp
@@ -987,7 +987,7 @@ void DoDamage(ItemInfo* item, int damage, bool silent)
 				Rumble(power, 0.15f);
 			}
 
-			int damageDelta = oldHitPoints - item->HitPoints;
+			int damageDelta = std::max(0, oldHitPoints - item->HitPoints);
 			SaveGame::Statistics.Game.DamageTaken += damageDelta;
 			SaveGame::Statistics.Level.DamageTaken += damageDelta;
 		}


### PR DESCRIPTION
## Checklist

- [ ] I have added a changelog entry to the `CHANGELOG.md` file on the branch/fork (if it is an internal change, this is not needed).
- [x] This pull request meets the Coding Conventions standards: https://github.com/MontyTRC89/TombEngine/blob/master/CONTRIBUTING.md#coding-conventions

## Links to issue(s) this pull request concerns (if applicable)

N/A

## Pull request description

This pull request fixes a concealed issue that may cause incorrectly reported "Damage taken" statistics after player was killed by traps such as teeth spikes. It happens because `DoDamage` is called with `INT_MAX` argument for such cases, and even if damage itself is clamped to 0 without this function, statistics were adding the argument value directly to the taken damage. This pull request fixes it by calculating real damage delta between previous health value and resulting health value for the statistics.

As this issue was concealed and never appearing in real life scenarios, unless level designer manually recovers player from death, I am not adding this bugfix to a changelog.