### PR TITLE
Add Logic.HasCallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ TombEngine releases are located in this repository (alongside with Tomb Editor):
 ### Lua API changes
 * Fixed `Timer` class not working correctly with single frame intervals.
 * Fixed alpha value being ignored for `Flow.Settings.UI.shadowTextColor` parameter.
+* Added `HasCallback`for checking if a callback exists.
 
 ## [Version 1.11]
 

--- a/TombEngine/Scripting/Internal/ReservedScriptNames.h
+++ b/TombEngine/Scripting/Internal/ReservedScriptNames.h
@@ -342,6 +342,7 @@ static constexpr char ScriptReserved_HasLineOfSight[]				= "HasLineOfSight";
 
 static constexpr char ScriptReserved_AddCallback[]					= "AddCallback";
 static constexpr char ScriptReserved_RemoveCallback[]				= "RemoveCallback";
+static constexpr char ScriptReserved_HasCallback[]					= "HasCallback";
 static constexpr char ScriptReserved_HandleEvent[]					= "HandleEvent";
 static constexpr char ScriptReserved_EnableEvent[]					= "EnableEvent";
 static constexpr char ScriptReserved_DisableEvent[]					= "DisableEvent";

--- a/TombEngine/Scripting/Internal/TEN/Logic/LogicHandler.cpp
+++ b/TombEngine/Scripting/Internal/TEN/Logic/LogicHandler.cpp
@@ -115,6 +115,7 @@ LogicHandler::LogicHandler(sol::state* lua, sol::table& parent) : _handler{ lua 
 
 	tableLogic.set_function(ScriptReserved_AddCallback, &LogicHandler::AddCallback, this);
 	tableLogic.set_function(ScriptReserved_RemoveCallback, &LogicHandler::RemoveCallback, this);
+	tableLogic.set_function(ScriptReserved_HasCallback, &LogicHandler::HasCallback, this);
 	tableLogic.set_function(ScriptReserved_HandleEvent, &LogicHandler::HandleEvent, this);
 	tableLogic.set_function(ScriptReserved_EnableEvent, &LogicHandler::EnableEvent, this);
 	tableLogic.set_function(ScriptReserved_DisableEvent, &LogicHandler::DisableEvent, this);
@@ -244,6 +245,28 @@ void LogicHandler::RemoveCallback(CallbackPoint point, const LevelFunc& levelFun
 	}
 
 	it->second->erase(levelFunc.m_funcName);
+}
+
+/*** Check if a function is registered as a callback for a specific callback point.
+
+@function HasCallback
+@tparam Logic.CallbackPoint point The callback point to check.
+@tparam function func The function to check; must be in the `LevelFuncs` hierarchy.
+@treturn boolean True if the function is registered for the callback point, false otherwise.
+@usage
+	if TEN.Logic.HasCallback(TEN.Logic.CallbackPoint.PRE_LOOP, LevelFuncs.MyFunc) then
+		print("MyFunc is registered for PRE_LOOP")
+	end
+*/
+bool LogicHandler::HasCallback(CallbackPoint point, const LevelFunc& levelFunc)
+{
+	auto it = _callbacks.find(point);
+	if (it == _callbacks.end())
+	{
+		return false;
+	}
+
+	return it->second->find(levelFunc.m_funcName) != it->second->end();
 }
 
 /*** Attempt to find an event set and execute a particular event from it.

--- a/TombEngine/Scripting/Internal/TEN/Logic/LogicHandler.h
+++ b/TombEngine/Scripting/Internal/TEN/Logic/LogicHandler.h
@@ -149,6 +149,7 @@ public:
 
 	void AddCallback(CallbackPoint point, const LevelFunc& levelFunc);
 	void RemoveCallback(CallbackPoint point, const LevelFunc& levelFunc);
+	bool HasCallback(CallbackPoint point, const LevelFunc& levelFunc);
 	void HandleEvent(const std::string& name, EventType type, sol::optional<Moveable&> activator);
 	void EnableEvent(const std::string& name, EventType type);
 	void DisableEvent(const std::string& name, EventType type);


### PR DESCRIPTION
## Checklist

- [x] I have added a changelog entry to the `CHANGELOG.md` file on the branch/fork (if it is an internal change, this is not needed).
- [x] This pull request meets the Coding Conventions standards: https://github.com/MontyTRC89/TombEngine/blob/master/CONTRIBUTING.md#coding-conventions

## Links to issue(s) this pull request concerns (if applicable)



## Pull request description
This function allows to check if a callback exists at a specific endpoint for the specified function.

```
	if TEN.Logic.HasCallback(TEN.Logic.CallbackPoint.PRE_LOOP, LevelFuncs.MyFunc) then
		print("MyFunc is registered for PRE_LOOP")
	end
```