### PR TITLE
Fixed bindings reset on engine restart

### DIFF
--- a/TombEngine/Specific/EngineMain.cpp
+++ b/TombEngine/Specific/EngineMain.cpp
@@ -368,12 +368,11 @@ int main(int argc, char* argv[])
 	}
 
 	g_Renderer.Create();
+	g_Bindings.Initialize();
 
 	// Load configuration and optionally show setup dialog.
 	if (!LoadConfiguration())
 		InitDefaultConfiguration();
-
-	g_Bindings.Initialize();
 
 	// Initialize main window.
 	int width = g_Configuration.ScreenWidth;


### PR DESCRIPTION
## Checklist

- [ ] I have added a changelog entry to the `CHANGELOG.md` file on the branch/fork (if it is an internal change, this is not needed).
- [x] This pull request meets the Coding Conventions standards: https://github.com/MontyTRC89/TombEngine/blob/master/CONTRIBUTING.md#coding-conventions

## Links to issue(s) this pull request concerns (if applicable)

N/A

## Pull request description

Fixes an unnoticed bug introduced by `renderer_abstraction` which resets control bindings to default every engine restart and crashes the engine if it was previously on the `sdl3_input` branch.