### PR TITLE
Fixed sound volume not set on missing config file

### DIFF
--- a/TombEngine/Game/gui.cpp
+++ b/TombEngine/Game/gui.cpp
@@ -44,8 +44,6 @@ namespace TEN::Gui
 	constexpr int PHD_CENTER_Y	  = DISPLAY_SPACE_RES.y / 2;
 	constexpr int OBJLIST_SPACING = PHD_CENTER_X / 2;
 
-	constexpr auto VOLUME_MAX			 = 100;
-	constexpr auto VOLUME_STEP			 = VOLUME_MAX / 20;
 	constexpr auto MOUSE_SENSITIVITY_MAX = 35;
 	constexpr auto MOUSE_SENSITIVITY_MIN = 1;
 	constexpr auto MOUSE_SMOOTHING_MAX	 = 5;
@@ -1123,7 +1121,7 @@ namespace TEN::Gui
 					if (CurrentSettings.Configuration.MusicVolume > VOLUME_MAX)
 						CurrentSettings.Configuration.MusicVolume = VOLUME_MAX;
 
-					SetVolumeTracks(CurrentSettings.Configuration.MusicVolume);
+					SetAudioConfig(CurrentSettings.Configuration);
 				}
 
 				break;
@@ -1135,7 +1133,7 @@ namespace TEN::Gui
 					if (CurrentSettings.Configuration.SfxVolume > VOLUME_MAX)
 						CurrentSettings.Configuration.SfxVolume = VOLUME_MAX;
 
-					SetVolumeFX(CurrentSettings.Configuration.SfxVolume);
+					SetAudioConfig(CurrentSettings.Configuration);
 					isVolumeAdjusted = IsPulsed(In::Right, 0.1f);
 				}
 
@@ -1191,8 +1189,7 @@ namespace TEN::Gui
 			}
 			else if (SelectedOption == OtherSettingsOption::Cancel)
 			{
-				SetVolumeTracks(g_Configuration.MusicVolume);
-				SetVolumeFX(g_Configuration.SfxVolume);
+				SetAudioConfig(g_Configuration);
 			}
 			else
 			{

--- a/TombEngine/Game/gui.cpp
+++ b/TombEngine/Game/gui.cpp
@@ -1121,7 +1121,7 @@ namespace TEN::Gui
 					if (CurrentSettings.Configuration.MusicVolume > VOLUME_MAX)
 						CurrentSettings.Configuration.MusicVolume = VOLUME_MAX;
 
-					SetAudioConfig(CurrentSettings.Configuration);
+					SetAudioConfiguration(CurrentSettings.Configuration);
 				}
 
 				break;
@@ -1133,7 +1133,7 @@ namespace TEN::Gui
 					if (CurrentSettings.Configuration.SfxVolume > VOLUME_MAX)
 						CurrentSettings.Configuration.SfxVolume = VOLUME_MAX;
 
-					SetAudioConfig(CurrentSettings.Configuration);
+					SetAudioConfiguration(CurrentSettings.Configuration);
 					isVolumeAdjusted = IsPulsed(In::Right, 0.1f);
 				}
 
@@ -1189,7 +1189,7 @@ namespace TEN::Gui
 			}
 			else if (SelectedOption == OtherSettingsOption::Cancel)
 			{
-				SetAudioConfig(g_Configuration);
+				SetAudioConfiguration(g_Configuration);
 			}
 			else
 			{

--- a/TombEngine/Game/gui.cpp
+++ b/TombEngine/Game/gui.cpp
@@ -1078,7 +1078,7 @@ namespace TEN::Gui
 					if (CurrentSettings.Configuration.MusicVolume < 0)
 						CurrentSettings.Configuration.MusicVolume = 0;
 
-					SetVolumeTracks(CurrentSettings.Configuration.MusicVolume);
+					SetAudioConfiguration(CurrentSettings.Configuration);
 				}
 
 				break;
@@ -1090,7 +1090,7 @@ namespace TEN::Gui
 					if (CurrentSettings.Configuration.SfxVolume < 0)
 						CurrentSettings.Configuration.SfxVolume = 0;
 
-					SetVolumeFX(CurrentSettings.Configuration.SfxVolume);
+					SetAudioConfiguration(CurrentSettings.Configuration);
 					isVolumeAdjusted = IsPulsed(In::Left, 0.1f);
 				}
 

--- a/TombEngine/Math/Constants.h
+++ b/TombEngine/Math/Constants.h
@@ -29,6 +29,11 @@
 	constexpr auto GAMMA_MAX     = 1.5f;
 	constexpr auto GAMMA_STEP    = 0.1f;
 
+	// Sound constants
+
+	constexpr auto VOLUME_MAX	= 100;
+	constexpr auto VOLUME_STEP	= VOLUME_MAX / 20;
+
 	// World constants
 
 	constexpr auto BLOCK_UNIT = 1024;

--- a/TombEngine/Specific/EngineMain.cpp
+++ b/TombEngine/Specific/EngineMain.cpp
@@ -374,7 +374,7 @@ int main(int argc, char* argv[])
 	if (!LoadConfiguration())
 	{
 		InitDefaultConfiguration();
-		SetAudioConfig(g_Configuration);
+		SetAudioConfiguration(g_Configuration);
 	}
 
 	// Initialize main window.

--- a/TombEngine/Specific/EngineMain.cpp
+++ b/TombEngine/Specific/EngineMain.cpp
@@ -372,7 +372,10 @@ int main(int argc, char* argv[])
 
 	// Load configuration and optionally show setup dialog.
 	if (!LoadConfiguration())
+	{
 		InitDefaultConfiguration();
+		SetAudioConfig(g_Configuration);
+	}
 
 	// Initialize main window.
 	int width = g_Configuration.ScreenWidth;

--- a/TombEngine/Specific/configuration.cpp
+++ b/TombEngine/Specific/configuration.cpp
@@ -63,10 +63,10 @@ static bool ReadAllText(const std::string& path, std::string& out)
 	return (read == out.size());
 }
 
-void SaveAudioConfig()
+void SetAudioConfig(const GameConfiguration& config)
 {
-	SetVolumeTracks(g_Configuration.MusicVolume);
-	SetVolumeFX(g_Configuration.SfxVolume);
+	SetVolumeTracks(config.MusicVolume);
+	SetVolumeFX(config.SfxVolume);
 }
 
 void InitDefaultConfiguration()
@@ -91,8 +91,8 @@ void InitDefaultConfiguration()
 	g_Configuration.SoundDevice = 1;
 	g_Configuration.EnableSound = true;
 	g_Configuration.EnableReverb = true;
-	g_Configuration.MusicVolume = 100;
-	g_Configuration.SfxVolume = 100;
+	g_Configuration.MusicVolume = VOLUME_MAX;
+	g_Configuration.SfxVolume = VOLUME_MAX;
 
 	g_Configuration.EnableSubtitles = true;
 	g_Configuration.EnableAutoMonkeySwingJump = false;
@@ -281,9 +281,7 @@ bool LoadConfiguration()
 
 	g_Configuration.EnableSound = g_Configuration.SoundDevice > 0;
 
-	SetVolumeTracks(g_Configuration.MusicVolume);
-	SetVolumeFX(g_Configuration.SfxVolume);
-
+	SetAudioConfig(g_Configuration);
 	DefaultConflict();
 
 	return true;

--- a/TombEngine/Specific/configuration.cpp
+++ b/TombEngine/Specific/configuration.cpp
@@ -63,7 +63,7 @@ static bool ReadAllText(const std::string& path, std::string& out)
 	return (read == out.size());
 }
 
-void SetAudioConfig(const GameConfiguration& config)
+void SetAudioConfiguration(const GameConfiguration& config)
 {
 	SetVolumeTracks(config.MusicVolume);
 	SetVolumeFX(config.SfxVolume);
@@ -281,7 +281,7 @@ bool LoadConfiguration()
 
 	g_Configuration.EnableSound = g_Configuration.SoundDevice > 0;
 
-	SetAudioConfig(g_Configuration);
+	SetAudioConfiguration(g_Configuration);
 	DefaultConflict();
 
 	return true;

--- a/TombEngine/Specific/configuration.h
+++ b/TombEngine/Specific/configuration.h
@@ -107,6 +107,6 @@ struct GameConfiguration
 void InitDefaultConfiguration();
 bool LoadConfiguration();
 bool SaveConfiguration();
-void SetAudioConfig(const GameConfiguration& config);
+void SetAudioConfiguration(const GameConfiguration& config);
 
 extern GameConfiguration g_Configuration;

--- a/TombEngine/Specific/configuration.h
+++ b/TombEngine/Specific/configuration.h
@@ -81,8 +81,8 @@ struct GameConfiguration
 	int	 SoundDevice  = 0;
 	bool EnableSound  = false;
 	bool EnableReverb = false;
-	int	 MusicVolume  = 0;
-	int	 SfxVolume	  = 0;
+	int	 MusicVolume  = VOLUME_MAX;
+	int	 SfxVolume	  = VOLUME_MAX;
 
 	// Gameplay
 
@@ -107,6 +107,6 @@ struct GameConfiguration
 void InitDefaultConfiguration();
 bool LoadConfiguration();
 bool SaveConfiguration();
-void SaveAudioConfig();
+void SetAudioConfig(const GameConfiguration& config);
 
 extern GameConfiguration g_Configuration;


### PR DESCRIPTION
## Checklist

- [ ] I have added a changelog entry to the `CHANGELOG.md` file on the branch/fork (if it is an internal change, this is not needed).
- [x] This pull request meets the Coding Conventions standards: https://github.com/MontyTRC89/TombEngine/blob/master/CONTRIBUTING.md#coding-conventions

## Links to issue(s) this pull request concerns (if applicable)

N/A

## Pull request description

Fixes the issue with no sound when there is no configuration file present.
Also generalizes sound volume setting with a helper function.

Things to test:
- [x] Setting music/sound volume in settings
- [x] Whether the sound is present if config is missing
- [x] Whether the sound is present if config is present