### PR TITLE
Reduce amount of samplers in shaders

### DIFF
--- a/TombEngine/Renderer/Native/DirectX11/DX11GraphicsDevice.cpp
+++ b/TombEngine/Renderer/Native/DirectX11/DX11GraphicsDevice.cpp
@@ -275,7 +275,7 @@ namespace TEN::Renderer::Native::DirectX11
 			return;
 		}
 
-		_context->PSSetSamplers((unsigned int)registerType, 1, &d3dSamplerState);
+		_context->PSSetSamplers((unsigned int)samplerType, 1, &d3dSamplerState);
 	}
 
 	void DX11GraphicsDevice::UnbindTexture(ShaderStage stage, TextureRegister registerType)

--- a/TombEngine/Renderer/RendererEnums.h
+++ b/TombEngine/Renderer/RendererEnums.h
@@ -212,7 +212,9 @@ enum class TextureRegister
 	LegacyEnvironmentReflections = 12,
 	SkyboxEnvironmentReflections = 13,
 	AnimatedFrames = 14, // StructuredBuffer<AnimatedFrameUV> for per-draw animated UVs.
-	DistortionMap = 15
+	DistortionMap = 15,
+	NearBlurMap = 16,
+	FarBlurMap = 17
 };
 
 enum class SamplerStateRegister

--- a/TombEngine/Renderer/RendererPostProcess.cpp
+++ b/TombEngine/Renderer/RendererPostProcess.cpp
@@ -74,8 +74,8 @@ namespace TEN::Renderer
 		_graphicsDevice->BindRenderTarget(renderTarget->GetRenderTarget(), nullptr);
 		BindRenderTargetAsTexture(TextureRegister::ColorMap, _postProcessRenderTarget[0]->GetRenderTarget(), SamplerStateRegister::LinearClamp);
 		BindRenderTargetAsTexture(TextureRegister::GBufferDepthMap, _depthRenderTarget->GetRenderTarget(), SamplerStateRegister::PointWrap);
-		BindRenderTargetAsTexture(TextureRegister::DistortionMap, _dofRenderTarget[1]->GetRenderTarget(), SamplerStateRegister::LinearClamp);
-		BindRenderTargetAsTexture(TextureRegister::CausticsMap, _dofRenderTarget[0]->GetRenderTarget(), SamplerStateRegister::LinearClamp);
+		BindRenderTargetAsTexture(TextureRegister::NearBlurMap, _dofRenderTarget[0]->GetRenderTarget(), SamplerStateRegister::LinearClamp);
+		BindRenderTargetAsTexture(TextureRegister::FarBlurMap, _dofRenderTarget[1]->GetRenderTarget(), SamplerStateRegister::LinearClamp);
 		DrawTriangles(3, 0);
 	}
 
@@ -374,11 +374,11 @@ namespace TEN::Renderer
 		_stPostProcessBuffer.BlurRadius = GLOW_BLUR_RADIUS;
 
 		// Horizontal blur
-		_graphicsDevice->ClearRenderTarget2D(_glowRenderTarget[1]->GetRenderTarget(), Colors::Transparent);
-		_graphicsDevice->BindRenderTarget(_glowRenderTarget[1]->GetRenderTarget(), nullptr);
-
 		_stPostProcessBuffer.BlurDirection = Vector2(1.0f, 0.0f);
 		UpdateConstantBuffer(&_stPostProcessBuffer, _cbPostProcessBuffer.get());
+
+		_graphicsDevice->ClearRenderTarget2D(_glowRenderTarget[1]->GetRenderTarget(), Colors::Transparent);
+		_graphicsDevice->BindRenderTarget(_glowRenderTarget[1]->GetRenderTarget(), nullptr);
 
 		BindRenderTargetAsTexture(TextureRegister::ColorMap, _glowRenderTarget[0]->GetRenderTarget(), SamplerStateRegister::LinearClamp);
 		DrawTriangles(3, 0);
@@ -410,8 +410,8 @@ namespace TEN::Renderer
 		_graphicsDevice->ClearRenderTarget2D(renderTarget->GetRenderTarget(), Colors::Transparent);
 		_graphicsDevice->BindRenderTarget(renderTarget->GetRenderTarget(), nullptr);
 
-		BindRenderTargetAsTexture(static_cast<TextureRegister>(0), _postProcessRenderTarget[0]->GetRenderTarget(), SamplerStateRegister::LinearClamp);
-		BindRenderTargetAsTexture(static_cast<TextureRegister>(3), _glowRenderTarget[0]->GetRenderTarget(), SamplerStateRegister::LinearClamp);
+		BindRenderTargetAsTexture(TextureRegister::ColorMap, _postProcessRenderTarget[0]->GetRenderTarget(), SamplerStateRegister::LinearClamp);
+		BindRenderTargetAsTexture(TextureRegister::EmissiveMap, _glowRenderTarget[0]->GetRenderTarget(), SamplerStateRegister::LinearClamp);
 		DrawTriangles(3, 0);
 	}
 }

--- a/TombEngine/Shaders/DOF.hlsli
+++ b/TombEngine/Shaders/DOF.hlsli
@@ -94,9 +94,9 @@ float4 PSDOFDownsample(PixelShaderInput input) : SV_Target
     for (int i = 0; i < 4; i++)
     {
         float2 sampleUV = saturate(input.UV + offsets[i] * fullTexel);
-        color += ColorTexture.SampleLevel(ColorSampler, sampleUV, 0).rgb;
+        color += ColorTexture.SampleLevel(LinearClampSampler, sampleUV, 0).rgb;
 
-        float sceneDepth = DepthTexture.Sample(DepthSampler, sampleUV).x;
+        float sceneDepth = DepthTexture.Sample(PointWrapSampler, sampleUV).x;
         viewDepth += abs(ReconstructViewPosition(sampleUV, sceneDepth, InverseProjection).z);
     }
 
@@ -118,7 +118,7 @@ float4 PSDOFDownsample(PixelShaderInput input) : SV_Target
 
 float4 PSDOFFarBlur(PixelShaderInput input) : SV_Target
 {
-    float4 center       = ColorTexture.SampleLevel(ColorSampler, input.UV, 0);
+    float4 center       = ColorTexture.SampleLevel(LinearClampSampler, input.UV, 0);
     float  centerSigned = UnpackSignedCoC(center.a);
     float  centerFarCoC = max(0.0f, centerSigned);
     float  radius       = GetBokehRadius(centerFarCoC);
@@ -135,7 +135,7 @@ float4 PSDOFFarBlur(PixelShaderInput input) : SV_Target
     for (int i = 0; i < DOF_DISC_SAMPLES; i++)
     {
         float2 offset    = DOF_DISC_OFFSETS[i] * radius * TexelSize;
-        float4 tap       = ColorTexture.SampleLevel(ColorSampler, saturate(input.UV + offset), 0);
+        float4 tap       = ColorTexture.SampleLevel(LinearClampSampler, saturate(input.UV + offset), 0);
         float  tapSigned = UnpackSignedCoC(tap.a);
         float  tapFarCoC = max(0.0f, tapSigned);
 
@@ -160,7 +160,7 @@ float4 PSDOFFarBlur(PixelShaderInput input) : SV_Target
 // Reuse the bokeh disc offsets for the dilation neighbourhood.
 float4 PSDOFNearDilate(PixelShaderInput input) : SV_Target
 {
-    float4 center   = ColorTexture.SampleLevel(ColorSampler, input.UV, 0);
+    float4 center   = ColorTexture.SampleLevel(LinearClampSampler, input.UV, 0);
     float  minAlpha = center.a;
 
     // Scale dilation radius with bokeh strength; clamp so it stays reasonable.
@@ -170,7 +170,7 @@ float4 PSDOFNearDilate(PixelShaderInput input) : SV_Target
     for (int i = 0; i < DOF_DILATE_SAMPLES; i++)
     {
         float2 offset   = DOF_DISC_OFFSETS[i] * dilateRadius * TexelSize;
-        float  tapAlpha = ColorTexture.SampleLevel(ColorSampler, saturate(input.UV + offset), 0).a;
+        float  tapAlpha = ColorTexture.SampleLevel(LinearClampSampler, saturate(input.UV + offset), 0).a;
 		
         // Lower packed alpha = higher near CoC; min expands foreground blur outward.
         minAlpha = min(minAlpha, tapAlpha);
@@ -188,7 +188,7 @@ float4 PSDOFNearDilate(PixelShaderInput input) : SV_Target
 
 float4 PSDOFNearBlur(PixelShaderInput input) : SV_Target
 {
-    float4 center        = ColorTexture.SampleLevel(ColorSampler, input.UV, 0);
+    float4 center        = ColorTexture.SampleLevel(LinearClampSampler, input.UV, 0);
     float  centerSigned  = UnpackSignedCoC(center.a);
     float  centerNearCoC = max(0.0f, -centerSigned);
     float  radius        = GetBokehRadius(centerNearCoC);
@@ -205,7 +205,7 @@ float4 PSDOFNearBlur(PixelShaderInput input) : SV_Target
     for (int i = 0; i < DOF_DISC_SAMPLES; i++)
     {
         float2 offset     = DOF_DISC_OFFSETS[i] * radius * TexelSize;
-        float4 tap        = ColorTexture.SampleLevel(ColorSampler, saturate(input.UV + offset), 0);
+        float4 tap        = ColorTexture.SampleLevel(LinearClampSampler, saturate(input.UV + offset), 0);
         float  tapSigned  = UnpackSignedCoC(tap.a);
         float  tapNearCoC = max(0.0f, -tapSigned);
 
@@ -219,19 +219,18 @@ float4 PSDOFNearBlur(PixelShaderInput input) : SV_Target
 
 // ---------------------------------------------------------------------------
 // Pass 5 — full-resolution composite.
-// t0  (ColorTexture)      = sharp full-res image
-// t6  (DepthTexture)      = scene depth
-// t15 (DistortionTexture) = far blur (half-res, alpha = farCoC)
-// t2  (NormalsTexture)    = near blur (half-res, alpha = nearCoC)
+// t0  (ColorTexture)    = sharp full-res image
+// t16 (NearBlurTexture) = far blur (half-res, alpha = farCoC)
+// t17 (FarBlurTexture)  = near blur (half-res, alpha = nearCoC)
 //
 // Composite order: sharp → apply far blur → apply near blur on top.
 // ---------------------------------------------------------------------------
 
 float4 PSDOFComposite(PixelShaderInput input) : SV_Target
 {
-    float4 sharpColor = ColorTexture.Sample(ColorSampler, input.UV);
-    float4 farBlur    = DistortionTexture.Sample(DistortionSampler, input.UV);
-    float4 nearBlur   = NormalsTexture.Sample(NormalsSampler, input.UV);
+    float4 sharpColor = ColorTexture.Sample(LinearClampSampler, input.UV);
+    float4 nearBlur   = NearBlurTexture.Sample(LinearClampSampler, input.UV);
+    float4 farBlur    = FarBlurTexture.Sample(LinearClampSampler, input.UV);
 
     float farCoC  = saturate(farBlur.a);
     float nearCoC = saturate(nearBlur.a);

--- a/TombEngine/Shaders/FXAA.hlsl
+++ b/TombEngine/Shaders/FXAA.hlsl
@@ -1,6 +1,7 @@
 #include "./VertexInput.hlsli"
 #include "./Math.hlsli"
 #include "./CBPostProcess.hlsli"
+#include "./Samplers.hlsli"
 
 #define FXAA_SPAN_MAX	8.0
 #define FXAA_REDUCE_MUL 1.0/4.0
@@ -14,17 +15,16 @@ struct PixelShaderInput
 };
 
 Texture2D Texture : register(t0);
-SamplerState Sampler : register(s0);
 
 float4 ApplyFXAA(PixelShaderInput input)
 {
     float2 add = 1.0f / ViewportSize;
 
-	float3 rgbNW = Texture.Sample(Sampler, input.UV + float2(-add.x, -add.y));
-	float3 rgbNE = Texture.Sample(Sampler, input.UV + float2(add.x, -add.y));
-	float3 rgbSW = Texture.Sample(Sampler, input.UV + float2(-add.x, add.y));
-	float3 rgbSE = Texture.Sample(Sampler, input.UV + float2(add.x, add.y));
-	float3 rgbM = Texture.Sample(Sampler, input.UV);
+	float3 rgbNW = Texture.Sample(AnisotropicClampSampler, input.UV + float2(-add.x, -add.y));
+	float3 rgbNE = Texture.Sample(AnisotropicClampSampler, input.UV + float2(add.x, -add.y));
+	float3 rgbSW = Texture.Sample(AnisotropicClampSampler, input.UV + float2(-add.x, add.y));
+	float3 rgbSE = Texture.Sample(AnisotropicClampSampler, input.UV + float2(add.x, add.y));
+	float3 rgbM = Texture.Sample(AnisotropicClampSampler, input.UV);
 
 	float lumaNW = Luma(rgbNW);
 	float lumaNE = Luma(rgbNE);
@@ -48,12 +48,12 @@ float4 ApplyFXAA(PixelShaderInput input)
 		max(float2(-FXAA_SPAN_MAX, -FXAA_SPAN_MAX), dir * rcpDirMin)) * add;
 
 	float3 rgbA = (1.0f / 2.0f) *
-		(Texture.Sample(Sampler, input.UV + dir * (1.0f / 3.0f - 0.5f)) +
-			Texture.Sample(Sampler, input.UV + dir * (2.0f / 2.0f - 0.5f)));
+		(Texture.Sample(AnisotropicClampSampler, input.UV + dir * (1.0f / 3.0f - 0.5f)) +
+			Texture.Sample(AnisotropicClampSampler, input.UV + dir * (2.0f / 2.0f - 0.5f)));
 
 	float3 rgbB = rgbA * (1.0f / 2.0f) + (1.0f / 4.0f) *
-		(Texture.Sample(Sampler, input.UV + dir * (0.0f / 3.0f - 0.5f)) +
-			Texture.Sample(Sampler, input.UV + dir * (3.0f / 3.0f - 0.5f)));
+		(Texture.Sample(AnisotropicClampSampler, input.UV + dir * (0.0f / 3.0f - 0.5f)) +
+			Texture.Sample(AnisotropicClampSampler, input.UV + dir * (3.0f / 3.0f - 0.5f)));
 
 	float lumaB = Luma(rgbB);
 

--- a/TombEngine/Shaders/FullscreenQuad.hlsl
+++ b/TombEngine/Shaders/FullscreenQuad.hlsl
@@ -1,4 +1,5 @@
 #include "./VertexInput.hlsli"
+#include "./Samplers.hlsli"
 
 struct PixelShaderInput
 {
@@ -8,7 +9,6 @@ struct PixelShaderInput
 };
 
 Texture2D Texture : register(t0);
-SamplerState Sampler : register(s0);
 
 PixelShaderInput VS(VertexShaderInput input)
 {
@@ -23,7 +23,7 @@ PixelShaderInput VS(VertexShaderInput input)
 
 float4 PS(PixelShaderInput input) : SV_TARGET
 {
-	float4 output = Texture.Sample(Sampler, input.UV);
+	float4 output = Texture.Sample(AnisotropicClampSampler, input.UV);
 	float4 colorMul = min(input.Color, 1.0f);
 	output = output * colorMul;
 

--- a/TombEngine/Shaders/GBuffer.hlsl
+++ b/TombEngine/Shaders/GBuffer.hlsl
@@ -21,10 +21,7 @@ struct PixelShaderInput
 };
 
 Texture2D Texture : register(t0);
-SamplerState Sampler : register(s0);
-
 Texture2D NormalTexture : register(t1);
-SamplerState NormalTextureSampler : register(s1);
 
 struct PixelShaderOutput
 {
@@ -131,15 +128,15 @@ PixelShaderOutput PS(PixelShaderInput input)
         else
             input.UV = CalculateUVRotate(input.UV, 0);
 
-	float4 color = Texture.Sample(Sampler, input.UV);
+	float4 color = Texture.Sample(AnisotropicClampSampler, input.UV);
 
 	DoAlphaTest(color);
 	
-    float4 emissive = EmissiveTexture.Sample(EmissiveSampler, input.UV);
-    float specular = ORSHTexture.Sample(ORSHSampler, input.UV).z;
+	float4 emissive = EmissiveTexture.Sample(AnisotropicClampSampler, input.UV);
+	float specular = ORSHTexture.Sample(AnisotropicClampSampler, input.UV).z;
 	
 	float3x3 TBN = float3x3(input.Tangent, input.Binormal, input.Normal);
-	float3 normal = DecodeNormalMap(NormalTexture.Sample(NormalTextureSampler, input.UV));
+	float3 normal = DecodeNormalMap(NormalTexture.Sample(AnisotropicClampSampler, input.UV));
 	normal = EncodeNormal(normalize(mul(mul(normal, TBN), (float3x3)View)));
 
 	output.Normals.xyz = normal;

--- a/TombEngine/Shaders/HUD.hlsl
+++ b/TombEngine/Shaders/HUD.hlsl
@@ -1,5 +1,6 @@
 #include "VertexInput.hlsli"
 #include "Math.hlsli"
+#include "./Samplers.hlsli"
 
 cbuffer HUDBuffer : register(b10)
 {
@@ -26,7 +27,6 @@ cbuffer HUDBarBuffer : register(b11)
 };
 
 Texture2D Texture : register(t5);
-SamplerState Sampler : register(s5);
 
 PixelShaderInput VS(VertexShaderInput input)
 {
@@ -45,7 +45,7 @@ half4 PSColoredHUD(PixelShaderInput input) : SV_TARGET
 half4 PSTexturedHUD(PixelShaderInput input) : SV_TARGET
 {
 	float2 uv = float2((input.UV.x * BarScale.x) + BarStartUV.x, (input.UV.y * BarScale.y) + BarStartUV.y);
-	float4 output = Texture.Sample(Sampler, uv);
+	float4 output = Texture.Sample(LinearClampSampler, uv);
 	return output;
 }
 
@@ -81,7 +81,7 @@ half4 PSTexturedHUDBar(PixelShaderInput input) : SV_TARGET
 		discard;
 	}
 	float2 uv = float2((input.UV.x * BarScale.x) + BarStartUV.x, (input.UV.y * BarScale.y) + BarStartUV.y);
-	half4 col = Texture.Sample(Sampler, uv);
+	half4 col = Texture.Sample(LinearClampSampler, uv);
 	if (Poisoned) {
 		float factor = sin(((Frame % 30) / 30.0) * PI2) * 0.5 + 0.5;
 		col = lerp(col, half4(214 / 512.0, 241 / 512.0, 18 / 512.0, 1), factor);

--- a/TombEngine/Shaders/InstancedSprites.hlsl
+++ b/TombEngine/Shaders/InstancedSprites.hlsl
@@ -5,6 +5,7 @@
 #include "./ShaderLight.hlsli"
 #include "./SpriteEffects.hlsli"
 #include "./VertexEffects.hlsli"
+#include "./Samplers.hlsli"
 
 // NOTE: This shader is used for all opaque or not sorted transparent sprites, that can be instanced for a faster drawing
 
@@ -39,10 +40,7 @@ cbuffer InstancedSpriteBuffer : register(b13)
 };
 
 Texture2D Texture : register(t0);
-SamplerState Sampler : register(s0);
-
 Texture2D DepthTexture : register(t6);
-SamplerState DepthSampler : register(s6);
 
 PixelShaderInput VS(VertexShaderInput input, uint InstanceID : SV_InstanceID)
 {
@@ -78,7 +76,7 @@ PixelShaderInput VS(VertexShaderInput input, uint InstanceID : SV_InstanceID)
 
 float4 PS(PixelShaderInput input) : SV_TARGET
 {
-	float4 output = Texture.Sample(Sampler, input.UV) * input.Color;
+	float4 output = Texture.Sample(LinearClampSampler, input.UV) * input.Color;
 
     InstancedSprite sprite = Sprites[input.InstanceID];
 	
@@ -87,7 +85,7 @@ float4 PS(PixelShaderInput input) : SV_TARGET
 		float particleDepth = input.PositionCopy.z / input.PositionCopy.w;
 		input.PositionCopy.xy /= input.PositionCopy.w;
 		float2 texCoord = 0.5f * (float2(input.PositionCopy.x, -input.PositionCopy.y) + 1);
-		float sceneDepth = DepthTexture.Sample(DepthSampler, texCoord).x;
+		float sceneDepth = DepthTexture.Sample(PointWrapSampler, texCoord).x;
 
 		sceneDepth = LinearizeDepth(sceneDepth, NearPlane, FarPlane);
 		particleDepth = LinearizeDepth(particleDepth, NearPlane, FarPlane);
@@ -103,13 +101,13 @@ float4 PS(PixelShaderInput input) : SV_TARGET
 
     if (sprite.RenderType == 1)
     {
-        float4 rawOutput = Texture.Sample(Sampler, input.UV) * input.Color;
+		float4 rawOutput = Texture.Sample(LinearClampSampler, input.UV) * input.Color;
 		output = DoLaserBarrierEffect(input.Position, float4(ModulateColor(rawOutput.rgb), rawOutput.a), input.UV, FADE_FACTOR, Frame);
     }
 
     if (sprite.RenderType == 2)
     {
-        float4 rawOutput = Texture.Sample(Sampler, input.UV) * input.Color;
+		float4 rawOutput = Texture.Sample(LinearClampSampler, input.UV) * input.Color;
 		output = DoLaserBeamEffect(input.Position, float4(ModulateColor(rawOutput.rgb), rawOutput.a), input.UV, FADE_FACTOR, Frame);
     }
 

--- a/TombEngine/Shaders/Inventory.hlsl
+++ b/TombEngine/Shaders/Inventory.hlsl
@@ -27,10 +27,7 @@ struct PixelShaderOutput
 };
     
 Texture2D Texture : register(t0);
-SamplerState Sampler : register(s0);
-
 Texture2D NormalTexture : register(t1);
-SamplerState NormalTextureSampler : register(s1);
 
 PixelShaderInput VS(VertexShaderInput input)
 {
@@ -73,7 +70,7 @@ PixelShaderOutput PS(PixelShaderInput input) : SV_TARGET
 	
     PixelShaderOutput output;
     
-    float4 tex = Texture.Sample(Sampler, input.UV);
+    float4 tex = Texture.Sample(AnisotropicClampSampler, input.UV);
     float3 baseColor = tex.xyz * ModulateColor(Objects[0].Color.xyz);
     float3 pos = normalize(input.WorldPosition);
 
@@ -81,15 +78,15 @@ PixelShaderOutput PS(PixelShaderInput input) : SV_TARGET
 
     DoAlphaTest(output.Color);
     
-    float4 ORSH = ORSHTexture.Sample(ORSHSampler, input.UV);
+    float4 ORSH = ORSHTexture.Sample(AnisotropicClampSampler, input.UV);
     float ambientOcclusion = ORSH.x;
     float roughness = ORSH.y;
     float specular = ORSH.z;
 	
-    float3 emissive = EmissiveTexture.Sample(EmissiveSampler, input.UV).xyz;
+    float3 emissive = EmissiveTexture.Sample(AnisotropicClampSampler, input.UV).xyz;
 	
     float3x3 TBN = float3x3(input.Tangent, input.Binormal, input.Normal);
-    float3 normal = UnpackNormalMap(NormalTexture.Sample(NormalTextureSampler, input.UV));
+    float3 normal = UnpackNormalMap(NormalTexture.Sample(AnisotropicClampSampler, input.UV));
     normal = normalize(mul(normal, TBN));
     
     // Material effects

--- a/TombEngine/Shaders/Materials.hlsli
+++ b/TombEngine/Shaders/Materials.hlsli
@@ -22,20 +22,13 @@
 #define POM_MIN_ANGLE 0.4f
 #define POM_HEIGHT_SCALE 0.0035f
 
+#include "./Samplers.hlsli"
+
 Texture2D SSAOTexture : register(t9);
-SamplerState SSAOSampler : register(s9);
-
 Texture2D ORSHTexture : register(t10);
-SamplerState ORSHSampler : register(s10);
-
 Texture2D EmissiveTexture : register(t11);
-SamplerState EmissiveSampler : register(s11);
-
 Texture2D LegacyReflectionsTexture : register(t12);
-SamplerState LegacyReflectionsSampler : register(s12);
-
 Texture2DArray SkyboxReflectionsTexture : register(t13);
-SamplerState SkyboxReflectionsSampler : register(s13);
 
 float2 ToCentralSquare(float2 uvEnv, float aspect)
 {
@@ -70,7 +63,7 @@ float3 CalculateSkyBoxReflections(float3 worldPosition, float3 normal, float spe
     int slice = (d.z <= 0.0f) ? 0 : 1;
     uv.y = 1.0f - uv.y;
     
-    float3 reflectedColor = SkyboxReflectionsTexture.Sample(SkyboxReflectionsSampler, float3(uv, slice)).rgb;
+    float3 reflectedColor = SkyboxReflectionsTexture.Sample(AnisotropicClampSampler, float3(uv, slice)).rgb;
     return lerp(pixelColor, reflectedColor, saturate(specular));
 }
 
@@ -88,7 +81,7 @@ float3 CalculateLegacyReflections(float3 worldPosition, float3 normal, float spe
     uv = ToCentralSquare(uv, AspectRatio);
 
     // Sample legacy reflection buffer
-    float3 reflectedColor = LegacyReflectionsTexture.Sample(LegacyReflectionsSampler, uv).rgb;
+    float3 reflectedColor = LegacyReflectionsTexture.Sample(AnisotropicClampSampler, uv).rgb;
     return lerp(pixelColor, reflectedColor, specular);
 }
 
@@ -156,7 +149,7 @@ float2 ParallaxOcclusionMapping(float3x3 TBN, float3 pos, float2 baseUV)
     float currentDepth = 0.0f;
     float2 currentUV = baseUV;
     float2 wrappedUV = frac(currentUV);
-    float currentMapDepth = 1.0f - ORSHTexture.Sample(ORSHSampler, wrappedUV).w;
+    float currentMapDepth = 1.0f - ORSHTexture.Sample(AnisotropicClampSampler, wrappedUV).w;
 
     [loop]
     for (int i = 0; i < numSamples; i++)
@@ -168,13 +161,13 @@ float2 ParallaxOcclusionMapping(float3x3 TBN, float3 pos, float2 baseUV)
         currentDepth += layerDepth;
 
         wrappedUV = frac(currentUV);
-        currentMapDepth = 1.0f - ORSHTexture.Sample(ORSHSampler, wrappedUV).w;
+        currentMapDepth = 1.0f - ORSHTexture.Sample(AnisotropicClampSampler, wrappedUV).w;
     }
 
     // Linear refinement between last two steps.
     float2 prevUV = currentUV - deltaUV;
     float2 wrappedPrevUV = frac(prevUV);
-    float mapDepthPrev = 1.0f - ORSHTexture.Sample(ORSHSampler, wrappedPrevUV).w;
+    float mapDepthPrev = 1.0f - ORSHTexture.Sample(AnisotropicClampSampler, wrappedPrevUV).w;
 
     float afterDepth = currentMapDepth - currentDepth;
     float beforeDepth = mapDepthPrev - (currentDepth - layerDepth);
@@ -191,7 +184,7 @@ float CalculateOcclusion(float2 samplePosition, float alpha)
     if (AmbientOcclusion == 0 || !BlendModeSupportsSSAO() || (MaterialTypeAndFlags & MATERIAL_FLAG_HEIGHTMAP))
 		return 1.0f;
 		
-	float occlusion = pow(SSAOTexture.Sample(SSAOSampler, samplePosition).x, AmbientOcclusionExponent);
+    float occlusion = pow(SSAOTexture.Sample(PointWrapSampler, samplePosition).x, AmbientOcclusionExponent);
 	
 	if (BlendMode == BLENDMODE_ALPHABLEND)
 		occlusion = lerp(occlusion, 1.0f, alpha);

--- a/TombEngine/Shaders/Objects.hlsl
+++ b/TombEngine/Shaders/Objects.hlsl
@@ -41,16 +41,9 @@ struct PixelShaderOutput
 };
 
 Texture2D Texture : register(t0);
-SamplerState Sampler : register(s0);
-
 Texture2D NormalTexture : register(t1);
-SamplerState NormalTextureSampler : register(s1);
-
 Texture2D AmbientMapFrontTexture : register(t7);
-SamplerState AmbientMapFrontSampler : register(s7);
-
 Texture2D AmbientMapBackTexture : register(t8);
-SamplerState AmbientMapBackSampler : register(s8);
 
 PixelShaderInput VS(VertexShaderInput input, uint InstanceID : SV_InstanceID)
 {
@@ -110,18 +103,18 @@ PixelShaderOutput PS(PixelShaderInput input)
 	float3x3 TBNf = float3x3(input.Tangent, input.Binormal, input.FaceNormal);
 	input.UV = ParallaxOcclusionMapping(TBNf, input.WorldPosition, input.UV);
 
-	float4 ORSH = ConvertAnimOSRH(ORSHTexture.Sample(ORSHSampler, input.UV));
+	float4 ORSH = ConvertAnimOSRH(ORSHTexture.Sample(AnisotropicClampSampler, input.UV));
 	float ambientOcclusion = ORSH.x;
 	float roughness = ORSH.y;
 	float specular = ORSH.z;
 
-	float3 emissive = EmissiveTexture.Sample(EmissiveSampler, input.UV).xyz;
+	float3 emissive = EmissiveTexture.Sample(AnisotropicClampSampler, input.UV).xyz;
 
 	float3x3 TBN = float3x3(input.Tangent, input.Binormal, input.Normal);
-	float3 normal = ConvertAnimNormal(UnpackNormalMap(NormalTexture.Sample(NormalTextureSampler, input.UV)));
+	float3 normal = ConvertAnimNormal(UnpackNormalMap(NormalTexture.Sample(AnisotropicClampSampler, input.UV)));
 	normal = EnsureNormal(mul(normal, TBN), input.WorldPosition);
 
-	float4 tex = Texture.Sample(Sampler, input.UV);
+	float4 tex = Texture.Sample(AnisotropicClampSampler, input.UV);
 	DoAlphaTest(tex);
 
 	// Material effects

--- a/TombEngine/Shaders/PostProcess.hlsl
+++ b/TombEngine/Shaders/PostProcess.hlsl
@@ -44,31 +44,16 @@ struct PixelShaderInput
 };
 
 Texture2D ColorTexture : register(t0);
-SamplerState ColorSampler : register(s0);
-
-Texture2D NormalsTexture : register(t2);
-SamplerState NormalsSampler : register(s2);
-
-Texture2D GlowTexture : register(t3);
-SamplerState GlowSampler : register(s3);
-
-Texture2D LegacyEnvironmentTexture : register(t4);
-SamplerState LegacyEnvironmentSampler : register(s4);
-
-Texture2D EmissiveAndSpecularTexture : register(t5);
-SamplerState EmissiveAndSpecularSampler : register(s5);
-
 Texture2D DepthTexture : register(t6);
-SamplerState DepthSampler : register(s6);
-
+Texture2D GlowTexture : register(t11);
 Texture2D DistortionTexture : register(t15);
-SamplerState DistortionSampler : register(s15);
+Texture2D NearBlurTexture : register(t16);
+Texture2D FarBlurTexture : register(t17);
 
 #include "./DOF.hlsli"
-
 float GetSceneViewDepth(float2 uv)
 {
-    float depth = DepthTexture.Sample(DepthSampler, uv).x;
+    float depth = DepthTexture.Sample(PointWrapSampler, uv).x;
     return abs(ReconstructViewPosition(uv, depth, InverseProjection).z);
 }
 
@@ -83,16 +68,14 @@ PixelShaderInput VS(PostProcessVertexShaderInput input)
 
     return output;
 }
-
 float4 PS(PixelShaderInput input) : SV_Target
 {
-    return ColorTexture.Sample(ColorSampler, input.UV);
+    return ColorTexture.Sample(LinearClampSampler, input.UV);
 }
 
 float4 PSMonochrome(PixelShaderInput input) : SV_Target
 {
-    float4 color = ColorTexture.Sample(ColorSampler, input.UV);
-
+    float4 color = ColorTexture.Sample(LinearClampSampler, input.UV);
     float luma = Luma(color.rgb);
     float3 output = lerp(color.rgb, float3(luma, luma, luma), EffectStrength);
 
@@ -101,7 +84,7 @@ float4 PSMonochrome(PixelShaderInput input) : SV_Target
 
 float4 PSNegative(PixelShaderInput input) : SV_Target
 {
-	float4 color = ColorTexture.Sample(ColorSampler, input.UV);
+    float4 color = ColorTexture.Sample(LinearClampSampler, input.UV);
 
 	float luma = Luma(1.0f - color);
 	float3 output = lerp(color.rgb, float3(luma, luma, luma), EffectStrength);
@@ -111,7 +94,7 @@ float4 PSNegative(PixelShaderInput input) : SV_Target
 
 float4 PSExclusion(PixelShaderInput input) : SV_Target
 {
-	float4 color = ColorTexture.Sample(ColorSampler, input.UV);
+    float4 color = ColorTexture.Sample(LinearClampSampler, input.UV);
 
 	float3 exColor = color.xyz + (1.0f - color.xyz) - 2.0f * color.xyz * (1.0f - color.xyz);
 	float3 output = lerp(color.rgb, exColor, EffectStrength);
@@ -121,8 +104,8 @@ float4 PSExclusion(PixelShaderInput input) : SV_Target
 
 float4 PSDistortion(PixelShaderInput input) : SV_Target
 {
-    float4 color = ColorTexture.Sample(ColorSampler, input.UV);
-    float4 distortionData = DistortionTexture.Sample(DistortionSampler, input.UV);
+    float4 color = ColorTexture.Sample(LinearClampSampler, input.UV);
+    float4 distortionData = DistortionTexture.Sample(LinearClampSampler, input.UV);
 
     // x = accumulated luma strength; early-out if no distortion emitter covered this pixel.
     float totalStrength = distortionData.x;
@@ -160,8 +143,8 @@ float4 PSDistortion(PixelShaderInput input) : SV_Target
     float noiseY = SimplexNoise(float3(input.UV * noiseScale + 5.7f, noiseSpeed + 1.3f));
     float2 refractVector = float2(noiseX, noiseY) * 1.5f;
 
-	// Shimmer layer.
-	float shimmerTime = noiseSpeed * 3.5f;
+    // Shimmer layer.
+    float shimmerTime = noiseSpeed * 3.5f;
 	float shimmerX = SimplexNoise(float3(input.UV * shimmerScale * 1.7f, shimmerTime + 13.1f));
 	float shimmerY = SimplexNoise(float3(input.UV * shimmerScale * 2.3f, shimmerTime + 31.7f));
 	float2 shimmerVec = float2(shimmerX, shimmerY) * shimmerStrength;
@@ -185,12 +168,12 @@ float4 PSDistortion(PixelShaderInput input) : SV_Target
     if (refractedDepth - DISTORTION_DEPTH_REJECT_MIN < emitterDist)
         return color;
 
-    return ColorTexture.Sample(ColorSampler, refractedUV);
+    return ColorTexture.Sample(LinearClampSampler, refractedUV);
 }
 
 float4 PSFinalPass(PixelShaderInput input) : SV_TARGET
 {
-    float4 output = ColorTexture.Sample(ColorSampler, input.UV);
+    float4 output = ColorTexture.Sample(LinearClampSampler, input.UV);
 
     float3 colorMul = min(input.Color.xyz, 1.0f);
 
@@ -284,7 +267,7 @@ float3 LensFlareColorCorrection(float3 color, float factor,float factor2)
 
 float4 PSLensFlare(PixelShaderInput input) : SV_Target
 {
-	float4 color = ColorTexture.Sample(ColorSampler, input.UV);
+    float4 color = ColorTexture.Sample(LinearClampSampler, input.UV);
 	
 	float4 position = input.PositionCopy;
 	float3 totalLensFlareColor = float3(0.0f, 0.0f, 0.0f);
@@ -313,7 +296,7 @@ float4 PSBlurBilinear(PixelShaderInput input) : SV_Target
     int r = clamp(BlurRadius, 0, MAX_BLUR_RADIUS);
     
     float w0 = Gaussian(0.0, BlurSigma);
-    float4 color = ColorTexture.Sample(ColorSampler, input.UV) * w0;
+    float4 color = ColorTexture.Sample(LinearClampSampler, input.UV) * w0;
     float weightSum = w0;
 
     [unroll]
@@ -325,8 +308,8 @@ float4 PSBlurBilinear(PixelShaderInput input) : SV_Target
         float wk = Gaussian((float) k, BlurSigma);
 
         float2 off = BlurDirection * TexelSize * k;
-        float4 c1 = ColorTexture.Sample(ColorSampler, input.UV + off);
-        float4 c2 = ColorTexture.Sample(ColorSampler, input.UV - off);
+        float4 c1 = ColorTexture.Sample(LinearClampSampler, input.UV + off);
+        float4 c2 = ColorTexture.Sample(LinearClampSampler, input.UV - off);
 
         color += (c1 + c2) * wk;
         weightSum += 2.0 * wk;
@@ -350,7 +333,7 @@ float4 PSBlurFull(PixelShaderInput input) : SV_Target
 
         float w = Gaussian((float) k, BlurSigma);
         float2 off = BlurDirection * TexelSize * k;
-        color += ColorTexture.Sample(ColorSampler, input.UV + off) * w;
+        color += ColorTexture.Sample(LinearClampSampler, input.UV + off) * w;
         weightSum += w;
     }
 
@@ -380,19 +363,19 @@ float4 PSDownscale(PixelShaderInput input) : SV_Target
     float3 c = 0;
 
     // center
-    c += ColorTexture.SampleLevel(ColorSampler, input.UV, 0).rgb * wc;
+    c += ColorTexture.SampleLevel(LinearClampSampler, input.UV, 0).rgb * wc;
 
     // N/S/E/W
-    c += ColorTexture.SampleLevel(ColorSampler, input.UV + dx, 0).rgb * w1;
-    c += ColorTexture.SampleLevel(ColorSampler, input.UV - dx, 0).rgb * w1;
-    c += ColorTexture.SampleLevel(ColorSampler, input.UV + dy, 0).rgb * w1;
-    c += ColorTexture.SampleLevel(ColorSampler, input.UV - dy, 0).rgb * w1;
+    c += ColorTexture.SampleLevel(LinearClampSampler, input.UV + dx, 0).rgb * w1;
+    c += ColorTexture.SampleLevel(LinearClampSampler, input.UV - dx, 0).rgb * w1;
+    c += ColorTexture.SampleLevel(LinearClampSampler, input.UV + dy, 0).rgb * w1;
+    c += ColorTexture.SampleLevel(LinearClampSampler, input.UV - dy, 0).rgb * w1;
 
     // diagonals
-    c += ColorTexture.SampleLevel(ColorSampler, input.UV + dx + dy, 0).rgb * wd;
-    c += ColorTexture.SampleLevel(ColorSampler, input.UV + dx - dy, 0).rgb * wd;
-    c += ColorTexture.SampleLevel(ColorSampler, input.UV - dx + dy, 0).rgb * wd;
-    c += ColorTexture.SampleLevel(ColorSampler, input.UV - dx - dy, 0).rgb * wd;
+    c += ColorTexture.SampleLevel(LinearClampSampler, input.UV + dx + dy, 0).rgb * wd;
+    c += ColorTexture.SampleLevel(LinearClampSampler, input.UV + dx - dy, 0).rgb * wd;
+    c += ColorTexture.SampleLevel(LinearClampSampler, input.UV - dx + dy, 0).rgb * wd;
+    c += ColorTexture.SampleLevel(LinearClampSampler, input.UV - dx - dy, 0).rgb * wd;
 
     return float4(c, 1);
 }
@@ -404,11 +387,10 @@ float3 SoftAddBlend(float3 base, float3 add)
 
 float4 PSGlowCombine(PixelShaderInput input) : SV_Target
 {
-    float3 base = ColorTexture.Sample(ColorSampler, input.UV).rgb;
-    float3 glow = GlowTexture.Sample(GlowSampler, input.UV).rgb * GlowIntensity;
+    float3 base = ColorTexture.Sample(LinearClampSampler, input.UV).rgb;
+    float3 glow = GlowTexture.Sample(LinearClampSampler, input.UV).rgb * GlowIntensity;
 
-    float3 outc = (GlowSoftAdd != 0) ? SoftAddBlend(base, glow)
-                                 : saturate(base + glow);
+    float3 outc = (GlowSoftAdd != 0) ? SoftAddBlend(base, glow) : saturate(base + glow);
 
     return float4(outc, 1);
 }

--- a/TombEngine/Shaders/RoomAmbient.hlsl
+++ b/TombEngine/Shaders/RoomAmbient.hlsl
@@ -8,6 +8,7 @@
 #include "./AnimatedTextures.hlsli"
 #include "./Shadows.hlsli"
 #include "./ShaderLight.hlsli"
+#include "./Samplers.hlsli"
 
 struct PixelShaderInput
 {
@@ -18,7 +19,6 @@ struct PixelShaderInput
 };
 
 Texture2D Texture : register(t0);
-SamplerState Sampler : register(s0);
 
 // DPDepth-vertex-shader
 PixelShaderInput VS(VertexShaderInput input)
@@ -85,7 +85,7 @@ float4 PS(PixelShaderInput input) : SV_TARGET0
     if (Animated && Type == 1)
         input.UV = CalculateUVRotate(input.UV, 0);
 	
-    float4 output = Texture.Sample(Sampler, input.UV);
+	float4 output = Texture.Sample(AnisotropicClampSampler, input.UV);
 
     clip(input.ClipDepth);
 
@@ -102,7 +102,7 @@ float4 PSSky(PixelShaderInput input) : SV_TARGET
     if (Animated && Type == 1)
         input.UV = CalculateUVRotate(input.UV, 0);
 	
-    float4 output = Texture.Sample(Sampler, input.UV);
+	float4 output = Texture.Sample(AnisotropicClampSampler, input.UV);
 	
     clip(input.ClipDepth);
 

--- a/TombEngine/Shaders/Rooms.hlsl
+++ b/TombEngine/Shaders/Rooms.hlsl
@@ -29,13 +29,8 @@ struct PixelShaderInput
 };
 
 Texture2D Texture : register(t0);
-SamplerState Sampler : register(s0);
-
 Texture2D NormalTexture : register(t1);
-SamplerState NormalTextureSampler : register(s1);
-
 Texture2D CausticsTexture : register(t2);
-SamplerState CausticsTextureSampler : register(s2);
 
 struct PixelShaderOutput
 {
@@ -94,18 +89,18 @@ PixelShaderOutput PS(PixelShaderInput input)
     float3x3 TBNf = float3x3(input.Tangent, input.Binormal, input.FaceNormal);
     input.UV = ParallaxOcclusionMapping(TBNf, input.WorldPosition, input.UV);                	  
 
-    float4 ORSH = ConvertAnimOSRH(ORSHTexture.Sample(ORSHSampler, input.UV));
+	float4 ORSH = ConvertAnimOSRH(ORSHTexture.Sample(AnisotropicClampSampler, input.UV));
     float ambientOcclusion = ORSH.x;
     float roughness = ORSH.y;
     float specular = ORSH.z;
 
-    float3 emissive = EmissiveTexture.Sample(EmissiveSampler, input.UV).xyz;
+	float3 emissive = EmissiveTexture.Sample(AnisotropicClampSampler, input.UV).xyz;
 	
     float3x3 TBN = float3x3(input.Tangent, input.Binormal, input.Normal);
-    float3 normal = ConvertAnimNormal(UnpackNormalMap(NormalTexture.Sample(NormalTextureSampler, input.UV)));
+	float3 normal = ConvertAnimNormal(UnpackNormalMap(NormalTexture.Sample(AnisotropicClampSampler, input.UV)));
     normal = EnsureNormal(mul(normal, TBN), input.WorldPosition);
 
-	output.Color = Texture.Sample(Sampler, input.UV);
+	output.Color = Texture.Sample(AnisotropicClampSampler, input.UV);
 	DoAlphaTest(output.Color);
 
     // Material effects
@@ -195,9 +190,9 @@ PixelShaderOutput PS(PixelShaderInput input)
         float2 uv_y = CausticsStartUV + float2(p.z, p.x) * CausticsSize;
         float2 uv_z = CausticsStartUV + float2(p.y, p.x) * CausticsSize;
 
-        float3 xaxis = CausticsTexture.SampleLevel(CausticsTextureSampler, uv_x, 0).xyz;
-        float3 yaxis = CausticsTexture.SampleLevel(CausticsTextureSampler, uv_y, 0).xyz;
-        float3 zaxis = CausticsTexture.SampleLevel(CausticsTextureSampler, uv_z, 0).xyz;
+		float3 xaxis = CausticsTexture.SampleLevel(AnisotropicClampSampler, uv_x, 0).xyz;
+		float3 yaxis = CausticsTexture.SampleLevel(AnisotropicClampSampler, uv_y, 0).xyz;
+		float3 zaxis = CausticsTexture.SampleLevel(AnisotropicClampSampler, uv_z, 0).xyz;
 
         float3 xc = xaxis * blending.x;
         float3 yc = yaxis * blending.y;

--- a/TombEngine/Shaders/SSAO.hlsl
+++ b/TombEngine/Shaders/SSAO.hlsl
@@ -2,6 +2,7 @@
 #include "./VertexInput.hlsli"
 #include "./CBCamera.hlsli"
 #include "./CBPostProcess.hlsli"
+#include "./Samplers.hlsli"
 
 #define SIGMA 3.0
 #define BSIGMA 0.3
@@ -14,16 +15,9 @@ struct PixelShaderInput
 };
 
 Texture2D DepthTexture : register(t0);
-SamplerState DepthSampler : register(s0);
-
 Texture2D NormalsTexture : register(t1);
-SamplerState NormalsSampler : register(s1);
-
 Texture2D NoiseTexture : register(t2);
-SamplerState NoiseSampler : register(s2);
-
 Texture2D SSAOTexture : register(t9);
-SamplerState SSAOSampler : register(s9);
 
 float3 DecodeNormal(float3 n)
 {
@@ -34,7 +28,7 @@ float3 ReconstructPositionFromDepth(float2 uv)
 {
     float x = uv.x * 2.0f - 1.0f;
     float y = (1.0f - uv.y) * 2.0f - 1.0f;
-    float z = DepthTexture.Sample(DepthSampler, uv).x;
+    float z = DepthTexture.Sample(PointWrapSampler, uv).x;
 
     float4 projectedPosition = float4(x, y, z, 1.0f);
     float4 position = mul(projectedPosition, InverseProjection);
@@ -49,7 +43,7 @@ float PS(PixelShaderInput input) : SV_Target
     float2 noiseScale = ViewportSize / 4.0f;
 
     float3 position = ReconstructPositionFromDepth(input.UV);
-    float3 encodedNormal = NormalsTexture.Sample(NormalsSampler, input.UV).xyz;
+    float3 encodedNormal = NormalsTexture.Sample(PointWrapSampler, input.UV).xyz;
 
     float farMask = step(40960.0f, length(position)); // 1 if too far
     float noNormalMask = step(length(encodedNormal), 0.0001f); // 1 if normal is too small
@@ -59,7 +53,7 @@ float PS(PixelShaderInput input) : SV_Target
         return float4(1.0f, 1.0f, 1.0f, 1.0f);
 
     float3 normal = DecodeNormal(encodedNormal);
-    float3 randomVec = NoiseTexture.Sample(NoiseSampler, input.UV * noiseScale).xyz;
+    float3 randomVec = NoiseTexture.Sample(PointWrapSampler, input.UV * noiseScale).xyz;
 
     float3 tangent = normalize(randomVec - normal * dot(randomVec, normal));
     float3 bitangent = SafeNormalize(cross(normal, tangent));
@@ -114,7 +108,7 @@ float PSBlur(PixelShaderInput input) : SV_Target
     }
 
     float color;
-    float baseColor = SSAOTexture.Sample(SSAOSampler, input.UV).x;
+    float baseColor = SSAOTexture.Sample(PointWrapSampler, input.UV).x;
     float gfactor;
     float bfactor;
     float bZnorm = 1.0 / normpdf(0.0, BSIGMA);
@@ -126,7 +120,7 @@ float PSBlur(PixelShaderInput input) : SV_Target
         {
             // Color at pixel in the neighborhood
             float2 offset = float2(i, j) * texelSize;
-            color = SSAOTexture.Sample(SSAOSampler, input.UV + offset).x;
+            color = SSAOTexture.Sample(PointWrapSampler, input.UV + offset).x;
 
             // Compute both the gaussian smoothed and bilateral
             gfactor = kernel[kernelSize + j] * kernel[kernelSize + i];

--- a/TombEngine/Shaders/Samplers.hlsli
+++ b/TombEngine/Shaders/Samplers.hlsli
@@ -1,0 +1,11 @@
+#ifndef SAMPLERSSHADER
+#define SAMPLERSSHADER
+
+SamplerState PointWrapSampler : register(s1);
+SamplerState LinearWrapSampler : register(s2);
+SamplerState LinearClampSampler : register(s3);
+SamplerState AnisotropicWrapSampler : register(s4);
+SamplerState AnisotropicClampSampler : register(s5);
+SamplerComparisonState ShadowMapSampler : register(s6);
+
+#endif // SAMPLERSSHADER

--- a/TombEngine/Shaders/ShadowMap.hlsl
+++ b/TombEngine/Shaders/ShadowMap.hlsl
@@ -12,7 +12,6 @@ struct PixelShaderInput
 };
 
 Texture2D Texture : register(t0);
-SamplerState Sampler : register(s0);
 
 PixelShaderInput VS(VertexShaderInput input)
 {

--- a/TombEngine/Shaders/Shadows.hlsli
+++ b/TombEngine/Shaders/Shadows.hlsli
@@ -1,6 +1,7 @@
 #include "./Blending.hlsli"
 #include "./Math.hlsli"
 #include "./ShaderLight.hlsli"
+#include "./Samplers.hlsli"
 
 #define SHADOW_INTENSITY (0.6f)
 #define SHADOW_BLUR      (2.0f)
@@ -23,7 +24,6 @@ cbuffer ShadowLightBuffer : register(b4)
 };
 
 Texture2DArray ShadowMap : register(t3);
-SamplerComparisonState ShadowMapSampler : register(s3);
 
 float2 TexOffset(int u, int v) 
 {

--- a/TombEngine/Shaders/Sky.hlsl
+++ b/TombEngine/Shaders/Sky.hlsl
@@ -6,6 +6,7 @@
 #include "./CBSky.hlsli"
 #include "./AnimatedTextures.hlsli"
 #include "./VertexEffects.hlsli"
+#include "./Samplers.hlsli"
 
 struct PixelShaderInput
 {
@@ -17,7 +18,6 @@ struct PixelShaderInput
 };
 
 Texture2D Texture : register(t0);
-SamplerState Sampler : register(s0);
 
 PixelShaderInput VS(VertexShaderInput input)
 {
@@ -39,7 +39,7 @@ float4 PS(PixelShaderInput input) : SV_TARGET
     if (Animated && Type == 1)
         input.UV = CalculateUVRotate(input.UV, 0);
 	
-	float4 output = Texture.Sample(Sampler, input.UV);
+	float4 output = Texture.Sample(AnisotropicClampSampler, input.UV);
 
 	DoAlphaTest(output);
 

--- a/TombEngine/Shaders/Sprites.hlsl
+++ b/TombEngine/Shaders/Sprites.hlsl
@@ -4,6 +4,7 @@
 #include "./SpriteEffects.hlsli"
 #include "./ShaderLight.hlsli"
 #include "./VertexInput.hlsli"
+#include "./Samplers.hlsli"
 
 // NOTE: Shader is used for all 3D and alpha blended sprites because transformed vertices are already sent to GPU instead of instances.
 
@@ -27,10 +28,7 @@ struct PixelShaderInput
 };
 
 Texture2D Texture : register(t0);
-SamplerState Sampler : register(s0);
-
 Texture2D DepthTexture : register(t6);
-SamplerState DepthSampler : register(s6);
 
 PixelShaderInput VS(VertexShaderInput input)
 {
@@ -52,7 +50,7 @@ PixelShaderInput VS(VertexShaderInput input)
 
 float4 PS(PixelShaderInput input) : SV_TARGET
 {
-	float4 output = Texture.Sample(Sampler, input.UV) * input.Color;
+		float4 output = Texture.Sample(LinearClampSampler, input.UV) * input.Color;
 
 	if (IsSoftParticle == 1)
 	{
@@ -60,7 +58,7 @@ float4 PS(PixelShaderInput input) : SV_TARGET
 		input.PositionCopy.xy /= input.PositionCopy.w;
 
 		float2 texCoord = 0.5f * (float2(input.PositionCopy.x, -input.PositionCopy.y) + 1.0f);
-		float sceneDepth = DepthTexture.Sample(DepthSampler, texCoord).x;
+		float sceneDepth = DepthTexture.Sample(PointWrapSampler, texCoord).x;
 
 		sceneDepth = LinearizeDepth(sceneDepth, NearPlane, FarPlane);
 		particleDepth = LinearizeDepth(particleDepth, NearPlane, FarPlane);

--- a/TombEngine/TombEngine.vcxproj
+++ b/TombEngine/TombEngine.vcxproj
@@ -1521,6 +1521,9 @@ if not exist "%ScriptsDir%\Strings.lua" xcopy /Y "$(SolutionDir)Scripts\Strings.
     <None Include="Shaders\Materials.hlsli">
       <DeploymentContent>true</DeploymentContent>
     </None>
+    <None Include="Shaders\Samplers.hlsli">
+      <DeploymentContent>true</DeploymentContent>
+    </None>
     <None Include="Shaders\SMAA.hlsli">
       <DeploymentContent>true</DeploymentContent>
     </None>


### PR DESCRIPTION
## Checklist

- [ ] I have added a changelog entry to the `CHANGELOG.md` file on the branch/fork (if it is an internal change, this is not needed).
- [x] This pull request meets the Coding Conventions standards: https://github.com/MontyTRC89/TombEngine/blob/master/CONTRIBUTING.md#coding-conventions

## Links to issue(s) this pull request concerns (if applicable)

N/A

## Pull request description

This pull request is an intermediate effort to reduce amount of used texture samplers which were previously unnecessarily assigned as a pair with sampled texture. Instead, now sampler count corresponds to actual `SamplerState` enum count and is properly reused in shaders. Additionally, this PR clarifies some of the texture registers usage, i.e. before some registers were abused by unrelated shaders.