### PR TITLE
Fix TR5 Bats Emitter issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ TombEngine releases are located in this repository (alongside with Tomb Editor):
 
 * Fixed incorrect dynamic range for vertex colors, ambient light, dynamic lights and particle effects.
 * Fixed flyby camera jitter by converting the spline type to floating-point.
+* Fixed TR5 Bats Emitter issues.
 
 ### Lua API changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ TombEngine releases are located in this repository (alongside with Tomb Editor):
 
 * Fixed incorrect dynamic range for vertex colors, ambient light, dynamic lights and particle effects.
 * Fixed flyby camera jitter by converting the spline type to floating-point.
-* Fixed TR5 Bats Emitter issues.
+* Fixed BATS_EMITTER targeting issues.
 * Fixed occasional flame emitter sprite jitter.
 
 ### Lua API changes

--- a/TombEngine/Objects/TR5/Emitter/tr5_bats_emitter.cpp
+++ b/TombEngine/Objects/TR5/Emitter/tr5_bats_emitter.cpp
@@ -207,9 +207,7 @@ void UpdateBats()
 		if (ItemNearTarget(bat->Pose.Position, LaraItem, CLICK(1)))
 		{
 			TriggerBlood(bat->Pose.Position.x, bat->Pose.Position.y, bat->Pose.Position.z, 2 * GetRandomControl(), 2);
-
-			if (LaraItem->HitPoints > 0)
-				DoDamage(LaraItem, BAT_LARA_DAMAGE);
+			DoDamage(LaraItem, BAT_LARA_DAMAGE);
 		}
 
 		Matrix translation = Matrix::CreateTranslation(bat->Pose.Position.x, bat->Pose.Position.y, bat->Pose.Position.z);

--- a/TombEngine/Objects/TR5/Emitter/tr5_bats_emitter.cpp
+++ b/TombEngine/Objects/TR5/Emitter/tr5_bats_emitter.cpp
@@ -35,7 +35,10 @@ void InitializeLittleBats(short itemNumber)
 		item->Pose.Position.x += CLICK(2);
 
 	if (Objects[ID_BATS_EMITTER].loaded)
-		ZeroMemory(Bats, NUM_BATS * sizeof(BatData));
+	{
+		for (auto& bat : Bats)
+			bat = {};
+	}
 
 	//LOWORD(item) = sub_402F27(ebx0, Bats, 0, 1920);
 }

--- a/TombEngine/Objects/TR5/Emitter/tr5_bats_emitter.cpp
+++ b/TombEngine/Objects/TR5/Emitter/tr5_bats_emitter.cpp
@@ -17,6 +17,7 @@ using namespace TEN::Animation;
 using namespace TEN::Math;
 
 constexpr auto BAT_LARA_DAMAGE = 2;
+constexpr auto BAT_DAMAGE_CHANCE = 1 / 5.0f;
 
 int NextBat;
 BatData Bats[NUM_BATS];
@@ -204,7 +205,8 @@ void UpdateBats()
 		bat->Pose.Position.y += bat->Velocity * phd_sin(-bat->Pose.Orientation.x);
 		bat->Pose.Position.z += sp * phd_cos(bat->Pose.Orientation.y);
 
-		if (ItemNearTarget(bat->Pose.Position, LaraItem, CLICK(1)))
+		if (ItemNearTarget(bat->Pose.Position, LaraItem, CLICK(1)) &&
+			Random::TestProbability(BAT_DAMAGE_CHANCE))
 		{
 			TriggerBlood(bat->Pose.Position.x, bat->Pose.Position.y, bat->Pose.Position.z, 2 * GetRandomControl(), 2);
 			DoDamage(LaraItem, BAT_LARA_DAMAGE);

--- a/TombEngine/Objects/TR5/Emitter/tr5_bats_emitter.cpp
+++ b/TombEngine/Objects/TR5/Emitter/tr5_bats_emitter.cpp
@@ -35,7 +35,7 @@ void InitializeLittleBats(short itemNumber)
 		item->Pose.Position.x += CLICK(2);
 
 	if (Objects[ID_BATS_EMITTER].loaded)
-		memset(Bats, 0, NUM_BATS * sizeof(BatData));
+		ZeroMemory(Bats, NUM_BATS * sizeof(BatData));
 
 	//LOWORD(item) = sub_402F27(ebx0, Bats, 0, 1920);
 }
@@ -178,8 +178,8 @@ void UpdateBats()
 		{
 			short velocity = bat->Velocity * 128;
 
-			short xAngle = abs(angles.x - bat->Pose.Orientation.x) / 8;
-			short yAngle = abs(angles.y - bat->Pose.Orientation.y) / 8;
+			short xAngle = Geometry::GetShortestAngle(bat->Pose.Orientation.x, angles.x) / 8;
+			short yAngle = Geometry::GetShortestAngle(bat->Pose.Orientation.y, angles.y) / 8;
 
 			if (xAngle < -velocity)
 				xAngle = -velocity;
@@ -201,10 +201,12 @@ void UpdateBats()
 		bat->Pose.Position.y += bat->Velocity * phd_sin(-bat->Pose.Orientation.x);
 		bat->Pose.Position.z += sp * phd_cos(bat->Pose.Orientation.y);
 
-		if (!(i % 1) && ItemNearTarget(bat->Pose.Position, LaraItem, CLICK(1)))
+		if (ItemNearTarget(bat->Pose.Position, LaraItem, CLICK(1)))
 		{
 			TriggerBlood(bat->Pose.Position.x, bat->Pose.Position.y, bat->Pose.Position.z, 2 * GetRandomControl(), 2);
-			DoDamage(LaraItem, BAT_LARA_DAMAGE);
+
+			if (LaraItem->HitPoints > 0)
+				DoDamage(LaraItem, BAT_LARA_DAMAGE);
 		}
 
 		Matrix translation = Matrix::CreateTranslation(bat->Pose.Position.x, bat->Pose.Position.y, bat->Pose.Position.z);
@@ -217,6 +219,6 @@ void UpdateBats()
 		auto* bat = &Bats[minIndex];
 
 		if (!(GetRandomControl() & 4))
-			SoundEffect(SFX_TR4_BATS,&bat->Pose);
+			SoundEffect(SFX_TR4_BATS, &bat->Pose);
 	}
 }

--- a/TombEngine/Objects/TR5/Emitter/tr5_bats_emitter.h
+++ b/TombEngine/Objects/TR5/Emitter/tr5_bats_emitter.h
@@ -12,12 +12,12 @@ struct BatData
 	short Velocity;
 	short Counter;
 	short LaraTarget;
-	byte XTarget;
-	byte ZTarget;
+	short XTarget;
+	short ZTarget;
 
 	byte Flags;
-	
-	Matrix Transform	 = Matrix::Identity;
+
+	Matrix Transform = Matrix::Identity;
 	Matrix PrevTransform = Matrix::Identity;
 
 	void StoreInterpolationData()


### PR DESCRIPTION
## Fixes

- Fixed bat target offset storage by changing `XTarget` and `ZTarget` from `byte` to `short`.
  (XTarget and ZTarget must use a signed integer type, because their randomized offsets can be negative)
- Fixed bat steering by using `Geometry::GetShortestAngle()` for angle delta calculation.
- Fixed turn behavior so bats can correctly steer in both directions.
- Replaced raw memory clearing of the TR5 bats array with value initialization so `BatData` are initialized correctly.

## Result

These changes restore more reliable bat movement and targeting behavior and prevent incorrect offset wrapping caused by unsigned target fields.


https://github.com/user-attachments/assets/910d99dd-6e43-429c-ad59-8b17e87b7c40


