### PR TITLE
Restore shader compile message

### DIFF
--- a/TombEngine/Renderer/Native/DirectX11/DX11GraphicsDevice.cpp
+++ b/TombEngine/Renderer/Native/DirectX11/DX11GraphicsDevice.cpp
@@ -926,88 +926,87 @@ namespace TEN::Renderer::Native::DirectX11
 		auto prefix = ((req.CompileIndex < 10) ? "0" : "") + std::to_string(req.CompileIndex) + "_";
 
 		// VS
-		auto makeCsoName = [&](const std::string& shaderType) {
-			return req.BinaryDirectory + prefix + req.FileName + "." +
-				shaderType + ".cso";
-			};
+		auto makeCsoName = [&](const std::string& shaderType) 
+		{
+			return req.BinaryDirectory + prefix + req.FileName + "." + shaderType + ".cso";
+		};
 
 		auto macros = ToD3DMacros(req.Macros);
 
-		auto compileOne = [&](const std::string& shaderType,
-			const std::string& entry,
-			const char* model,
-			ID3D10Blob** outBlob)
+		auto compileOne = [&](const std::string& shaderType, const std::string& entry, const char* model, ID3D10Blob** outBlob)
+		{
+			auto csoFileName = makeCsoName(shaderType);
+			auto srcFileName = baseFileName;
+
+			auto srcFileNameWithExt = srcFileName + ".hlsl";
+			if (!std::filesystem::exists(srcFileNameWithExt))
 			{
-				auto csoFileName = makeCsoName(shaderType);
-				auto srcFileName = baseFileName;
+				srcFileNameWithExt = srcFileName + ".fx";
+			}
 
-				auto srcFileNameWithExt = srcFileName + ".hlsl";
-				if (!std::filesystem::exists(srcFileNameWithExt))
+			bool loadedFromDisk = false;
+			if (!req.ForceRecompile && std::filesystem::exists(csoFileName))
+			{
+				auto csoTime = std::filesystem::last_write_time(csoFileName);
+				auto srcTime = std::filesystem::last_write_time(srcFileNameWithExt);
+				if (srcTime < csoTime)
 				{
-					srcFileNameWithExt = srcFileName + ".fx";
-				}
-
-				bool loadedFromDisk = false;
-				if (!req.ForceRecompile && std::filesystem::exists(csoFileName))
-				{
-					auto csoTime = std::filesystem::last_write_time(csoFileName);
-					auto srcTime = std::filesystem::last_write_time(srcFileNameWithExt);
-					if (srcTime < csoTime)
+					std::ifstream ifs(std::filesystem::path{csoFileName}, std::ios::binary);
+					if (ifs)
 					{
-						std::ifstream ifs(std::filesystem::path{csoFileName}, std::ios::binary);
-						if (ifs)
-						{
-							ifs.seekg(0, std::ios::end);
-							auto size = ifs.tellg();
-							ifs.seekg(0, std::ios::beg);
-							std::vector<char> buf(size);
-							ifs.read(buf.data(), size);
-							D3DCreateBlob((SIZE_T)size, outBlob);
-							memcpy((*outBlob)->GetBufferPointer(), buf.data(), size);
-							loadedFromDisk = true;
-						}
+						ifs.seekg(0, std::ios::end);
+						auto size = ifs.tellg();
+						ifs.seekg(0, std::ios::beg);
+						std::vector<char> buf(size);
+						ifs.read(buf.data(), size);
+						D3DCreateBlob((SIZE_T)size, outBlob);
+						memcpy((*outBlob)->GetBufferPointer(), buf.data(), size);
+						loadedFromDisk = true;
 					}
 				}
+			}
 
-				if (!loadedFromDisk)
-				{
-					UINT flags = D3DCOMPILE_ENABLE_STRICTNESS | D3DCOMPILE_PACK_MATRIX_ROW_MAJOR;
+			if (!loadedFromDisk)
+			{
+				UINT flags = D3DCOMPILE_ENABLE_STRICTNESS | D3DCOMPILE_PACK_MATRIX_ROW_MAJOR;
 #ifdef _DEBUG
-					flags |= D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+				flags |= D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #else
-					flags |= D3DCOMPILE_OPTIMIZATION_LEVEL3 | D3DCOMPILE_IEEE_STRICTNESS;
+				flags |= D3DCOMPILE_OPTIMIZATION_LEVEL3 | D3DCOMPILE_IEEE_STRICTNESS;
 #endif
 
-					ComPtr<ID3D10Blob> errors;
-					auto target = shaderType + entry;
-					auto wPath = TEN::Utils::ToWString(srcFileNameWithExt);
-					auto hr = D3DCompileFromFile(
-						wPath.c_str(),
-						macros.data(),
-						D3D_COMPILE_STANDARD_FILE_INCLUDE,
-						target.c_str(),
-						model,
-						flags,
-						0,
-						outBlob,
-						&errors
-					);
-					if (FAILED(hr))
-					{
-						if (errors)
-						{
-							TENLog((const char*)errors->GetBufferPointer(), LogLevel::Error);
-						}
-						throwIfFailed(hr);
-					}
+				TENLog(fmt::format("Compiling shader '{}'", srcFileNameWithExt));
 
-					std::ofstream ofs(std::filesystem::path{csoFileName}, std::ios::binary);
-					if (ofs)
+				ComPtr<ID3D10Blob> errors;
+				auto target = shaderType + entry;
+				auto wPath = TEN::Utils::ToWString(srcFileNameWithExt);
+				auto hr = D3DCompileFromFile(
+					wPath.c_str(),
+					macros.data(),
+					D3D_COMPILE_STANDARD_FILE_INCLUDE,
+					target.c_str(),
+					model,
+					flags,
+					0,
+					outBlob,
+					&errors);
+
+				if (FAILED(hr))
+				{
+					if (errors)
 					{
-						ofs.write((const char*)(*outBlob)->GetBufferPointer(), (*outBlob)->GetBufferSize());
+						TENLog((const char*)errors->GetBufferPointer(), LogLevel::Error);
 					}
+					throwIfFailed(hr);
 				}
-			};
+
+				std::ofstream ofs(std::filesystem::path{csoFileName}, std::ios::binary);
+				if (ofs)
+				{
+					ofs.write((const char*)(*outBlob)->GetBufferPointer(), (*outBlob)->GetBufferSize());
+				}
+			}
+		};
 
 		if (req.Type == ShaderType::Pixel || req.Type == ShaderType::PixelAndVertex)
 		{


### PR DESCRIPTION
## Checklist

- [ ] I have added a changelog entry to the `CHANGELOG.md` file on the branch/fork (if it is an internal change, this is not needed).
- [x] This pull request meets the Coding Conventions standards: https://github.com/MontyTRC89/TombEngine/blob/master/CONTRIBUTING.md#coding-conventions

## Links to issue(s) this pull request concerns (if applicable)

N/A

## Pull request description

Restores "Compiling shader..." message to the console/log.