### PR TITLE
Added autoexec script file loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ TombEngine releases are located in this repository (alongside with Tomb Editor):
 ### Lua API changes
 
 * Added ring inventory module.
+* Added loading of the `Scripts/Autoexec.lua` script file before every level script is loaded.
 * Added `GlobalVars` namespace for globally persistent variables across game sessions, including the title level.
 * Added `Flow.Settings.Animation.systemBlendDuration` setting to specify hardcoded animation blend durations.
 * Added `Flow.Settings.Effects` category with blood, ricochet and explosion settings.

--- a/Scripts/Autoexec.lua
+++ b/Scripts/Autoexec.lua
@@ -1,0 +1,1 @@
+local RingInventory = require("Engine.RingInventory.Inventory")

--- a/TombEngine/Game/control/control.cpp
+++ b/TombEngine/Game/control/control.cpp
@@ -589,19 +589,27 @@ void CleanUp()
 
 void InitializeScripting(int levelIndex, bool loadGame)
 {
-	TENLog("Loading level script...", LogLevel::Info);
-
 	g_GameStringsHandler->ClearDisplayStrings();
 	g_GameScript->ResetScripts(!levelIndex || loadGame);
+
+	auto gameDir = g_GameFlow->GetGameDir();
+	auto autoexecScriptFileName = gameDir + "Scripts/Autoexec.lua";
+
+	if (std::filesystem::is_regular_file(autoexecScriptFileName))
+	{
+		TENLog("Loading autoexec script...", LogLevel::Info);
+		g_GameScript->ExecuteScriptFile(gameDir + "Scripts/Autoexec.lua");
+	}
 
 	const auto& level = *g_GameFlow->GetLevel(levelIndex);
 
 	// Run level script if it exists.
 	if (!level.ScriptFileName.empty())
 	{
-		auto levelScriptName = g_GameFlow->GetGameDir() + level.ScriptFileName;
+		auto levelScriptName = gameDir + level.ScriptFileName;
 		if (std::filesystem::is_regular_file(levelScriptName))
 		{
+			TENLog("Loading level script...", LogLevel::Info);
 			g_GameScript->ExecuteScriptFile(levelScriptName);
 		}
 		else


### PR DESCRIPTION
## Checklist

- [x] I have added a changelog entry to the `CHANGELOG.md` file on the branch/fork (if it is an internal change, this is not needed).
- [x] This pull request meets the Coding Conventions standards: https://github.com/MontyTRC89/TombEngine/blob/master/CONTRIBUTING.md#coding-conventions

## Links to issue(s) this pull request concerns (if applicable)

N/A

## Pull request description

This PR adds extra autoexec script file loading just before loading level script file, so that builders may add commonly used modules, such as ring inventory or photo mode, to their projects without polluting level scripts with repeated includes.