### PR TITLE
Fix jump switch issues

### DIFF
--- a/TombEngine/Game/control/trigger.cpp
+++ b/TombEngine/Game/control/trigger.cpp
@@ -187,9 +187,7 @@ bool SwitchTrigger(short itemNumber, short timer)
 	// Handle switches.
 	if (item.Status == ITEM_DEACTIVATED)
 	{
-		if (((item.Animation.ActiveState == SWITCH_OFF && item.ObjectNumber != ID_JUMP_SWITCH) ||
-			 (item.Animation.ActiveState == SWITCH_ON && item.ObjectNumber == ID_JUMP_SWITCH)) &&
-			timer > 0)
+		if (item.Animation.ActiveState == SWITCH_OFF && timer > 0)
 		{
 			item.Timer = timer;
 			item.Status = ITEM_ACTIVE;

--- a/TombEngine/Objects/Generic/Switches/generic_switch.cpp
+++ b/TombEngine/Objects/Generic/Switches/generic_switch.cpp
@@ -61,17 +61,8 @@ namespace TEN::Entities::Switches
 
 		if (!TriggerActive(switchItem) && !(switchItem->Flags & IFLAG_INVISIBLE))
 		{
-			if (switchItem->ObjectNumber == ID_JUMP_SWITCH)
-			{
-				switchItem->Animation.TargetState = SWITCH_OFF;
-				switchItem->Timer = 0;
-				AnimateItem(switchItem);
-			}
-			else
-			{
-				switchItem->Animation.TargetState = SWITCH_ON;
-				switchItem->Timer = 0;
-			}
+			switchItem->Animation.TargetState = SWITCH_ON;
+			switchItem->Timer = 0;
 		}
 
 		AnimateItem(switchItem);

--- a/TombEngine/Objects/Generic/Switches/jump_switch.cpp
+++ b/TombEngine/Objects/Generic/Switches/jump_switch.cpp
@@ -46,23 +46,20 @@ namespace TEN::Entities::Switches
 		idleDownAnim.StateID = SWITCH_OFF;
 		resetUpAnim.StateID = SWITCH_ON;
 
-		for (auto& dispatch : idleUpAnim.Dispatches)
+		auto remapDispatch = [](auto& anim, int fromState, int toState, int nextAnim)
 		{
-			if (dispatch.StateID == SWITCH_ON)
+			for (auto& dispatch : anim.Dispatches)
 			{
-				dispatch.StateID = SWITCH_OFF;
-				dispatch.NextAnimNumber = 1;
+				if (dispatch.StateID == fromState)
+				{
+					dispatch.StateID = toState;
+					dispatch.NextAnimNumber = nextAnim;
+				}
 			}
-		}
+		};
 
-		for (auto& dispatch : idleDownAnim.Dispatches)
-		{
-			if (dispatch.StateID == SWITCH_OFF)
-			{
-				dispatch.StateID = SWITCH_ON;
-				dispatch.NextAnimNumber = 3;
-			}
-		}
+		remapDispatch(idleUpAnim, SWITCH_ON, SWITCH_OFF, 1);
+		remapDispatch(idleDownAnim, SWITCH_OFF, SWITCH_ON, 3);
 	}
 
 	void JumpSwitchCollision(short itemNumber, ItemInfo* laraItem, CollisionInfo* coll)

--- a/TombEngine/Objects/Generic/Switches/jump_switch.cpp
+++ b/TombEngine/Objects/Generic/Switches/jump_switch.cpp
@@ -7,6 +7,7 @@
 #include "Game/items.h"
 #include "Game/Lara/lara.h"
 #include "Game/Lara/lara_helpers.h"
+#include "Game/Setup.h"
 #include "Objects/Generic/Switches/generic_switch.h"
 #include "Specific/Input/Input.h"
 #include "Specific/level.h"
@@ -30,19 +31,58 @@ namespace TEN::Entities::Switches
 	};
 	const auto JumpSwitchPos = Vector3i(0, -208, 256);
 
+	void SetupJumpSwitch(ObjectInfo& object)
+	{
+		if (object.Animations.size() < 4)
+			return;
+
+		auto& idleUpAnim = object.Animations[0];
+		auto& pullDownAnim = object.Animations[1];
+		auto& idleDownAnim = object.Animations[2];
+		auto& resetUpAnim = object.Animations[3];
+
+		idleUpAnim.StateID = SWITCH_ON;
+		pullDownAnim.StateID = SWITCH_OFF;
+		idleDownAnim.StateID = SWITCH_OFF;
+		resetUpAnim.StateID = SWITCH_ON;
+
+		for (auto& dispatch : idleUpAnim.Dispatches)
+		{
+			if (dispatch.StateID == SWITCH_ON)
+			{
+				dispatch.StateID = SWITCH_OFF;
+				dispatch.NextAnimNumber = 1;
+			}
+		}
+
+		for (auto& dispatch : idleDownAnim.Dispatches)
+		{
+			if (dispatch.StateID == SWITCH_OFF)
+			{
+				dispatch.StateID = SWITCH_ON;
+				dispatch.NextAnimNumber = 3;
+			}
+		}
+	}
+
 	void JumpSwitchCollision(short itemNumber, ItemInfo* laraItem, CollisionInfo* coll)
 	{
 		auto* laraInfo = GetLaraInfo(laraItem);
 		auto* switchItem = &g_Level.Items[itemNumber];
 
-		g_Hud.InteractionHighlighter.Test(*laraItem, *switchItem, InteractionMode::Activation);
+		bool isSwitchAvailable =
+			switchItem->Status == ITEM_NOT_ACTIVE &&
+			switchItem->Animation.ActiveState == SWITCH_ON;
 
-		if (IsHeld(In::Action) &&
+		if (isSwitchAvailable)
+			g_Hud.InteractionHighlighter.Test(*laraItem, *switchItem, InteractionMode::Activation);
+
+		if (isSwitchAvailable &&
+			IsHeld(In::Action) &&
 			(laraItem->Animation.ActiveState == LS_REACH || laraItem->Animation.ActiveState == LS_JUMP_UP) &&
 			(laraItem->Status || laraItem->Animation.IsAirborne) &&
 			laraItem->Animation.Velocity.y > 0 &&
-			laraInfo->Control.HandStatus == HandStatus::Free &&
-			switchItem->Animation.ActiveState == SWITCH_OFF)
+			laraInfo->Control.HandStatus == HandStatus::Free)
 		{
 			if (TestLaraPosition(JumpSwitchBounds, switchItem, laraItem))
 			{
@@ -54,7 +94,7 @@ namespace TEN::Entities::Switches
 				laraItem->Animation.FrameNumber = 0;
 				laraItem->Animation.IsAirborne = false;
 				laraInfo->Control.HandStatus = HandStatus::Busy;
-				switchItem->Animation.TargetState = SWITCH_ON;
+				switchItem->Animation.TargetState = SWITCH_OFF;
 				switchItem->Status = ITEM_ACTIVE;
 
 				AddActiveItem(itemNumber);

--- a/TombEngine/Objects/Generic/Switches/jump_switch.h
+++ b/TombEngine/Objects/Generic/Switches/jump_switch.h
@@ -2,8 +2,10 @@
 
 struct CollisionInfo;
 struct ItemInfo;
+struct ObjectInfo;
 
 namespace TEN::Entities::Switches
 {
+	void SetupJumpSwitch(ObjectInfo& object);
 	void JumpSwitchCollision(short itemNumber, ItemInfo* laraItem, CollisionInfo* coll);
 }

--- a/TombEngine/Objects/Generic/generic_objects.cpp
+++ b/TombEngine/Objects/Generic/generic_objects.cpp
@@ -160,6 +160,7 @@ void StartSwitches(ObjectInfo* object)
 	object = &Objects[ID_JUMP_SWITCH];
 	if (object->loaded)
 	{
+		SetupJumpSwitch(*object);
 		object->collision = JumpSwitchCollision;
 		object->control = SwitchControl;
 		object->SetHitEffect(true);


### PR DESCRIPTION
Fixes `JUMP_SWITCH` so it behaves correctly with switch triggers, timed triggers, and event sets.

`JUMP_SWITCH` has a different animation/state layout from regular switches, so its states and dispatch transitions are normalized during setup. This lets generic switch logic handle it consistently.

Also prevents Lara from re-activating the switch while it is already pressed and waiting for the timer reset.
