### PR TITLE
Fix JUMP_SWITCH not activating event sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,11 +37,10 @@ TombEngine releases are located in this repository (alongside with Tomb Editor):
 * Fixed flyby camera jitter by converting the spline type to floating-point.
 * Fixed MONKEY not picking up SMALLMEDI_ITEM and KEY_ITEM4 (latter is possible by using AI_MODIFY on the monkey).
 * Fixed BATS_EMITTER targeting issues.
+* Fixed JUMP_SWITCH not activating event sets.
 * Fixed occasional flame emitter sprite jitter.
 * Fixed incorrect aspect ratio when resizing the window in windowed mode.
 * Fixed title level selection dialog not scrolling offscreen entries.
-* Fixed JUMP_SWITCH not activating event sets
-
 
 ### Lua API changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ TombEngine releases are located in this repository (alongside with Tomb Editor):
 * Fixed occasional flame emitter sprite jitter.
 * Fixed incorrect aspect ratio when resizing the window in windowed mode.
 * Fixed title level selection dialog not scrolling offscreen entries.
+* Fixed JUMP_SWITCH not activating event sets
+
 
 ### Lua API changes
 

--- a/TombEngine/Game/control/trigger.cpp
+++ b/TombEngine/Game/control/trigger.cpp
@@ -495,7 +495,8 @@ void TestTriggers(int x, int y, int z, FloorInfo* floor, Activator activator, bo
 			if (!SwitchTrigger(value, timer))
 				return;
 
-			switchOff = (triggerType == TRIGGER_TYPES::SWITCH && timer && g_Level.Items[value].Animation.ActiveState == 1);
+			switchOff = (triggerType == TRIGGER_TYPES::SWITCH && timer &&
+				g_Level.Items[value].Animation.ActiveState == (g_Level.Items[value].ObjectNumber == ID_JUMP_SWITCH ? SWITCH_OFF : SWITCH_ON));
 			break;
 
 		case TRIGGER_TYPES::MONKEY:


### PR DESCRIPTION

`JUMP_SWITCH` has inverted animation states — its resting position is `SWITCH_OFF`, the opposite of normal switches. The `switchOff` check in `TestTriggers` hardcoded `ActiveState == 1`, treating a thrown jump switch as if it were resting, which suppressed its one-shot actions (event sets, cameras, flipeffects, finish, secret, soundtracks) on timed triggers.

Fixed by comparing against the switch's actual resting state (`SWITCH_OFF` for `JUMP_SWITCH`, `SWITCH_ON` otherwise), matching the inversion handling already present in `SwitchControl` and `SwitchTrigger`.

Backward compatible: normal switches are unchanged, no stored state is modified (Lua realtime reads unaffected) — only timed jump switches change behavior.
