### PR TITLE
Fix z-fighting with display items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ TombEngine releases are located in this repository (alongside with Tomb Editor):
 * Fixed title level selection dialog not scrolling offscreen entries.
 * Fixed incorrect blend mode application for sprites.
 * Fixed UI bars being affected by the postprocess mode.
+* Fixed Z-fighting on DisplayItems.
 
 ### Lua API changes
 

--- a/TombEngine/Renderer/RendererEnums.h
+++ b/TombEngine/Renderer/RendererEnums.h
@@ -43,8 +43,12 @@ constexpr auto DISPLAY_SPACE_ASPECT = DISPLAY_SPACE_RES.x / DISPLAY_SPACE_RES.y;
 constexpr auto REFERENCE_FONT_SIZE = 35.0f;
 constexpr auto HUD_ZERO_Y = -DISPLAY_SPACE_RES.y;
 
-constexpr float DISPLAY_ITEM_NEAR_PLANE = 0.1f;
-constexpr float DISPLAY_ITEM_FAR_PLANE = BLOCK(100);
+// Near/far planes for the display item virtual camera. These are intentionally tight to maximise
+// depth buffer precision and prevent z-fighting. Display items are typically rendered ~BLOCK(1)
+// from the camera; the far plane of BLOCK(5) is generous but avoids the catastrophic near/far
+// ratio (previously 1 000 000 : 1) that caused z-fighting between mesh faces.
+constexpr float DISPLAY_ITEM_NEAR_PLANE = 10.0f;
+constexpr float DISPLAY_ITEM_FAR_PLANE  = BLOCK(5);
 
 constexpr auto UNDERWATER_FOG_MIN_DISTANCE = 4;
 constexpr auto UNDERWATER_FOG_MAX_DISTANCE = 30;


### PR DESCRIPTION
This pull request updates the near and far plane values for the display item virtual camera in `RendererEnums.h` to improve depth buffer precision and prevent z-fighting issues. The new values set a much closer far plane, reducing the near/far ratio and addressing rendering artifacts.

**Rendering improvements:**
* Adjusted `DISPLAY_ITEM_NEAR_PLANE` to `10.0f` and `DISPLAY_ITEM_FAR_PLANE` to `BLOCK(5)` in `RendererEnums.h` to maximize depth buffer precision and prevent z-fighting between mesh faces. The previous far plane was set much farther away, causing precision issues.